### PR TITLE
Fixed the null count and total samples, and more.

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -447,11 +447,13 @@ class Profiler(object):
 
     @property
     def samples_used(self):
+        """
+        Calculates and returns the maximum samples used in any of the columns.
+        """
         samples_used = 0
         columns = list(self._profile.values())
         for col in columns:
-            if col.sample_size:
-                samples_used = max(samples_used, col.sample_size)
+            samples_used = max(samples_used, col.sample_size)
         return samples_used
 
     def report(self, report_options=None):

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -446,7 +446,7 @@ class Profiler(object):
         return self._profile
 
     @property
-    def samples_used(self):
+    def _max_col_samples_used(self):
         """
         Calculates and returns the maximum samples used in any of the columns.
         """
@@ -470,7 +470,7 @@ class Profiler(object):
         columns = list(self._profile.values())
         report = OrderedDict([
             ("global_stats", {
-                "samples_used": self.samples_used,
+                "samples_used": self._max_col_samples_used,
                 "column_count": len(columns),
                 "row_count": self.total_samples,
                 "row_has_null_ratio": self._get_row_has_null_ratio(),
@@ -496,12 +496,12 @@ class Profiler(object):
         return len(self.hashed_row_dict) / self.total_samples
 
     def _get_row_is_null_ratio(self):
-        return 0 if self.samples_used == 0 \
-            else self.row_is_null_count / self.samples_used
+        return 0 if self._max_col_samples_used == 0 \
+            else self.row_is_null_count / self._max_col_samples_used
 
     def _get_row_has_null_ratio(self):
-        return 0 if self.samples_used == 0 \
-            else self.row_has_null_count / self.samples_used
+        return 0 if self._max_col_samples_used == 0 \
+            else self.row_has_null_count / self._max_col_samples_used
 
     def _get_duplicate_row_count(self):
         return self.total_samples - len(self.hashed_row_dict)

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -445,6 +445,15 @@ class Profiler(object):
     def profile(self):
         return self._profile
 
+    @property
+    def samples_used(self):
+        samples_used = 0
+        columns = list(self._profile.values())
+        for col in columns:
+            if col.sample_size:
+                samples_used = max(samples_used, col.sample_size)
+        return samples_used
+
     def report(self, report_options=None):
         if not report_options:
             report_options = {
@@ -459,7 +468,7 @@ class Profiler(object):
         columns = list(self._profile.values())
         report = OrderedDict([
             ("global_stats", {
-                "samples_used": columns[0].sample_size if columns else 0,
+                "samples_used": self.samples_used,
                 "column_count": len(columns),
                 "row_count": self.total_samples,
                 "row_has_null_ratio": self._get_row_has_null_ratio(),
@@ -485,14 +494,12 @@ class Profiler(object):
         return len(self.hashed_row_dict) / self.total_samples
 
     def _get_row_is_null_ratio(self):
-        columns = list(self._profile.values())
-        samples_used = columns[0].sample_size
-        return self.row_is_null_count / samples_used
+        return 0 if self.samples_used == 0 \
+            else self.row_is_null_count / self.samples_used
 
     def _get_row_has_null_ratio(self):
-        columns = list(self._profile.values())
-        samples_used = columns[0].sample_size
-        return self.row_has_null_count / samples_used
+        return 0 if self.samples_used == 0 \
+            else self.row_has_null_count / self.samples_used
 
     def _get_duplicate_row_count(self):
         return self.total_samples - len(self.hashed_row_dict)

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -527,15 +527,13 @@ class TestProfilerNullValues(unittest.TestCase):
         profile.update_profile(data)
         
         self.assertEqual(16, profile.total_samples)
-        self.assertEqual(4, profile.report()["global_stats"]["samples_used"])
+        self.assertEqual(4, profile.samples_used)
         self.assertEqual(2, profile.row_has_null_count)
         self.assertEqual(0.5, profile._get_row_has_null_ratio())
         self.assertEqual(2, profile.row_is_null_count)
         self.assertEqual(0.5, profile._get_row_is_null_ratio())
         self.assertEqual(0.4375, profile._get_unique_row_ratio())
         self.assertEqual(9, profile._get_duplicate_row_count())
-
-
 
 
 if __name__ == '__main__':

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -527,7 +527,7 @@ class TestProfilerNullValues(unittest.TestCase):
         profile.update_profile(data)
         
         self.assertEqual(16, profile.total_samples)
-        self.assertEqual(4, profile.samples_used)
+        self.assertEqual(4, profile._max_col_samples_used)
         self.assertEqual(2, profile.row_has_null_count)
         self.assertEqual(0.5, profile._get_row_has_null_ratio())
         self.assertEqual(2, profile.row_is_null_count)

--- a/dataprofiler/tests/profilers/utils.py
+++ b/dataprofiler/tests/profilers/utils.py
@@ -11,8 +11,7 @@ def set_seed(seed=None):
     :param seed:
     :return:
     """
-    np.random.seed(seed)
-    random.seed(seed)
+    os.environ["DATAPROFILER_SEED"] = str(seed)
 
 
 def delete_folder(path):

--- a/dataprofiler/tests/profilers/utils.py
+++ b/dataprofiler/tests/profilers/utils.py
@@ -11,7 +11,8 @@ def set_seed(seed=None):
     :param seed:
     :return:
     """
-    os.environ["DATAPROFILER_SEED"] = str(seed)
+    np.random.seed(seed)
+    random.seed(seed)
 
 
 def delete_folder(path):


### PR DESCRIPTION
AC: 
- Address issue 107 (https://github.com/capitalone/DataProfiler/issues/107)
- Fix issue.

Notes:
Rows_ingested and total_samples were the same, got rid of rows_ingested.
The nulls were not being updated properly with multiple batches of data, fixed.
The null ratios were not being calculated properly, fixed.
Setting the seed for tests was faulty, fixed.