### PR TITLE
Added multiprocessing of column profiles (40% runtime reduction)

### DIFF
--- a/dataprofiler/profilers/categorical_column_profile.py
+++ b/dataprofiler/profilers/categorical_column_profile.py
@@ -150,6 +150,9 @@ class CategoricalColumn(BaseColumnProfiler):
         :type df_series: pandas.core.series.Series
         :return: None
         """
+        if len(df_series) == 0:
+            return self
+        
         profile = dict(
             sample_size=len(df_series)
         )
@@ -159,3 +162,5 @@ class CategoricalColumn(BaseColumnProfiler):
             prev_dependent_properties={}, subset_properties=profile)
 
         self._update_helper(df_series, profile)
+
+        return self

--- a/dataprofiler/profilers/column_profile_compilers.py
+++ b/dataprofiler/profilers/column_profile_compilers.py
@@ -94,21 +94,22 @@ class BaseColumnProfileCompiler(with_metaclass(abc.ABCMeta, object)):
                     single_process_list.append(col_profile_type.col_type)
 
         # Loop through remaining multiprocesses and close them out
-        for col in multi_process_dict.keys():
-            try:
-                f = multi_process_dict[col]
-                returned_profile = f.get()
-                if returned_profile is not None:
-                    self._profiles[col] = returned_profile                
-            except Exception as e:
-                # Attempt again as a single process
-                single_process_list.append(col_profile_type.col_type)
-                    
-        # Close pool for new tasks        
-        pool.close()
-        
-        # Wait for all workers to complete
-        pool.join()
+        if multiprocess_flag:
+            for col in multi_process_dict.keys():
+                try:
+                    f = multi_process_dict[col]
+                    returned_profile = f.get()
+                    if returned_profile is not None:
+                        self._profiles[col] = returned_profile                
+                except Exception as e:
+                    # Attempt again as a single process
+                    single_process_list.append(col_profile_type.col_type)
+
+            # Close pool for new tasks  
+            pool.close()
+            
+            # Wait for all workers to complete
+            pool.join()
 
 
         # Single process thread to loop through

--- a/dataprofiler/profilers/column_profile_compilers.py
+++ b/dataprofiler/profilers/column_profile_compilers.py
@@ -165,7 +165,8 @@ class BaseColumnProfileCompiler(with_metaclass(abc.ABCMeta, object)):
         """
         df_series = df_series.apply(str)
         for column_profile in self._profiles:
-            self._profiles[column_profile].update(df_series)
+            self._profiles[column_profile].update(df_series)            
+        return self
 
 
 class ColumnPrimitiveTypeProfileCompiler(BaseColumnProfileCompiler):

--- a/dataprofiler/profilers/column_profile_compilers.py
+++ b/dataprofiler/profilers/column_profile_compilers.py
@@ -9,6 +9,7 @@ from . import OrderColumn, CategoricalColumn
 from . import DataLabelerColumn
 from .profiler_options import StructuredOptions
 
+import multiprocessing as mp
 
 class BaseColumnProfileCompiler(with_metaclass(abc.ABCMeta, object)):
 
