### PR TITLE
Improved chunking index speeds

### DIFF
--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -36,4 +36,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest --forked
+        DATAPROFILER_SEED=0 pytest --forked

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -16,6 +16,7 @@
 import collections
 import random
 import math
+import numpy as np
 
 
 def dict_merge(dct, merge_dct):
@@ -59,7 +60,9 @@ def shuffle_in_chunks(data_length, chunk_size):
     :return: list of shuffled indices of chunk size
     """
     indices = KeyDict()
+    rng = np.random.default_rng()
     j = 0
+    
     # loop through all chunks
     for chunk_ind in range(max(math.ceil(data_length / chunk_size), 1)):
 
@@ -67,11 +70,22 @@ def shuffle_in_chunks(data_length, chunk_size):
         true_chunk_size = min(chunk_size, data_length - chunk_size * chunk_ind)
         values = [-1] * true_chunk_size
 
+        
+        # Generate random list of indicies         
+        list_j = j
+        lower_bound_list = np.zeros([true_chunk_size])
+        for i in range(true_chunk_size):
+            lower_bound_list[i] = list_j
+            list_j+=1
+        random_list = rng.integers(lower_bound_list, data_length)
+
+
         # shuffle the indexes
         for count in range(true_chunk_size):
 
             # get a random index to swap and swap it with j
-            k = random.randrange(j, data_length)
+            # k = random.randrange(j, data_length)
+            k = random_list[count]
             indices[j], indices[k] = indices[k], indices[j]
 
             # set the swapped value to the output

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -7,6 +7,21 @@ import numpy as np
 
 
 def dict_merge(dct, merge_dct):
+    # Recursive dictionary merge
+    # Copyright (C) 2016 Paul Durivage <pauldurivage+github@gmail.com>
+    # 
+    # This program is free software: you can redistribute it and/or modify
+    # it under the terms of the GNU General Public License as published by
+    # the Free Software Foundation, either version 3 of the License, or
+    # (at your option) any later version.
+    # 
+    # This program is distributed in the hope that it will be useful,
+    # but WITHOUT ANY WARRANTY; without even the implied warranty of
+    # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    # GNU General Public License for more details.
+    # 
+    # You should have received a copy of the GNU General Public License
+    # along with this program.  If not, see <https://www.gnu.org/licenses/>.
     """ Recursive dict merge. Inspired by :meth:``dict.update()``, instead of
     updating only top-level keys, dict_merge recurses down into dicts nested
     to an arbitrary depth, updating keys. The ``merge_dct`` is merged into

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -72,11 +72,7 @@ def shuffle_in_chunks(data_length, chunk_size):
 
         
         # Generate random list of indicies         
-        list_j = j
-        lower_bound_list = np.zeros([true_chunk_size])
-        for i in range(true_chunk_size):
-            lower_bound_list[i] = list_j
-            list_j+=1
+        lower_bound_list = np.array(range(j, j + true_chunk_size))
         random_list = rng.integers(lower_bound_list, data_length)
 
 

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -84,7 +84,6 @@ def shuffle_in_chunks(data_length, chunk_size):
         for count in range(true_chunk_size):
 
             # get a random index to swap and swap it with j
-            # k = random.randrange(j, data_length)
             k = random_list[count]
             indices[j], indices[k] = indices[k], indices[j]
 

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -1,21 +1,8 @@
-# Recursive dictionary merge
-# Copyright (C) 2016 Paul Durivage <pauldurivage+github@gmail.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import os
 import collections
 import random
 import math
+import warnings
 import numpy as np
 
 
