### PR TITLE
Removed Superfluous Error Message

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -171,7 +171,6 @@ class StructuredDataProfile(object):
                 profile[key] = unordered_profile[key]
             except KeyError as e:
                 profile[key] = None
-                print(f"Error: {key} has no data")
 
         return profile
 


### PR DESCRIPTION
AC: 
- Address issue 64: https://github.com/capitalone/DataProfiler/issues/64
- Find a solution
- PR

So I just removed the error message because: 
1. It's not an error
2. It's not helpful/needed dialogue
3. If there was an error, it shouldn't be reported there

No tests to add given the nature of this problem.