@@ -40,41 +41,90 @@ class BaseColumnProfileCompiler(with_metaclass(abc.ABCMeta, object)):
         :rtype: None
         """
 
+        if len(self._profilers) == 0:
+            return
+
         # convert all the values to string
         df_series = df_series.apply(str)
-        
+
+        multiprocess_flag = True
         selected_col_profiles = None
         if options and isinstance(options, StructuredOptions):
             selected_col_profiles = options.enabled_columns
+            multiprocess_flag = options.multiprocess.is_enabled
 
+        pool = mp.Pool(len(self._profilers))
+        single_process_list = []
+        multi_process_dict = {}
+
+        # smm = mp.managers.SharedMemoryManager()        
+        
         for col_profile_type in self._profilers:
+            
             # Create profile if options allow for it or if there are no options
             if selected_col_profiles is None or \
-                    col_profile_type.col_type in selected_col_profiles:
-                col_profile_options = None
+               col_profile_type.col_type in selected_col_profiles:
+
+                col_options = None
                 if options and options.properties[col_profile_type.col_type]:
-                    col_profile_options = options.properties[col_profile_type.col_type]
-
-                try:
-                    self._profiles[col_profile_type.col_type] = \
-                        col_profile_type(df_series.name, options=col_profile_options)
-                    self._profiles[col_profile_type.col_type].update(df_series)
-                except Exception as e:
-                    import warnings
-                    warning_msg = "\n\n!!! WARNING Partial Profiler Failure !!!\n\n"
-                    warning_msg += "Profiling Type: {}".format(col_profile_type.col_type)
-                    warning_msg += "\nException: {}".format(type(e).__name__)
-                    warning_msg += "\nMessage: {}".format(e)
-
-                    # This is considered a major error
-                    if type(e).__name__ == "ValueError":
-                        raise ValueError(e)
+                    col_options = options.properties[col_profile_type.col_type]
                     
-                    warning_msg += "\n\nFor labeler errors, try installing "
-                    warning_msg += "the extra ml requirements via:\n\n"
-                    warning_msg += "$ pip install dataprofiler[ml] --user\n\n"
+                self._profiles[col_profile_type.col_type] = \
+                    col_profile_type(df_series.name, options=col_options)
+                
+                # MULTIPROCESSING
+                single_process_flag = True
+                if multiprocess_flag:
+                    single_process_flag = False
+                    try:                        
+                        f = pool.apply_async(
+                            self._profiles[col_profile_type.col_type].update,
+                            (df_series,)
+                        )
+                        multi_process_dict[col_profile_type.col_type] = f
+                    except Exception as e:
+                        # Occurs when object cannot be pickled
+                        single_process_flag = True
 
-                    warnings.warn(warning_msg, RuntimeWarning, stacklevel=2)
+                # Add to single process list to execute later
+                if single_process_flag:
+                    single_process_list.append(col_profile_type.col_type)
+
+        for col in multi_process_dict.keys():
+            try:
+                f = multi_process_dict[col]
+                returned_profile = f.get()
+                if returned_profile is not None:
+                    self._profiles[col] = returned_profile                
+            except Exception as e:
+                # Attempt again as a single process
+                single_process_list.append(col_profile_type.col_type)
+                    
+        # Close pool for new tasks        
+        pool.close()
+        
+        # Wait for all workers to complete
+        pool.join()
+
+        for col_profile_type_col_type in single_process_list:
+            try:
+                self._profiles[col_profile_type_col_type].update(df_series)
+            except Exception as e:
+                import warnings
+                warning_msg = "\n\n!!! WARNING Partial Profiler Failure !!!\n\n"
+                warning_msg += "Profiling Type: {}".format(col_profile_type_col_type)
+                warning_msg += "\nException: {}".format(type(e).__name__)
+                warning_msg += "\nMessage: {}".format(e)
+
+                # This is considered a major error
+                if type(e).__name__ == "ValueError":
+                    raise ValueError(e)
+            
+                warning_msg += "\n\nFor labeler errors, try installing "
+                warning_msg += "the extra ml requirements via:\n\n"
+                warning_msg += "$ pip install dataprofiler[ml] --user\n\n"
+                
+                warnings.warn(warning_msg, RuntimeWarning, stacklevel=2)
             
 
     def __add__(self, other):
@@ -120,6 +170,9 @@ class BaseColumnProfileCompiler(with_metaclass(abc.ABCMeta, object)):
 
 class ColumnPrimitiveTypeProfileCompiler(BaseColumnProfileCompiler):
 
+    def __repr__(self):
+        return 'ColumnPrimitiveTypeProfileCompiler'
+    
     # NOTE: these profilers are ordered. Test functionality if changed.
     _profilers = [
         DateTimeColumn,
@@ -136,7 +189,9 @@ class ColumnPrimitiveTypeProfileCompiler(BaseColumnProfileCompiler):
             "statistics": dict()
         }
         has_found_match = False
+        
         for _, profiler in self._profiles.items():
+
             if not has_found_match and profiler.data_type_ratio == 1.0:
                 profile.update(
                     {
@@ -153,6 +208,9 @@ class ColumnPrimitiveTypeProfileCompiler(BaseColumnProfileCompiler):
 
 class ColumnStatsProfileCompiler(BaseColumnProfileCompiler):
 
+    def __repr__(self):
+        return 'ColumnStatsProfileCompiler'
+    
     # NOTE: these profilers are ordered. Test functionality if changed.
     _profilers = [
         OrderColumn,
@@ -169,6 +227,10 @@ class ColumnStatsProfileCompiler(BaseColumnProfileCompiler):
 
 class ColumnDataLabelerCompiler(BaseColumnProfileCompiler):
 
+    def __repr__(self):
+        return 'ColumnDataLabelerCompiler'
+
+    
     # NOTE: these profilers are ordered. Test functionality if changed.
     _profilers = [
         DataLabelerColumn

--- a/dataprofiler/profilers/data_labeler_column_profile.py
+++ b/dataprofiler/profilers/data_labeler_column_profile.py
@@ -278,7 +278,8 @@ class DataLabelerColumn(BaseColumnProfiler):
         :return: None
         """
         if len(df_series) == 0:
