### PR TITLE
Seperate labeler as an extra

### DIFF
--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -26,7 +26,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-	if [ -f requirements-ml.txt ]; then pip install -r requirements-ml.txt; fi
+        if [ -f requirements-ml.txt ]; then pip install -r requirements-ml.txt; fi
         if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
     - name: Lint with flake8
       run: |

--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -26,6 +26,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+	if [ -f requirements-ml.txt ]; then pip install -r requirements-ml.txt; fi
         if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
     - name: Lint with flake8
       run: |

--- a/README.md
+++ b/README.md
@@ -199,6 +199,11 @@ Install requirements:
 pip3 install -r requirements.txt
 ```
 
+Install labeler dependencies:
+```
+pip3 install -r requirements-ml.txt
+```
+
 Install via the repo -- Build setup.py and install locally:
 ```
 python3 setup.py sdist bdist bdist_wheel

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Data Profiler | What's in your data?
 
-The Data Profiler provides insights on the schema and statistics of any file or dataset it profiles.
-
-Further, the Data Profiler has pre-built deep learning models to identify **sensitive data** and other entities in datasets.
+The Data Profiler provides insights on the schema and statistics of any file or dataset it profiles. Further, the Data Profiler has pre-built deep learning models to identify **sensitive data** and other entities.
 
 The best part? It only takes a few lines of code:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The Data Profiler provides insights on the schema and statistics of any file or dataset it profiles.
 
+Further, the Data Profiler has pre-built deep learning models to identify **sensitive data** and other entities in datasets.
+
 The best part? It only takes a few lines of code:
 
 ```python
@@ -19,7 +21,11 @@ human_readable_report = profile.report(report_options={"output_format":"pretty"}
 print(json.dumps(human_readable_report, indent=4))
 ```
 