@@ -59,8 +46,17 @@ def shuffle_in_chunks(data_length, chunk_size):
     :param chunk_size: size of shuffled chunks
     :return: list of shuffled indices of chunk size
     """
-    indices = KeyDict()
+    
     rng = np.random.default_rng()
+    if 'DATAPROFILER_SEED' in os.environ:
+        try:
+            seed_value = int(os.environ.get('DATAPROFILER_SEED'))
+            rng = np.random.default_rng(seed_value)
+        except ValueError as e:
+            warnings.warn("Seed should be an integer", RuntimeWarning)
+
+
+    indices = KeyDict()        
     j = 0
     
     # loop through all chunks

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -365,7 +365,7 @@ class TestStructuredDataProfileClass(unittest.TestCase):
         profile2.profiles = dict(test=2)
         merged_profile = profile1 + profile2
         self.assertEqual(3, merged_profile.profiles['test'])
-        self.assertEqual(['5.0', '4.0', '3.0', '1.0'], merged_profile.sample)
+        self.assertCountEqual(['5.0', '4.0', '3.0', '1.0'], merged_profile.sample)
         self.assertEqual(6, merged_profile.sample_size)
         self.assertEqual(2, merged_profile.null_count)
         self.assertListEqual(['nan'], merged_profile.null_types)

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -365,7 +365,7 @@ class TestStructuredDataProfileClass(unittest.TestCase):
         profile2.profiles = dict(test=2)
         merged_profile = profile1 + profile2
         self.assertEqual(3, merged_profile.profiles['test'])
-        self.assertEqual(['4.0', '5.0', '1.0', '3.0'], merged_profile.sample)
+        self.assertEqual(['5.0', '4.0', '3.0', '1.0'], merged_profile.sample)
         self.assertEqual(6, merged_profile.sample_size)
         self.assertEqual(2, merged_profile.null_count)
         self.assertListEqual(['nan'], merged_profile.null_types)
@@ -438,12 +438,8 @@ class TestStructuredDataProfileClass(unittest.TestCase):
     def test_null_count(self):
         column = pd.Series([1, float('nan')] * 10)
 
-        # test null_count when subset of full sample size
-        random.seed(0)
-        profile = StructuredDataProfile(column, sample_size=10)
-        self.assertEqual(6, profile.null_count)
-
         # test null_count when full sample size
+        random.seed(0)
         profile = StructuredDataProfile(column, sample_size=len(column))
         self.assertEqual(10, profile.null_count)
 


### PR DESCRIPTION
Shuffling indices for sampling is one of the slowest aspects of the library, see below for a 52Mb file with 2.7 million records. Shuffling is about 18% of the runtime. The proposal here reduces the overall runtime by ~6 seconds or 10%. 

I believe @JGSweets had something similar previously. Generally, python's `random` is faster. However, given the vectorized nature here, I recommend utilizing numpy. 

```
60479794 function calls (60295604 primitive calls) in 53.637 seconds

   Ordered by: internal time
   List reduced from 9957 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      126    5.188    0.041    6.512    0.052 numerical_column_stats.py:239(_total_histogram_bin_variance)
       12    4.128    0.344    9.595    0.800 utils.py:50(shuffle_in_chunks)
        6    3.089    0.515    4.544    0.757 float_column_profile.py:98(_get_float_precision)
    17982    2.883    0.000    3.055    0.000 numerical_column_stats.py:386(_get_percentile)
  3343290    2.737    0.000    6.006    0.000 base_column_profilers.py:47(_combine_unique_sets)
```

I then did a test with the current chunking function with 10 million records and a chunk_size of 10 thousand:
```
54578261 function calls in 23.893 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1001   11.084    0.011   23.772    0.024 shuffle_in_chunks.py:17(shuffle_in_chunks)
 10000000    5.136    0.000   11.887    0.000 random.py:291(randrange)
 10000000    4.714    0.000    6.751    0.000 random.py:238(_randbelow_with_getrandbits)
 14575255    1.323    0.000    1.323    0.000 {method 'getrandbits' of '_random.Random' objects}
```

The method proposed here (10 million records, chunk_size 10 thousand):
```
10049030 function calls in 13.806 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1001   12.514    0.013   13.687    0.014 shuffle_in_chunks.py:52(shuffle_in_chunks_v2)
 10000001    0.632    0.000    0.632    0.000 shuffle_in_chunks.py:14(__missing__)
     4000    0.339    0.000    0.339    0.000 {method 'items' of 'dict' objects}
     1000    0.154    0.000    0.535    0.001 {method 'integers' of 'numpy.random._generator.Generator' objects}
        1    0.119    0.119   13.806   13.806 shuffle_in_chunks.py:177(test_chunk_v2)
     4000    0.012    0.000    0.012    0.000 {method 'reduce' of 'numpy.ufunc' objects}
     4000    0.006    0.000    0.363    0.000 fromnumeric.py:70(_wrapreduction)
     4001    0.006    0.000    0.372    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
     1000    0.005    0.000    0.005    0.000 {built-in method numpy.zeros}
```