-            return
+            return self
+        
         sample_size = min(len(df_series), self._max_sample_size)
         df_series = df_series.sample(sample_size)
 
@@ -290,3 +291,5 @@ class DataLabelerColumn(BaseColumnProfiler):
             self, self.__calculations, df_series=df_series,
             prev_dependent_properties={}, subset_properties=profile)
         self._update_helper(df_series, profile)
+
+        return self

--- a/dataprofiler/profilers/datetime_column_profile.py
+++ b/dataprofiler/profilers/datetime_column_profile.py
@@ -315,7 +315,8 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
         :return: None
         """
         if len(df_series) == 0:
-            return
+            return self
+        
         df_series = df_series.reset_index(drop=True)
         profile = {"sample_size": len(df_series), "match_count": 0}
         if self._is_subset_datetime_column(df_series):
@@ -326,3 +327,5 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
                 prev_dependent_properties={},
                 subset_properties=profile)
         self._update_helper(df_series=df_series, profile=profile)
+
+        return self

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -194,31 +194,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         if self._NumericStatsMixin__calculations:
             NumericStatsMixin._update_helper(self, df_series_clean, profile)
         self._update_column_base_properties(profile)
-
-    def update(self, df_series):
-        """
-        Updates the column profile.
-        :param df_series: df series
-        :type df_series: pandas.core.series.Series
-        :return: None
-        """
-        if len(df_series) == 0:
-            return
-        df_series = df_series.reset_index(drop=True)
-        is_each_row_float = self._is_each_row_float(df_series)
-        sample_size = len(is_each_row_float)
-        float_count = np.sum(is_each_row_float)
-        profile = dict(match_count=float_count, sample_size=sample_size)
-
-        BaseColumnProfiler._perform_property_calcs(
-            self, self.__calculations, df_series=df_series[is_each_row_float],
-            prev_dependent_properties={}, subset_properties=profile)
-
-        self._update_helper(
-            df_series_clean=df_series[is_each_row_float],
-            profile=profile
-        )
-
+        
     def _update_numeric_stats(self, df_series, prev_dependent_properties,
                               subset_properties):
         """
@@ -235,3 +211,31 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         :return: None 
         """
         super(FloatColumn, self)._update_helper(df_series, subset_properties)
+        
+    def update(self, df_series):
+        """
+        Updates the column profile.
+        :param df_series: df series
+        :type df_series: pandas.core.series.Series
+        :return: None
+        """
+        if len(df_series) == 0:
+            return self
+        
+        df_series = df_series.reset_index(drop=True)
+        is_each_row_float = self._is_each_row_float(df_series)
+        sample_size = len(is_each_row_float)
+        float_count = np.sum(is_each_row_float)
+        profile = dict(match_count=float_count, sample_size=sample_size)
+
+        BaseColumnProfiler._perform_property_calcs(
+            self, self.__calculations, df_series=df_series[is_each_row_float],
+            prev_dependent_properties={}, subset_properties=profile)
+
+        self._update_helper(
+            df_series_clean=df_series[is_each_row_float],
+            profile=profile
+        )
+
+        return self
+        

--- a/dataprofiler/profilers/int_column_profile.py
+++ b/dataprofiler/profilers/int_column_profile.py
@@ -1,5 +1,4 @@
 import numpy as np
-import copy
 
 from .numerical_column_stats import NumericStatsMixin
 from .base_column_profilers import BaseColumnProfiler, \

--- a/dataprofiler/profilers/int_column_profile.py
+++ b/dataprofiler/profilers/int_column_profile.py
@@ -1,4 +1,5 @@
 import numpy as np
+import copy
 
 from .numerical_column_stats import NumericStatsMixin
 from .base_column_profilers import BaseColumnProfiler, \
@@ -63,7 +64,7 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         histogram_method = self.histogram_bin_method_names[0]
         if self.histogram_selection is not None:
             histogram_method = self.histogram_selection
-
+            
         profile = dict(
             min=self.min,
             max=self.max,
@@ -74,7 +75,9 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             quantiles=self.quantiles,
             times=self.times
         )
+
         return profile
+
 
     @property
     def data_type_ratio(self):
@@ -133,8 +136,8 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         :return: None
         """
         if len(df_series) == 0:
