### PR TITLE
Fix data labeler set bug

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -366,36 +366,15 @@ class Profiler(object):
             raise TypeError("Cannot provide TextData object to Profiler")
 
         # assign data labeler
-        use_data_labeler = True
-        data_labeler_dirpath = None
-        data_labeler = None
-        structured_options = None
-
-        if profiler_options and profiler_options.structured_options:
-            structured_options = profiler_options.structured_options
-
-        if structured_options and isinstance(
-                structured_options, StructuredOptions):
-            data_labeler_options = structured_options.data_labeler
-
-        if data_labeler_options and isinstance(
-                data_labeler_options, DataLabelerOptions):
-            use_data_labeler = data_labeler_options.is_enabled
-
-        if use_data_labeler:
-            if isinstance(data_labeler_options, DataLabelerOptions) and \
-                    data_labeler_options.data_labeler_dirpath:
-                data_labeler_dirpath = \
-                    data_labeler_options.data_labeler_dirpath
-
+        # assign data labeler
+        data_labeler_options = self.options.structured_options.data_labeler
+        if data_labeler_options.is_enabled \
+                and data_labeler_options.data_labeler_object is None:
             data_labeler = DataLabeler(
                 labeler_type='structured',
-                dirpath=data_labeler_dirpath,
+                dirpath=data_labeler_options.data_labeler_dirpath,
                 load_options=None)
-
-        if data_labeler:
-            self.options.structured_options.data_labeler.data_labeler_object = \
-                data_labeler
+            self.options.set({'data_labeler.data_labeler_object': data_labeler})
 
         self.update_profile(data)
 

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -327,6 +327,7 @@ class IntOptions(NumericalOptions):
         """
         return super()._validate_helper(variable_path) 
 
+
 class FloatOptions(NumericalOptions):
     def __init__(self):
         """
@@ -572,7 +573,21 @@ class StructuredOptions(BaseOption):
         :rtype: list(str)
         """
         errors = []
+
+        prop_check = dict([
+            ('int', IntOptions),
+            ('float', FloatOptions),
+            ('datetime', DateTimeOptions),
+            ('text', TextOptions),
+            ('order', OrderOptions),
+            ('category', CategoricalOptions),
+            ('data_labeler', DataLabelerOptions)
+        ])
+
         for column in self.properties:
+            if not isinstance(self.properties[column], prop_check[column]):
+                errors.append("{} must be a(n) {}.".format(
+                    column, prop_check[column].__name__))
             errors += self.properties[column]._validate_helper(
                 variable_path=(variable_path + '.' + column
                                if variable_path else column))

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -483,6 +483,19 @@ class DataLabelerOptions(BaseColumnOptions):
                 setattr(result, k, copy.deepcopy(v, memo))
         return result
 
+    @property
+    def properties(self):
+        """
+        Returns a copy of the option properties.
+
+        :return: dictionary of the option's properties attr: value
+        :rtype: dict
+        """
+        props = {k: copy.deepcopy(v)
+                 for k,v in self.__dict__.items() if k != 'data_labeler_object'}
+        props['data_labeler_object'] = self.data_labeler_object
+        return props
+
     def _validate_helper(self, variable_path='DataLabelerOptions'):
         """
         Validates the options do not conflict and cause errors.
@@ -499,7 +512,8 @@ class DataLabelerOptions(BaseColumnOptions):
                           .format(variable_path))
         if self.data_labeler_object and \
                 not isinstance(self.data_labeler_object, BaseDataLabeler):
-            errors.append("{}.data_labeler_object must be a BaseDataLabeler object."
+            errors.append("{}.data_labeler_object must be a BaseDataLabeler "
+                          "object."
                           .format(variable_path))
         if self.data_labeler_object and self.data_labeler_dirpath:
             warnings.warn("The data labeler passed in will be used,"

--- a/dataprofiler/tests/profilers/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/test_profiler_options.py
@@ -282,15 +282,13 @@ class TestProfilerOptions(unittest.TestCase):
         options = ProfilerOptions()
         options.structured_options.data_labeler = IntOptions()
         with self.assertRaisesRegex(
-                ValueError, "DataLabelerColumn parameter 'options' must be of "
-                            "type DataLabelerOptions."):
+                ValueError, "data_labeler must be a\(n\) DataLabelerOptions."):
             profile = Profiler(self.data, profiler_options=options)
         # Test incorrect float options
         options = ProfilerOptions()
         options.structured_options.float = IntOptions()
         with self.assertRaisesRegex(
-                ValueError, "FloatColumn parameter 'options' must be of type "
-                            "FloatOptions."):
+                ValueError, "float must be a\(n\) FloatOptions."):
             profile = Profiler(self.data, profiler_options=options)
 
     @mock.patch('dataprofiler.profilers.float_column_profile.FloatColumn.'

--- a/dataprofiler/tests/profilers/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/test_profiler_options.py
@@ -360,3 +360,20 @@ class TestDataLabelerCallWithOptions(unittest.TestCase):
         actual_sample_size = profile._profile[0].profiles['data_label_profile'] \
             ._profiles["data_labeler"]._max_sample_size
         self.assertEqual(actual_sample_size, 50)
+
+        data_labeler = mock.Mock(spec=BaseDataLabeler)
+        data_labeler.reverse_label_mapping = dict()
+        data_labeler.model.num_labels = 0
+        options.set({'data_labeler.data_labeler_object': data_labeler})
+        with self.assertWarnsRegex(UserWarning,
+                                   "The data labeler passed in will be used,"
+                                   " not through the directory of the default"
+                                   " model"):
+            options.validate()
+
+        profile = Profiler(self.data, profiler_options=options)
+        self.assertEqual(data_labeler,
+                         # profile, col prof, compiler
+                         (profile._profile[0].profiles['data_label_profile'].
+                          # column profiler
+                          _profiles["data_labeler"].data_labeler))


### PR DESCRIPTION
Data labeler Options will fail if the data labeler is set and properties is called.
This causes failures in validation during the setting of the data labeler.