-Install from pypi: `pip3 install DataProfiler`
+To install the full package from pypi: `pip install DataProfiler[ml]`
+
+If the ML requirements are too strict (say, you don't want to install tensorflow), you can install a slimmer package which disables the default sensitive data detection / entity recognition (labler)
+
+Install from pypi: `pip install DataProfiler`
 
 
 For API documentation, visit the [documentation page](https://capitalone.github.io/DataProfiler/).

--- a/dataprofiler/profilers/column_profile_compilers.py
+++ b/dataprofiler/profilers/column_profile_compilers.py
@@ -71,9 +71,8 @@ class BaseColumnProfileCompiler(with_metaclass(abc.ABCMeta, object)):
                         raise ValueError(e)
                     
                     warning_msg += "\n\nFor labeler errors, try installing "
-                    warning_msg += "the ml extra; command:\n\n"
-                    warning_msg += "  $ pip install dataprofiler[ml]"
-                    warning_msg += " --user\n\n"
+                    warning_msg += "the extra ml requirements via:\n\n"
+                    warning_msg += "$ pip install dataprofiler[ml] --user\n\n"
 
                     warnings.warn(warning_msg, RuntimeWarning, stacklevel=2)
             

--- a/dataprofiler/profilers/column_profile_compilers.py
+++ b/dataprofiler/profilers/column_profile_compilers.py
@@ -71,9 +71,9 @@ class BaseColumnProfileCompiler(with_metaclass(abc.ABCMeta, object)):
                         raise ValueError(e)
                     
                     warning_msg += "\n\nFor labeler errors, try installing "
-                    warning_msg += "tensorflow and tensorflow-addons; command:\n"
-                    warning_msg += "  $ pip install tensorflow "
-                    warning_msg += "tensorflow-addons --user\n"
+                    warning_msg += "the labeler extra; command:\n\n"
+                    warning_msg += "  $ pip install dataprofiler[labeler]"
+                    warning_msg += " --user\n\n"
 
                     warnings.warn(warning_msg, RuntimeWarning, stacklevel=2)
             

--- a/dataprofiler/profilers/column_profile_compilers.py
+++ b/dataprofiler/profilers/column_profile_compilers.py
@@ -71,8 +71,8 @@ class BaseColumnProfileCompiler(with_metaclass(abc.ABCMeta, object)):
                         raise ValueError(e)
                     
                     warning_msg += "\n\nFor labeler errors, try installing "
-                    warning_msg += "the labeler extra; command:\n\n"
-                    warning_msg += "  $ pip install dataprofiler[labeler]"
+                    warning_msg += "the ml extra; command:\n\n"
+                    warning_msg += "  $ pip install dataprofiler[ml]"
                     warning_msg += " --user\n\n"
 
                     warnings.warn(warning_msg, RuntimeWarning, stacklevel=2)

--- a/dataprofiler/version.py
+++ b/dataprofiler/version.py
@@ -4,7 +4,7 @@ File containers the version number for the package
 
 MAJOR               = 0
 MINOR               = 3
-MICRO               = 2
+MICRO               = 3
 
 VERSION             = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 

--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -1,0 +1,7 @@
+scikit-learn>=0.23.2
+scipy>=1.4.1
+tensorflow-addons>=0.11.2
+keras>=2.4.3
+tensorflow-gpu>=2.3.0; sys.platform == 'linux'
+tensorflow>=2.3.0; sys.platform == 'darwin'
+tensorboard>=2.3.0; sys.platform == 'darwin'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 h5py>=2.10.0
 wheel>=0.33.1
 future>=0.18.2
-numpy>=1.18.5,<=1.19.2
+numpy>=1.18.5
 pandas>=1.1.2
 python-dateutil>=2.7.5
 pytz>=2020.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,11 +10,4 @@ pyarrow>=1.0.1
 chardet>=3.0.4
 fastavro>=1.0.0.post1
 python-snappy>=0.5.4
-scikit-learn>=0.23.2
-tensorflow-addons>=0.11.2
-keras>=2.4.3
-scipy>=1.4.1
-tensorflow-gpu>=2.3.0; sys.platform == 'linux'
-tensorflow>=2.3.0; sys.platform == 'darwin'
-tensorboard>=2.3.0; sys.platform == 'darwin'
 h5py>=2.10.0

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,10 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 # Get the install_requirements from requirements.txt
 with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
     required_packages = f.read().splitlines()
+
+# Get the install_requirements from requirements.txt
+with open(path.join(here, 'requirements-ml.txt'), encoding='utf-8') as f:
+    ml_packages = f.read().splitlines()
     
 resource_dir = 'resources/'
 default_labeler_files = [(d, [os.path.join(d, f) for f in files])
@@ -89,6 +93,11 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=required_packages,
+
+
+    # List of run-time dependencies for the labeler. These will be installed
+    # by pip when someone installs the project[<label>].
+    extras_require={ 'labeler': ml_packages },
 
     # # If there are data files included in your packages that need to be
     # # installed, specify them here.  If using Python 2.6 or less, then these

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
 
     # List of run-time dependencies for the labeler. These will be installed
     # by pip when someone installs the project[<label>].
-    extras_require={ 'labeler': ml_packages },
+    extras_require={ 'ml': ml_packages },
 
     # # If there are data files included in your packages that need to be
     # # installed, specify them here.  If using Python 2.6 or less, then these


### PR DESCRIPTION
This directly addresses "issue" #39 

Install *with* the labeler:
```bash
python3.7 -m virtualenv --python=python3.7 venv1
source venv1/bin/activate
pip install --index-url https://test.pypi.org/simple/ dataprofiler[labeler]
```

Install *without* the labeler:
```
python3.7 -m virtualenv --python=python3.7 venv2
source venv2/bin/activate
pip install --index-url https://test.pypi.org/simple/ dataprofiler
```

**Note**: On Linux I had to install all the requirements from the primary index, then uninstall `dataprofiler` and associated libraries such as `tensorflow-gpu` to test it, but it worked fine.