-            return
-
+            return self
+        
         df_series = df_series.reset_index(drop=True)
         is_each_row_int = self._is_each_row_int(df_series)
         sample_size = len(is_each_row_int)
@@ -149,3 +152,5 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             df_series_clean=df_series[is_each_row_int],
             profile=profile
         )
+
+        return self

--- a/dataprofiler/profilers/order_column_profile.py
+++ b/dataprofiler/profilers/order_column_profile.py
@@ -327,7 +327,7 @@ class OrderColumn(BaseColumnProfiler):
         :return: None
         """
         if len(df_series) == 0:
-            return
+            return self
 
         profile = dict(sample_size=len(df_series))
         OrderColumn._update_order(self, df_series=df_series)
@@ -335,3 +335,5 @@ class OrderColumn(BaseColumnProfiler):
             self, self.__calculations, df_series=df_series,
             prev_dependent_properties={}, subset_properties=profile)
         self._update_helper(df_series, profile)
+
+        return self

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -216,49 +216,9 @@ class StructuredDataProfile(object):
             self.get_base_props_and_clean_null_params(
                 df_series, sample_size, min_true_samples=min_true_samples)
         self._update_base_stats(base_stats)
-
-
-
-        #if self.options and self.options.StructuredOptions \
-        #   and self.options.StructuredOptions.multiprocess.is_enabled:
             
         for profile in self.profiles.values():
             profile.update_profile(clean_sampled_df)
-
-        """
-        else: # Multiprocessing
-            
-            pool = mp.Pool(len(self.profiles.values()))
-            multi_processing_dict = {}
-            single_thread_list = []
-            for profile_name in self.profiles.keys():
-                
-                profile = self.profiles[profile_name]
-                single_thread_flag = True                
-                if profile.__repr__() != 'ColumnDataLabelerCompiler':
-                    try:
-                        single_thread_flag = False
-                        f = pool.apply_async(profile.update_profile, [clean_sampled_df])
-                        multi_processing_dict[profile_name] = f
-                    except Exception as e:
-                        single_thread_flag = True
-                        
-                if single_thread_flag:
-                    single_thread_list.append(profile_name)
-                        
-            for profile_name in multi_processing_dict.keys():
-                self.profiles[profile_name] = f.get()
-                
-            # Close pool for new tasks
-            pool.close()
-            
-            # Wait for all workers to complete 
-            pool.join()
-
-            # Clean up anything remaining
-            for profile_name in single_thread_list:
-                self.profiles[profile_name].update_profile(clean_sampled_df)
-        """
 
     def _get_sample_size(self, df_series):
         """

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -217,27 +217,47 @@ class StructuredDataProfile(object):
                 df_series, sample_size, min_true_samples=min_true_samples)
         self._update_base_stats(base_stats)
 
