### PR TITLE
Streamline null counting of regex (20% faster)

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -241,7 +241,7 @@ class StructuredDataProfile(object):
             "--*": NO_FLAG,
             "__*": NO_FLAG,
         }
-
+        
         len_df = len(df_series)
         if not len_df:
             return df_series, {
@@ -264,26 +264,27 @@ class StructuredDataProfile(object):
             total_sample_size += len(sample_inds)
 
             df_series_subset = df_series.iloc[sample_inds]
-            # Check if known null types exist in column
-            for na, flags in null_values_and_flags.items():
-                # Check for the regex of the na in the string.
-                reg_ex_na = f"^{na}$"
-                matching_na_elements = df_series_subset.str.contains(
-                    reg_ex_na, flags=flags)
-                for row, elem in matching_na_elements.items():
-                    if elem:
-                        # Since df_series_subset[row] is mutable,
-                        # need to make new var
-                        row_value = str(df_series_subset[row])
-                        na_columns.setdefault(row_value, list()).append(row)
 
-                # Drop the values that matched regex_na
-                df_series_subset = df_series_subset[~matching_na_elements]
+            query = '('+'|'.join(null_values_and_flags.keys())+')'
+            reg_ex_na = f"^{(query)}$"
+            matching_na_elements = df_series_subset.str.contains(
+                reg_ex_na, flags=re.IGNORECASE)
+
+            for row, elem in matching_na_elements.items():
+                if elem:
+                    # Since df_series_subset[row] is mutable,
+                    # need to make new var
+                    row_value = str(df_series_subset[row])
+                    na_columns.setdefault(row_value, list()).append(row)
+                    
+            # Drop the values that matched regex_na
+            df_series_subset = df_series_subset[~matching_na_elements]
+            
             true_sample_list += df_series_subset.index.tolist()
 
             if len(true_sample_list) >= min_true_samples and total_sample_size:
                 break
-
+            
         # close the generator in case it is not exhausted.
         sample_ind_generator.close()
 

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -265,7 +265,7 @@ class StructuredDataProfile(object):
 
             df_series_subset = df_series.iloc[sample_inds]
 
-            query = '('+'|'.join(null_values_and_flags.keys())+')'
+            query = '(' + '|'.join(null_values_and_flags.keys()) + ')'
             reg_ex_na = f"^{(query)}$"
             matching_na_elements = df_series_subset.str.contains(
                 reg_ex_na, flags=re.IGNORECASE)

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -442,13 +442,13 @@ class TestProfilerNullValues(unittest.TestCase):
         cls.trained_schema = dp.Profiler(test_dataset, len(test_dataset))
 
     def test_correct_rows_ingested(self):
-        self.assertEqual(['', 'nan', 'None', 'null'],
+        self.assertCountEqual(['', 'nan', 'None', 'null'],
                          self.trained_schema.profile['1'].null_types)
         self.assertEqual(
             5, self.trained_schema.profile['1'].null_count)
         self.assertEqual({'': [4], 'nan': [0], 'None': [2, 3], 'null': [
                          1]}, self.trained_schema.profile['1'].null_types_index)
-        self.assertEqual(['', 'nan', 'None', 'null'],
+        self.assertCountEqual(['', 'nan', 'None', 'null'],
                          self.trained_schema.profile[1].null_types)
         self.assertEqual(
             5, self.trained_schema.profile[1].null_count)


### PR DESCRIPTION
**Reduces runtime of non-labeler processing by 20%.** 

Partially addresses a potential speed up highlighted in issue #87 

**Before Changes (in master)**:
```
$ cat cprofile_stats/Profile_no_labeler.prof
         4688319 function calls (4610366 primitive calls) in 2.778 seconds

   Ordered by: internal time
   List reduced from 1162 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    23976    0.403    0.000    0.559    0.000 numerical_column_stats.py:386(_get_percentile)
   755201    0.146    0.000    0.146    0.000 {method 'search' of 're.Pattern' objects}
       80    0.140    0.002    0.378    0.005 {pandas._libs.lib.map_infer_mask}
       10    0.138    0.014    0.881    0.088 profile_builder.py:217(get_base_props_and_clean_null_params)
   755160    0.092    0.000    0.237    0.000 object_array.py:120(<lambda>)
       20    0.088    0.004    0.216    0.011 utils.py:50(shuffle_in_chunks)
   107900    0.071    0.000    0.170    0.000 base_column_profilers.py:47(_combine_unique_sets)
      350    0.069    0.000    0.137    0.000 {pandas._libs.lib.map_infer}
    32993    0.068    0.000    0.068    0.000 {method 'reduce' of 'numpy.ufunc' objects}
      222    0.056    0.000    0.056    0.000 {pandas._libs.lib.infer_dtype}
       10    0.054    0.005    0.220    0.022 text_column_profile.py:95(_update_vocab)
123750/123726    0.054    0.000    0.054    0.000 numerical_column_stats.py:85(__getattribute__)
   107880    0.052    0.000    0.119    0.000 random.py:174(randrange)
      168    0.051    0.000    0.114    0.001 numerical_column_stats.py:239(_total_histogram_bin_variance)
   107880    0.047    0.000    0.047    0.000 numerical_column_stats.py:545(is_int)
12798/10902    0.047    0.000    0.056    0.000 {built-in method numpy.array}
   107930    0.046    0.000    0.068    0.000 random.py:224(_randbelow)
       92    0.037    0.000    0.037    0.000 {built-in method pandas._libs.missing.isnaobj}
227832/227831    0.036    0.000    0.049    0.000 {built-in method builtins.isinstance}
   107880    0.034    0.000    0.034    0.000 numerical_column_stats.py:526(is_float)
```

**Post changes (in PR)**:
```
$ cat cprofile_stats/Profile_no_labeler.prof
         3344123 function calls (3266732 primitive calls) in 2.228 seconds

   Ordered by: internal time
   List reduced from 1181 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    23976    0.449    0.000    0.593    0.000 numerical_column_stats.py:386(_get_percentile)
       20    0.083    0.004    0.205    0.010 utils.py:50(shuffle_in_chunks)
   107900    0.068    0.000    0.164    0.000 base_column_profilers.py:47(_combine_unique_sets)
      350    0.066    0.000    0.130    0.000 {pandas._libs.lib.map_infer}
    32923    0.063    0.000    0.063    0.000 {method 'reduce' of 'numpy.ufunc' objects}
       10    0.053    0.005    0.213    0.021 text_column_profile.py:95(_update_vocab)
   107880    0.050    0.000    0.113    0.000 random.py:174(randrange)
123751/123727    0.049    0.000    0.049    0.000 numerical_column_stats.py:85(__getattribute__)
      168    0.046    0.000    0.104    0.001 numerical_column_stats.py:239(_total_histogram_bin_variance)
   107880    0.045    0.000    0.045    0.000 numerical_column_stats.py:545(is_int)
12308/10592    0.044    0.000    0.051    0.000 {built-in method numpy.array}
   107930    0.044    0.000    0.064    0.000 random.py:224(_randbelow)
       20    0.037    0.002    0.075    0.004 {pandas._libs.lib.map_infer_mask}
   107880    0.032    0.000    0.032    0.000 numerical_column_stats.py:526(is_float)
219204/219203    0.031    0.000    0.043    0.000 {built-in method builtins.isinstance}
      168    0.029    0.000    0.029    0.000 {method 'sort' of 'numpy.ndarray' objects}
30697/429    0.028    0.000    0.067    0.000 copy.py:132(deepcopy)
      162    0.028    0.000    0.028    0.000 {pandas._libs.lib.infer_dtype}
    24872    0.026    0.000    0.026    0.000 {method 'astype' of 'numpy.ndarray' objects}
   107921    0.026    0.000    0.026    0.000 {method 'search' of 're.Pattern' objects}
```