### PR TITLE
Fixes a bug in tensorflow import test when tests are ran sequentially

### DIFF
--- a/dataprofiler/tests/test_data_profiler.py
+++ b/dataprofiler/tests/test_data_profiler.py
@@ -25,7 +25,8 @@ class TestDataProfiler(unittest.TestCase):
 
         test_dir = os.path.join(MODULE_PATH, 'data')
         cls.input_file_names = [
-            dict(path=os.path.join(test_dir, 'csv/aws_honeypot_marx_geo.csv'), type='csv'),
+            dict(path=os.path.join(test_dir, 'csv/aws_honeypot_marx_geo.csv'),
+                 type='csv'),
         ]
 
     def test_data_import(self):
@@ -81,8 +82,6 @@ class TestDataProfiler(unittest.TestCase):
 
     def test_no_tensorflow(self):
         import sys
-        import importlib
-        import types
         import pandas
         orig_import = __import__
         # necessary for any wrapper around the library to test if snappy caught
@@ -92,16 +91,22 @@ class TestDataProfiler(unittest.TestCase):
             if name == 'tensorflow':
                 raise ImportError('test')
             return orig_import(name, *args)
-                        
+
         with mock.patch('builtins.__import__', side_effect=import_mock):
 
             with self.assertWarns(RuntimeWarning) as w:
-                import dataprofiler
-                df = pandas.DataFrame([[1, 2.0],[1, 2.2],[-1, 3]])
-                profile = dataprofiler.Profiler(df)
-        
+                modules_with_tf = [
+                    'dataprofiler.labelers.character_level_cnn_model',
+                ]
+                for module in modules_with_tf:
+                    if module in sys.modules:
+                        del sys.modules[module]
+                df = pandas.DataFrame([[1, 2.0], [1, 2.2], [-1, 3]])
+                profile = Profiler(df)
+
         warning_msg = "Partial Profiler Failure"
         self.assertIn(warning_msg, str(w.warning))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/dataprofiler/tests/test_data_profiler.py
+++ b/dataprofiler/tests/test_data_profiler.py
@@ -94,7 +94,8 @@ class TestDataProfiler(unittest.TestCase):
 
         with mock.patch('builtins.__import__', side_effect=import_mock):
 
-            with self.assertWarns(RuntimeWarning) as w:
+            with self.assertWarnsRegex(RuntimeWarning,
+                                       "Partial Profiler Failure"):
                 modules_with_tf = [
                     'dataprofiler.labelers.character_level_cnn_model',
                 ]
@@ -103,9 +104,6 @@ class TestDataProfiler(unittest.TestCase):
                         del sys.modules[module]
                 df = pandas.DataFrame([[1, 2.0], [1, 2.2], [-1, 3]])
                 profile = Profiler(df)
-
-        warning_msg = "Partial Profiler Failure"
-        self.assertIn(warning_msg, str(w.warning))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When other tests imported the library, this potentially was no longer caught since update is no longer in the try except. In parallel, this test would be successful, but not sequentially.