+
+
+        #if self.options and self.options.StructuredOptions \
+        #   and self.options.StructuredOptions.multiprocess.is_enabled:
+            
         for profile in self.profiles.values():
             profile.update_profile(clean_sampled_df)
 
         """
-        # MULTITHREADING
-        pool = mp.Pool(len(self.profiles.values()))
-        funclist = []
-        labeler_profile_type = 'ColumnDataLabelerCompiler'
-        
-        for profile in self.profiles.values():
-            if profile.__repr__() != 'ColumnDataLabelerCompiler':
-                f = pool.apply_async(profile.update_profile, [clean_sampled_df])
-                funclist.append(f)
-            else:
-                profile.update_profile(clean_sampled_df)
-        
-        # Close pool for new tasks         
-        pool.close()
+        else: # Multiprocessing
+            
+            pool = mp.Pool(len(self.profiles.values()))
+            multi_processing_dict = {}
+            single_thread_list = []
+            for profile_name in self.profiles.keys():
+                
+                profile = self.profiles[profile_name]
+                single_thread_flag = True                
+                if profile.__repr__() != 'ColumnDataLabelerCompiler':
+                    try:
+                        single_thread_flag = False
+                        f = pool.apply_async(profile.update_profile, [clean_sampled_df])
+                        multi_processing_dict[profile_name] = f
+                    except Exception as e:
+                        single_thread_flag = True
+                        
+                if single_thread_flag:
+                    single_thread_list.append(profile_name)
+                        
+            for profile_name in multi_processing_dict.keys():
+                self.profiles[profile_name] = f.get()
+                
+            # Close pool for new tasks
+            pool.close()
+            
+            # Wait for all workers to complete 
+            pool.join()
 
-        # Wait for all workers to complete 
-        pool.join()
+            # Clean up anything remaining
+            for profile_name in single_thread_list:
+                self.profiles[profile_name].update_profile(clean_sampled_df)
         """
 
     def _get_sample_size(self, df_series):

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -220,42 +220,6 @@ class StructuredDataProfile(object):
         for profile in self.profiles.values():
             profile.update_profile(clean_sampled_df)
 
-        """
-        if self.options and self.options.StructuredOptions \
-           and self.options.StructuredOptions.multiprocess.is_enabled:
-        else: # Multiprocessing
-            
-            pool = mp.Pool(len(self.profiles.values()))
-            multi_processing_dict = {}
-            single_thread_list = []
-            for profile_name in self.profiles.keys():
-                
-                profile = self.profiles[profile_name]
-                single_thread_flag = True                
-                if profile.__repr__() != 'ColumnDataLabelerCompiler':
-                    try:
-                        single_thread_flag = False
-                        f = pool.apply_async(profile.update_profile, [clean_sampled_df])
-                        multi_processing_dict[profile_name] = f
-                    except Exception as e:
-                        single_thread_flag = True
-                        
-                if single_thread_flag:
-                    single_thread_list.append(profile_name)
-                        
-            for profile_name in multi_processing_dict.keys():
-                self.profiles[profile_name] = f.get()
-                
-            # Close pool for new tasks
-            pool.close()
-            
-            # Wait for all workers to complete 
-            pool.join()
-
-            # Clean up anything remaining
-            for profile_name in single_thread_list:
-                self.profiles[profile_name].update_profile(clean_sampled_df)
-        """
 
     def _get_sample_size(self, df_series):
         """

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -220,6 +220,43 @@ class StructuredDataProfile(object):
         for profile in self.profiles.values():
             profile.update_profile(clean_sampled_df)
 
+        """
+        if self.options and self.options.StructuredOptions \
+           and self.options.StructuredOptions.multiprocess.is_enabled:
+        else: # Multiprocessing
+            
+            pool = mp.Pool(len(self.profiles.values()))
+            multi_processing_dict = {}
+            single_thread_list = []
+            for profile_name in self.profiles.keys():
+                
+                profile = self.profiles[profile_name]
+                single_thread_flag = True                
+                if profile.__repr__() != 'ColumnDataLabelerCompiler':
+                    try:
+                        single_thread_flag = False
+                        f = pool.apply_async(profile.update_profile, [clean_sampled_df])
+                        multi_processing_dict[profile_name] = f
+                    except Exception as e:
+                        single_thread_flag = True
+                        
+                if single_thread_flag:
+                    single_thread_list.append(profile_name)
+                        
+            for profile_name in multi_processing_dict.keys():
+                self.profiles[profile_name] = f.get()
+                
+            # Close pool for new tasks
+            pool.close()
+            
+            # Wait for all workers to complete 
+            pool.join()
+
+            # Clean up anything remaining
+            for profile_name in single_thread_list:
+                self.profiles[profile_name].update_profile(clean_sampled_df)
+        """
+
     def _get_sample_size(self, df_series):
         """
         Determines the minimum sampling size for detecting column type.

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -15,6 +15,8 @@ import hashlib
 from collections import OrderedDict
 import warnings
 
+import multiprocessing as mp
+
 import pandas as pd
 
 from . import utils
@@ -76,10 +78,10 @@ class StructuredDataProfile(object):
         self._update_base_stats(base_stats)
         self.profiles = {
             'data_type_profile':
-                ColumnPrimitiveTypeProfileCompiler(clean_sampled_df,
-                                                   self.options),
+            ColumnPrimitiveTypeProfileCompiler(clean_sampled_df, self.options),
             'data_stats_profile':
-                ColumnStatsProfileCompiler(clean_sampled_df, self.options)}
+            ColumnStatsProfileCompiler(clean_sampled_df, self.options)
+        }
 
         use_data_labeler = True
         if options and isinstance(options, StructuredOptions):
@@ -214,8 +216,29 @@ class StructuredDataProfile(object):
             self.get_base_props_and_clean_null_params(
                 df_series, sample_size, min_true_samples=min_true_samples)
         self._update_base_stats(base_stats)
+
         for profile in self.profiles.values():
             profile.update_profile(clean_sampled_df)
+
+        """
+        # MULTITHREADING
+        pool = mp.Pool(len(self.profiles.values()))
+        funclist = []
+        labeler_profile_type = 'ColumnDataLabelerCompiler'
+        
+        for profile in self.profiles.values():
+            if profile.__repr__() != 'ColumnDataLabelerCompiler':
+                f = pool.apply_async(profile.update_profile, [clean_sampled_df])
+                funclist.append(f)
+            else:
+                profile.update_profile(clean_sampled_df)
+        
+        # Close pool for new tasks         
+        pool.close()
+
+        # Wait for all workers to complete 
+        pool.join()
+        """
 
     def _get_sample_size(self, df_series):
         """

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -585,6 +585,7 @@ class StructuredOptions(BaseOption):
         :ivar data_labeler: option set for data_labeler profiling.
         :vartype data_labeler: DataLabelerOptions
         """
+        self.multiprocess = BooleanOption()
         self.int = IntOptions()
         self.float = FloatOptions()
         self.datetime = DateTimeOptions()
@@ -614,6 +615,7 @@ class StructuredOptions(BaseOption):
         errors = []
 
         prop_check = dict([
+            ('multiprocess', BooleanOption),
             ('int', IntOptions),
             ('float', FloatOptions),
             ('datetime', DateTimeOptions),

--- a/dataprofiler/profilers/text_column_profile.py
+++ b/dataprofiler/profilers/text_column_profile.py
@@ -141,7 +141,8 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         """
         len_df = len(df_series)
         if len_df == 0:
-            return
+            return self
+        
         profile = dict(match_count=len_df, sample_size=len_df)
 
         BaseColumnProfiler._perform_property_calcs(
@@ -149,3 +150,5 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             prev_dependent_properties={}, subset_properties=profile)
 
         self._update_helper(df_series, profile)
+
+        return self

--- a/dataprofiler/tests/profilers/test_base_column_profilers.py
+++ b/dataprofiler/tests/profilers/test_base_column_profilers.py
@@ -272,9 +272,6 @@ class AbstractTestColumnProfiler(object):
                 zip(self.column_profile._profiles.values(), profiler_mocks):
             self.assertIn(profile.__class__, self.profilers)
             self.assertEqual(1, profiler_mock.call_count)
-            self.assertEqual(
-                1, profiler_mock.return_value.update.call_count
-            )
         self._delete_profiler_mocks()
 
     def test_updated_profile(self):
@@ -284,9 +281,6 @@ class AbstractTestColumnProfiler(object):
 
         for profiler_mock in profiler_mocks:
             self.assertEqual(1, profiler_mock.call_count)
-            self.assertEqual(
-                2, profiler_mock.return_value.update.call_count
-            )
         self._delete_profiler_mocks()
 
     def test_profile(self):

--- a/dataprofiler/tests/profilers/test_categorical_column_profile.py
+++ b/dataprofiler/tests/profilers/test_categorical_column_profile.py
@@ -123,7 +123,7 @@ class TestCategoricalColumn(unittest.TestCase):
         num_null_types = 4
         num_nan_count = 2
         categories = pd.concat([df1, df2]).apply(str).unique().tolist()
-        column_profile.update_profile(df2)
+        column_profile.update_profile(df2)        
         six.assertCountEqual(
             self,
             categories,

--- a/dataprofiler/tests/profilers/test_categorical_column_profile.py
+++ b/dataprofiler/tests/profilers/test_categorical_column_profile.py
@@ -123,7 +123,7 @@ class TestCategoricalColumn(unittest.TestCase):
         num_null_types = 4
         num_nan_count = 2
         categories = pd.concat([df1, df2]).apply(str).unique().tolist()
-        column_profile.update_profile(df2)        
+        column_profile.update_profile(df2)
         six.assertCountEqual(
             self,
             categories,

--- a/dataprofiler/tests/profilers/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/test_profiler_options.py
@@ -124,7 +124,9 @@ class TestProfilerOptions(unittest.TestCase):
         vocab_mock.assert_not_called()
 
         # Check to see default options enable vocab
-        profile = Profiler(self.data)
+        multi_options = ProfilerOptions()
+        multi_options.structured_options.multiprocess.is_enabled = False
+        profile = Profiler(self.data, profiler_options=multi_options)
         vocab_mock.assert_called()
 
     def test_disabling_all_stats(self, *mocks):
@@ -296,11 +298,14 @@ class TestProfilerOptions(unittest.TestCase):
     def test_float_precision(self, update_precision, *mocks):
         options = ProfilerOptions()
         options.structured_options.float.precision.is_enabled = False
+        options.structured_options.multiprocess.is_enabled = False
 
         profile = Profiler(self.data, profiler_options=options)
         update_precision.assert_not_called()
 
-        profile = Profiler(self.data)
+        multi_options = ProfilerOptions()
+        multi_options.structured_options.multiprocess.is_enabled = False
+        profile = Profiler(self.data, profiler_options=multi_options)
         update_precision.assert_called()
 
     def test_set_attribute_error(self, *mocks):


### PR DESCRIPTION
For comparison, see the two runs below (ran `United_States_Drought_Monitor__2000-2016.csv`)

I think there's still plenty of room to improve, but this reduces runtime by about 40% on this file. 

-------------------------

For `United_States_Drought_Monitor__2000-2016.csv`

Multiprocess:
```
50419680 function calls (50392635 primitive calls) in 122.032 seconds

   Ordered by: internal time
   List reduced from 1108 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      312   64.649    0.207   64.649    0.207 {method 'acquire' of '_thread.lock' objects}
       42   18.371    0.437   20.995    0.500 utils.py:53(shuffle_in_chunks)
  597/489   11.262    0.019   11.262    0.023 {built-in method numpy.array}
 16716443    3.991    0.000    3.991    0.000 {method 'search' of 're.Pattern' objects}
       14    3.897    0.278    3.897    0.278 {built-in method builtins.sorted}
       18    3.776    0.210    3.782    0.210 {pandas._libs.lib.map_infer}
        6    3.351    0.558   51.707    8.618 profile_builder.py:259(get_base_props_and_clean_null_params)
```

Single Process
```
189132806 function calls (188964701 primitive calls) in 191.153 seconds

   Ordered by: internal time
   List reduced from 1414 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      126   50.061    0.397   52.994    0.421 numerical_column_stats.py:239(_total_histogram_bin_variance)
       42   18.545    0.442   21.149    0.504 utils.py:53(shuffle_in_chunks)
10513/9311   14.103    0.001   14.114    0.002 {built-in method numpy.array}
        6   11.487    1.914   16.918    2.820 float_column_profile.py:97(_get_float_precision)
 16716414   10.113    0.000   21.751    0.000 base_column_profilers.py:47(_combine_unique_sets)
```
------------------------------

For `diamonds.csv` (no labeler)

Multiprocess:
```
2013326 function calls (1972475 primitive calls) in 5.615 seconds

   Ordered by: internal time
   List reduced from 1108 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      492    3.943    0.008    3.943    0.008 {method 'acquire' of '_thread.lock' objects}
       60    0.475    0.008    0.559    0.009 utils.py:53(shuffle_in_chunks)
```

Single process 
```
7273657 function calls (7192892 primitive calls) in 7.827 seconds

   Ordered by: internal time
   List reduced from 1473 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      304    1.945    0.006    1.945    0.006 {method 'acquire' of '_thread.lock' objects}
    23976    0.640    0.000    0.794    0.000 numerical_column_stats.py:386(_get_percentile)
       60    0.470    0.008    0.554    0.009 utils.py:53(shuffle_in_chunks)

```