### PR TITLE
update get_percentiles to take in an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ Below is an breakdown of all the options.
                 * is_enabled - (Boolean) Enables or disables variance
             * histogram_and_quantiles - Generates a histogram and quantiles
             from the column values
-                * method - (String/List[String]) Designates preferred method for calculating histogram bins.  
+                * bin_count_or_method - (String/List[String]) Designates preferred method for calculating histogram bins or the number of bins to use.  
                 If left unspecified (None) the optimal method will be chosen by attempting all methods.  
                 If multiple specified (list) the optimal method will be chosen by attempting the provided ones.  
                 methods: 'auto', 'fd', 'doane', 'scott', 'rice', 'sturges', 'sqrt'  
@@ -498,7 +498,7 @@ Below is an breakdown of all the options.
                 * is_enabled - (Boolean) Enables or disables variance
             * histogram_and_quantiles - Generates a histogram and quantiles
             from the column values
-                * method - (String/List[String]) Designates preferred method for calculating histogram bins.  
+                * bin_count_or_method - (String/List[String]) Designates preferred method for calculating histogram bins or the number of bins to use.  
                 If left unspecified (None) the optimal method will be chosen by attempting all methods.  
                 If multiple specified (list) the optimal method will be chosen by attempting the provided ones.  
                 methods: 'auto', 'fd', 'doane', 'scott', 'rice', 'sturges', 'sqrt'  
@@ -518,7 +518,7 @@ Below is an breakdown of all the options.
                 * is_enabled - (Boolean) Enables or disables variance
             * histogram_and_quantiles - Generates a histogram and quantiles
             from the column values
-                * method - (String/List[String]) Designates preferred method for calculating histogram bins.  
+                * bin_count_or_method - (String/List[String]) Designates preferred method for calculating histogram bins or the number of bins to use.  
                 If left unspecified (None) the optimal method will be chosen by attempting all methods.  
                 If multiple specified (list) the optimal method will be chosen by attempting the provided ones.  
                 methods: 'auto', 'fd', 'doane', 'scott', 'rice', 'sturges', 'sqrt'  

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -120,9 +120,6 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         Property for profile. Returns the profile of the column.
         :return:
         """
-        histogram_method = self.histogram_bin_method_names[0]
-        if self.histogram_selection is not None:
-            histogram_method = self.histogram_selection
 
         profile = dict(
             min=self.np_type_to_type(self.min),

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -130,7 +130,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             mean=self.np_type_to_type(self.mean),
             variance=self.np_type_to_type(self.variance),
             stddev=self.np_type_to_type(self.stddev),
-            histogram=self.histogram_methods[histogram_method]['histogram'],
+            histogram=self._get_best_histogram_for_profile(),
             quantiles=self.quantiles,
             times=self.times,
             precision=dict(

--- a/dataprofiler/profilers/helpers/report_helpers.py
+++ b/dataprofiler/profilers/helpers/report_helpers.py
@@ -5,9 +5,9 @@ import numpy as np
 
 def calculate_quantiles(num_quantile_groups, quantiles):
     len_quant = len(quantiles)
-    if not (num_quantile_groups and 0 < num_quantile_groups <= len_quant):
+    if not (num_quantile_groups and 0 < num_quantile_groups <= (len_quant + 1)):
         num_quantile_groups = 4
-    quant_multiplier = len_quant/num_quantile_groups
+    quant_multiplier = (len_quant + 1) / num_quantile_groups
     # quantile is one less than group
     # Goes from zero (inclusive) to number of groups (exclusive)
     # +1 because 0 + 1 * multiplier = correct first quantile

--- a/dataprofiler/profilers/int_column_profile.py
+++ b/dataprofiler/profilers/int_column_profile.py
@@ -60,10 +60,6 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         
         :return:
         """
-        histogram_method = self.histogram_bin_method_names[0]
-        if self.histogram_selection is not None:
-            histogram_method = self.histogram_selection
-
         profile = dict(
             min=self.np_type_to_type(self.min),
             max=self.np_type_to_type(self.max),

--- a/dataprofiler/profilers/int_column_profile.py
+++ b/dataprofiler/profilers/int_column_profile.py
@@ -70,7 +70,7 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             mean=self.np_type_to_type(self.mean),
             variance=self.np_type_to_type(self.variance),
             stddev=self.np_type_to_type(self.stddev),
-            histogram=self.histogram_methods[histogram_method]['histogram'],
+            histogram=self._get_best_histogram_for_profile(),
             quantiles=self.quantiles,
             times=self.times
         )

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -362,9 +362,11 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
 
     def _get_histogram(self, values):
         """
-        Get histogram from values and bin method, using np.histogram
-        :param values: input values
-        :type values: np.array or pd.Series
+        Calculates the stored histogram the suggested bin counts for each
+        histogram method, uses np.histogram
+        
+        :param values: input data values
+        :type values: Union[np.array, pd.Series]
         :return: bin edges and bin counts
         """
         if len(np.unique(values)) == 1:
@@ -375,8 +377,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
                 unique_value = values.iloc[0]
             bin_edges = np.array([unique_value, unique_value])
             for i, bin_method in enumerate(self.histogram_bin_method_names):
-                self.histogram_methods[bin_method]['histogram']['bin_counts'] = \
-                    bin_counts
+                self.histogram_methods[bin_method]['histogram'][
+                    'bin_counts'] = bin_counts
                 self.histogram_methods[bin_method]['histogram'][
                     'bin_edges'] = bin_edges
                 self.histogram_methods[bin_method]['suggested_bin_count'] = 1

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -439,14 +439,22 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         normalized_bin_counts = bin_counts / np.sum(bin_counts)
         cumsum_bin_counts = np.cumsum(normalized_bin_counts)
 
+        median_value = None
+        median_bin_inds = cumsum_bin_counts == 0.5
+        if np.sum(median_bin_inds) > 1:
+            median_value = np.mean(bin_edges[np.append([False], median_bin_inds)])
+
         # use the floor by slightly increasing cases where no bin exist.
         cumsum_bin_counts[zero_inds] += 1e-15
 
         # add initial zero bin
         cumsum_bin_counts = np.append([0], cumsum_bin_counts)
 
-        return np.interp(
-            percentiles / 100, cumsum_bin_counts, bin_edges).tolist()
+        quantiles = np.interp(percentiles / 100,
+                              cumsum_bin_counts, bin_edges).tolist()
+        if median_value:
+            quantiles[499] = median_value
+        return quantiles
 
     def _get_quantiles(self):
         """

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -470,6 +470,11 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
 
             bin_edge = bin_edges[bin_id: bin_id + 3]
 
+            # if we know not float, we can assume values in bins are integers.
+            is_float_profile = self.__class__.__name__ == 'FloatColumn'
+            if not is_float_profile:
+                bin_edge = np.round(bin_edge)
+
             # loop until we have a new bin which contains the current bin.
             while (bin_edge[0] >= new_bin_edges[new_bin_id + 1]
                    and new_bin_id < suggested_bin_count - 1):

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -432,50 +432,11 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
             self.histogram_methods[selected_method]['histogram']['bin_counts']
         bin_edges = \
             self.histogram_methods[selected_method]['histogram']['bin_edges']
-        num_edges = len(bin_edges)
-
-        quantiles = [0] * len(percentiles)
-        sorted_percentile_inds = np.argsort(percentiles)
-
-        bin_id = -1
-        accumulated_count = 0
         bin_counts = bin_counts.astype(float)
         normalized_bin_counts = bin_counts / np.sum(bin_counts)
         return np.interp(percentiles / 100,
                          np.append([0], np.cumsum(normalized_bin_counts)),
                          bin_edges).tolist()
-
-        # for ind in sorted_percentile_inds:
-        #
-        #     percentile = percentiles[ind]
-        #     if percentile == 100:
-        #         quantiles[ind] = bin_edges[-1]
-        #         continue
-        #
-        #     percentile = float(percentile) / 100
-        #
-        #     # keep updating the total counts until it is
-        #     # close to the designated percentile
-        #     while accumulated_count < percentile:
-        #         bin_id += 1
-        #         accumulated_count += normalized_bin_counts[bin_id]
-        #
-        #     if accumulated_count == percentile:
-        #         if (num_edges % 2) == 0:
-        #             quantiles[ind] = 0.5 * (bin_edges[bin_id]
-        #                                     + bin_edges[bin_id + 1])
-        #         else:
-        #             quantiles[ind] = bin_edges[bin_id + 1]
-        #     else:
-        #         if bin_id == 0:
-        #             quantiles[ind] = 0.5 * (bin_edges[0] + bin_edges[1])
-        #         elif (num_edges % 2) == 0:
-        #             quantiles[ind] = 0.5 * (bin_edges[bin_id - 1]
-        #                                     + bin_edges[bin_id])
-        #         else:
-        #             quantiles[ind] = bin_edges[bin_id]
-
-        return quantiles
 
     def _get_quantiles(self):
         """

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -9,7 +9,6 @@ from __future__ import division
 
 from future.utils import with_metaclass
 import copy
-import time
 import abc
 import warnings
 

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -313,7 +313,9 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         # reset the edge
         bin_edges[-1] -= 1e-3
 
-        sum_error = (input_array - (bin_edges[inds] + bin_edges[inds - 1])/2) ** 2
+        sum_error = sum(
+            (input_array - (bin_edges[inds] + bin_edges[inds - 1])/2) ** 2
+        )
         return sum_error
 
     @staticmethod

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -340,23 +340,18 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         # Extend histogram to array format
         bin_counts = self._stored_histogram['histogram']['bin_counts']
         bin_edges = self._stored_histogram['histogram']['bin_edges']
-        # is_bin_non_zero = bin_counts > 0
-        # bin_midpoints = (bin_edges[1:][is_bin_non_zero]
-        #                  + bin_edges[:-1][is_bin_non_zero]) / 2
         is_bin_non_zero = bin_counts[:-1] > 0
         bin_midpoints = bin_edges[:-2][is_bin_non_zero]
-        hist_to_array = [[midpoint] * count for midpoint, count
-                         in zip(bin_midpoints, bin_counts[:-1][is_bin_non_zero])]
+        hist_to_array = [
+            [midpoint] * count for midpoint, count
+            in zip(bin_midpoints, bin_counts[:-1][is_bin_non_zero])
+        ]
         if not hist_to_array:
             hist_to_array = [[]]
-        # array_flatten = np.concatenate(hist_to_array)
+
         array_flatten = np.concatenate(
             (hist_to_array + [[bin_edges[-2]] * int(bin_counts[-1] / 2)] +
             [[bin_edges[-1]] * (bin_counts[-1] - int(bin_counts[-1] / 2))]))
-
-        # # the min/max must be preserved
-        # array_flatten[0] = bin_edges[0]
-        # array_flatten[-1] = bin_edges[-1]
 
         # If we know they are integers, we can limit the data to be as such
         # during conversion

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -354,6 +354,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
                 self.histogram_methods[method]['current_loss']
 
             if min_total_loss >= self.histogram_methods[method]['total_loss']:
+                # if same loss and less bins, don't save bc higher resolution
                 if (self.histogram_methods[method]['suggested_bin_count']
                         <= selected_suggested_bin_count
                         and min_total_loss ==
@@ -371,10 +372,10 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         bin_counts = self._stored_histogram['histogram']['bin_counts']
         bin_edges = self._stored_histogram['histogram']['bin_edges']
         is_bin_non_zero = bin_counts[:-1] > 0
-        bin_midpoints = bin_edges[:-2][is_bin_non_zero]
+        bin_left_edge = bin_edges[:-2][is_bin_non_zero]
         hist_to_array = [
-            [midpoint] * count for midpoint, count
-            in zip(bin_midpoints, bin_counts[:-1][is_bin_non_zero])
+            [left_edge] * count for left_edge, count
+            in zip(bin_left_edge, bin_counts[:-1][is_bin_non_zero])
         ]
         if not hist_to_array:
             hist_to_array = [[]]

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -175,7 +175,6 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
                 other1.match_count, other1.variance, other1.mean,
                 other2.match_count, other2.variance, other2.mean)
         if "histogram_and_quantiles" in self.__calculations.keys():
-            self._profile_histogram = None
             if other1.histogram_selection is not None and \
                     other2.histogram_selection is not None:
                 self._add_helper_merge_profile_histograms(other1, other2)

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -70,6 +70,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
                 self.user_set_histogram_bin = bin_count_or_method
                 self.histogram_bin_method_names = ['custom']
         self.histogram_methods = {}
+        self._profile_histogram = None
         for method in self.histogram_bin_method_names:
             self.histogram_methods[method] = {
                 'total_loss': 0,
@@ -80,7 +81,6 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
                     'bin_edges': None
                 }
             }
-        self._profile_histogram = None
         num_quantiles = 1000  # TODO: add to options
         self.quantiles = {bin_num: None for bin_num in range(num_quantiles - 1)}
         self.__calculations = {

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -124,8 +124,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         :return: None
         """
         # get available bin methods and set to current
-        bin_methods = list(set(other1.histogram_bin_method_names) &
-                           set(other2.histogram_bin_method_names))
+        bin_methods = [x for x in other1.histogram_bin_method_names
+                       if x in other2.histogram_bin_method_names]
         if not bin_methods:
             raise ValueError('Profiles have no overlapping bin methods and '
                              'therefore cannot be added together.')
@@ -370,13 +370,10 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         Get histogram from values and bin method, using np.histogram
         :param values: input values
         :type values: np.array or pd.Series
-        :param bin_method: bin method, e.g., sqrt, rice, etc
-        :type bin_method: str
         :return: bin edges and bin counts
         """
         if len(np.unique(values)) == 1:
             bin_counts = np.array([len(values)])
-            suggested_bin_count = 1
             if isinstance(values, (np.ndarray, list)):
                 unique_value = values[0]
             else:
@@ -387,8 +384,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
                     bin_counts
                 self.histogram_methods[bin_method]['histogram'][
                     'bin_edges'] = bin_edges
-                self.histogram_methods[bin_method]['suggested_bin_count'] = \
-                    suggested_bin_count
+                self.histogram_methods[bin_method]['suggested_bin_count'] = 1
         else:
             # if user set the bin count, then use the user set count to
             n_equal_bins = suggested_bin_count = self.min_histogram_bin

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -53,7 +53,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         self.sum = 0
         self.variance = 0
         self.max_histogram_bin = 10000
-        self.min_histogram_bin = 1
+        self.min_histogram_bin = 1000
         self.histogram_bin_method_names = [
             'auto', 'fd', 'doane', 'scott', 'rice', 'sturges', 'sqrt'
         ]

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -433,14 +433,14 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         bin_edges = \
             self.histogram_methods[selected_method]['histogram']['bin_edges']
 
-        non_zero_inds = bin_counts == 0
+        zero_inds = bin_counts == 0
 
         bin_counts = bin_counts.astype(float)
         normalized_bin_counts = bin_counts / np.sum(bin_counts)
         cumsum_bin_counts = np.cumsum(normalized_bin_counts)
 
         # use the floor by slightly increasing cases where no bin exist.
-        cumsum_bin_counts[non_zero_inds] += 1e-15
+        cumsum_bin_counts[zero_inds] += 1e-15
 
         # add initial zero bin
         cumsum_bin_counts = np.append([0], cumsum_bin_counts)

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -361,7 +361,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         # If we know they are integers, we can limit the data to be as such
         # during conversion
         if not self.__class__.__name__ == 'FloatColumn':
-            array_flatten = array_flatten.astype(int)
+            array_flatten = np.round(array_flatten)
 
         return array_flatten
 

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -440,7 +440,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         cumsum_bin_counts = np.cumsum(normalized_bin_counts)
 
         # use the floor by slightly increasing cases where no bin exist.
-        cumsum_bin_counts[non_zero_inds] += 1e-12
+        cumsum_bin_counts[non_zero_inds] += 1e-15
 
         # add initial zero bin
         cumsum_bin_counts = np.append([0], cumsum_bin_counts)

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -80,6 +80,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
                     'bin_edges': None
                 }
             }
+        self._profile_histogram = None
         num_quantiles = 1000  # TODO: add to options
         self.quantiles = {bin_num: None for bin_num in range(num_quantiles - 1)}
         self.__calculations = {
@@ -174,6 +175,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
                 other1.match_count, other1.variance, other1.mean,
                 other2.match_count, other2.variance, other2.mean)
         if "histogram_and_quantiles" in self.__calculations.keys():
+            self._profile_histogram = None
             if other1.histogram_selection is not None and \
                     other2.histogram_selection is not None:
                 self._add_helper_merge_profile_histograms(other1, other2)
@@ -525,6 +527,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         :return: histogram bin edges and bin counts
         :rtype: dict
         """
+        if self._profile_histogram is not None:
+            return self._profile_histogram
         best_histogram = {'bin_edges': [], 'bin_counts': []}
         best_hist_loss = np.inf
         for method in self.histogram_methods:
@@ -532,6 +536,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
             if hist_loss < best_hist_loss:
                 best_histogram = histogram
                 best_hist_loss = hist_loss
+        self._profile_histogram = best_histogram
         return best_histogram
 
     def _get_percentile(self, percentiles):
@@ -650,6 +655,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
                                      subset_properties):
         try:
             self._update_histogram(df_series)
+            self._profile_histogram = None
             if self.histogram_selection is not None:
                 self._get_quantiles()
         except BaseException:

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -432,6 +432,11 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
             self.histogram_methods[selected_method]['histogram']['bin_counts']
         bin_edges = \
             self.histogram_methods[selected_method]['histogram']['bin_edges']
+
+        non_zero_inds = bin_counts != 0
+        bin_counts = bin_counts[non_zero_inds]
+        bin_edges = bin_edges[np.append([True], non_zero_inds)]
+
         bin_counts = bin_counts.astype(float)
         normalized_bin_counts = bin_counts / np.sum(bin_counts)
         return np.interp(percentiles / 100,

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -433,11 +433,20 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         bin_edges = \
             self.histogram_methods[selected_method]['histogram']['bin_edges']
 
+        non_zero_inds = bin_counts == 0
+
         bin_counts = bin_counts.astype(float)
         normalized_bin_counts = bin_counts / np.sum(bin_counts)
-        return np.interp(percentiles / 100,
-                         np.append([0], np.cumsum(normalized_bin_counts)),
-                         bin_edges).tolist()
+        cumsum_bin_counts = np.cumsum(normalized_bin_counts)
+
+        # use the floor by slightly increasing cases where no bin exist.
+        cumsum_bin_counts[non_zero_inds] += 1e-12
+
+        # add initial zero bin
+        cumsum_bin_counts = np.append([0], cumsum_bin_counts)
+
+        return np.interp(
+            percentiles / 100, cumsum_bin_counts, bin_edges).tolist()
 
     def _get_quantiles(self):
         """

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -271,12 +271,14 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
 
     def _total_histogram_bin_variance(self, input_array, method):
         # calculate total variance over all bins of a histogram
+        bin_counts = self.histogram_methods[method]['histogram']['bin_counts']
         bin_edges = self.histogram_methods[method]['histogram']['bin_edges']
         inds = np.digitize(input_array, bin_edges)
         sum_var = 0
-        for i in range(1, len(bin_edges)):
+        non_zero_bins = np.where(bin_counts)[0] + 1
+        for i in non_zero_bins:
             elements_in_bin = input_array[inds == i]
-            bin_var = elements_in_bin.var() if len(elements_in_bin) > 0 else 0
+            bin_var = elements_in_bin.var()
             sum_var += bin_var
         return sum_var
 

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -313,12 +313,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         # reset the edge
         bin_edges[-1] -= 1e-3
 
-        sum_error = 0
-        non_zero_bins = np.where(bin_counts)[0] + 1
-        for i in non_zero_bins:
-            elements_in_bin = input_array[inds == i]
-            bin_error = sum((elements_in_bin - (bin_edges[i] + bin_edges[i-1])/2) ** 2)
-            sum_error += bin_error
+        sum_error = (input_array - (bin_edges[inds] + bin_edges[inds - 1])/2) ** 2
         return sum_error
 
     @staticmethod

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -433,10 +433,6 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         bin_edges = \
             self.histogram_methods[selected_method]['histogram']['bin_edges']
 
-        non_zero_inds = bin_counts != 0
-        bin_counts = bin_counts[non_zero_inds]
-        bin_edges = bin_edges[np.append([True], non_zero_inds)]
-
         bin_counts = bin_counts.astype(float)
         normalized_bin_counts = bin_counts / np.sum(bin_counts)
         return np.interp(percentiles / 100,

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -51,7 +51,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         self.max = None
         self.sum = 0
         self.variance = 0
-        self.max_histogram_bin = 10000
+        self.max_histogram_bin = 100000
         self.min_histogram_bin = 1000
         self.histogram_bin_method_names = [
             'auto', 'fd', 'doane', 'scott', 'rice', 'sturges', 'sqrt'

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -364,7 +364,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         """
         Calculates the stored histogram the suggested bin counts for each
         histogram method, uses np.histogram
-        
+
         :param values: input data values
         :type values: Union[np.array, pd.Series]
         :return: bin edges and bin counts
@@ -376,7 +376,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
             else:
                 unique_value = values.iloc[0]
             bin_edges = np.array([unique_value, unique_value])
-            for i, bin_method in enumerate(self.histogram_bin_method_names):
+            for bin_method in self.histogram_bin_method_names:
                 self.histogram_methods[bin_method]['histogram'][
                     'bin_counts'] = bin_counts
                 self.histogram_methods[bin_method]['histogram'][

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -11,7 +11,6 @@ from __future__ import division
 import copy
 import random
 import re
-import hashlib
 from collections import OrderedDict
 import warnings
 
@@ -26,8 +25,7 @@ from .column_profile_compilers import ColumnPrimitiveTypeProfileCompiler, \
     ColumnStatsProfileCompiler, ColumnDataLabelerCompiler
 from ..labelers.data_labelers import DataLabeler
 from .helpers.report_helpers import calculate_quantiles, _prepare_report
-from .profiler_options import ProfilerOptions, StructuredOptions, \
-    DataLabelerOptions
+from .profiler_options import ProfilerOptions, StructuredOptions
 
 
 class StructuredDataProfile(object):

--- a/dataprofiler/profilers/text_column_profile.py
+++ b/dataprofiler/profilers/text_column_profile.py
@@ -89,7 +89,6 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         :rtype: float
         """
         return 1.0 if self.sample_size else None
-
     
     @BaseColumnProfiler._timeit(name='vocab')
     def _update_vocab(self, data, prev_dependent_properties=None,

--- a/dataprofiler/profilers/text_column_profile.py
+++ b/dataprofiler/profilers/text_column_profile.py
@@ -64,9 +64,6 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         
         :return:
         """
-        histogram_method = self.histogram_bin_method_names[0]
-        if self.histogram_selection is not None:
-            histogram_method = self.histogram_selection
 
         profile = dict(
             min=self.min,

--- a/dataprofiler/profilers/text_column_profile.py
+++ b/dataprofiler/profilers/text_column_profile.py
@@ -5,6 +5,7 @@ from .profiler_options import TextOptions
 from . import utils
 import itertools
 
+
 class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
     """
     Text column profile subclass of BaseColumnProfiler. Represents a column in
@@ -73,7 +74,7 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             mean=self.mean,
             variance=self.variance,
             stddev=self.stddev,
-            histogram=self.histogram_methods[histogram_method]['histogram'],
+            histogram=self._get_best_histogram_for_profile(),
             quantiles=self.quantiles,
             vocab=self.vocab,
             times=self.times

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -478,7 +478,7 @@ class TestFloatColumn(unittest.TestCase):
         profiler1.max_histogram_bin = 50
         profiler1.update(df1)
         num_bins = len(profiler1.profile['histogram']['bin_counts'])
-        self.assertEqual(num_bins, 4)
+        self.assertEqual(4, num_bins)
 
         # this data uses large number of bins, which will be set to
         # the max limit
@@ -488,14 +488,26 @@ class TestFloatColumn(unittest.TestCase):
         profiler2.max_histogram_bin = 50
         profiler2.update(df2)
         num_bins = len(profiler2.profile['histogram']['bin_counts'])
-        self.assertEqual(num_bins, 50)
+        self.assertEqual(50, num_bins)
 
         # max number of bin is increased to 10000
         profiler2 = FloatColumn(df2.name)
         profiler2.max_histogram_bin = 10000
+        profiler2.histogram_methods = dict()
+        # set method to auto which uses 10000 bins
+        profiler2.histogram_bin_method_names = ['auto']
+        profiler2.histogram_methods['auto'] = {
+            'total_loss': 0,
+            'current_loss': 0,
+            'suggested_bin_count': 10,
+            'histogram': {
+                'bin_counts': None,
+                'bin_edges': None
+            }
+        }
         profiler2.update(df2)
         num_bins = len(profiler2.profile['histogram']['bin_counts'])
-        self.assertEqual(num_bins, 6)
+        self.assertEqual(10000, num_bins)
 
     def test_estimate_stats_from_histogram(self):
         data = pd.Series([], dtype=object)

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -627,9 +627,9 @@ class TestFloatColumn(unittest.TestCase):
                 'bin_edges': np.array([2.5, 5.0, 7.5, 10.0, 12.5]),
             },
             quantiles={
-                0: 35 / 8,  # 75% between 2.5 and 5 (histogram based)
-                1: (5 + 7.5) / 2,  # 50% between 5.0 and 7.5 (histogram based)
-                2: 35 / 4,  # 25% between 7.5 and 12.5 (histogram based)
+                0: 4.375,  # 75% between 2.5 and 5 (histogram based)
+                1: 6.25,  # 50% between 5.0 and 7.5 (histogram based)
+                2: 10.625,  # 25% between 10.0 and 12.5 (histogram based)
             },
             times=defaultdict(float, {'histogram_and_quantiles': 15.0,
                                       'precision': 1.0, 'max': 1.0, 'min': 1.0,

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -581,19 +581,22 @@ class TestFloatColumn(unittest.TestCase):
         profiler.update(df)
         profile = profiler.profile
 
-        est_quartiles = profile['quantiles']
-        est_Q1 = est_quartiles[249]
-        est_Q2 = est_quartiles[499]
-        est_Q3 = est_quartiles[749]
+        est_quantiles = profile['quantiles']
+        est_Q1 = est_quantiles[249]
+        est_Q2 = est_quantiles[499]
+        est_Q3 = est_quantiles[749]
 
         data_to_num = [float(item) for item in data]
         exact_Q1 = np.percentile(data_to_num, 25)
         exact_Q2 = np.percentile(data_to_num, 50)
         exact_Q3 = np.percentile(data_to_num, 75)
 
+        self.assertEqual(999, len(est_quantiles))
+        self.assertAlmostEqual(1.003, est_quantiles[0])
         self.assertEqual(est_Q1, exact_Q1)
         self.assertEqual(est_Q2, exact_Q2)
         self.assertEqual(est_Q3, exact_Q3)
+        self.assertAlmostEqual(3.997, est_quantiles[-1])
 
     def test_data_type_ratio(self):
         data = np.linspace(-5, 5, 4)

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -28,7 +28,7 @@ class TestFloatColumn(unittest.TestCase):
         self.assertEqual(profiler.variance, 0)
         self.assertTrue(profiler.stddev is np.nan)
         self.assertIsNone(profiler.histogram_selection)
-        self.assertEqual(len(profiler.quantiles), 1000)
+        self.assertEqual(len(profiler.quantiles), 999)
         self.assertIsNone(profiler.data_type_ratio)
 
     def test_single_data_variance_case(self):
@@ -627,12 +627,12 @@ class TestFloatColumn(unittest.TestCase):
                 'bin_edges': np.array([2.5, 5.0, 7.5, 10.0, 12.5]),
             },
             quantiles={
-                0: 3.75,
-                1: 5.0,
-                2: 10.0
+                0: 35 / 8,  # 75% between 2.5 and 5 (histogram based)
+                1: (5 + 7.5) / 2,  # 50% between 5.0 and 7.5 (histogram based)
+                2: 35 / 4,  # 25% between 7.5 and 12.5 (histogram based)
             },
-            times=defaultdict(float, {'histogram_and_quantiles': 15.0,\
-                                      'precision': 1.0, 'max': 1.0, 'min': 1.0,\
+            times=defaultdict(float, {'histogram_and_quantiles': 15.0,
+                                      'precision': 1.0, 'max': 1.0, 'min': 1.0,
                                       'sum': 1.0, 'variance': 1.0}),
             precision={
                 'min': 1,

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -658,7 +658,7 @@ class TestFloatColumn(unittest.TestCase):
             expected_histogram = expected_profile.pop('histogram')
             quantiles = profile.pop('quantiles')
             expected_quantiles = expected_profile.pop('quantiles')
-            actual_quartiles = {0: quantiles[249], 1: quantiles[499], 2: quantiles[749]}
+
             self.assertDictEqual(expected_profile, profile)
             self.assertDictEqual(expected_profile['precision'], profile['precision'])
             self.assertCountEqual(expected_histogram['bin_counts'],
@@ -666,7 +666,9 @@ class TestFloatColumn(unittest.TestCase):
             self.assertCountEqual(np.round(expected_histogram['bin_edges'], 12),
                                   np.round(histogram['bin_edges'], 12))
 
-            self.assertDictEqual(actual_quartiles, expected_quantiles)
+            self.assertAlmostEqual(expected_quantiles[0], quantiles[249])
+            self.assertAlmostEqual(expected_quantiles[1], quantiles[499])
+            self.assertAlmostEqual(expected_quantiles[2], quantiles[749])
 
             # Validate time in datetime class has expected time after second update
             profiler.update(df)

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -375,8 +375,8 @@ class TestFloatColumn(unittest.TestCase):
         # with equal bin size, each bin has the width of 1
         df3 = pd.Series(["1.0", "1.0", "3.0", "4.0"])
         expected_histogram3 = {
-            'bin_counts': np.array([2, 0, 2]),
-            'bin_edges': np.array([1.0, 2.0, 3.0, 4.0]),
+            'bin_counts': np.array([2, 0, 1, 1]),
+            'bin_edges': np.array([1.0, 1.75, 2.5, 3.25, 4.0]),
         }
         list_data_test.append([df3, expected_histogram3])
 
@@ -557,14 +557,12 @@ class TestFloatColumn(unittest.TestCase):
         input_array = [0.5, 1.0, 2.0, 5.0]
 
         profiler._merge_histogram(input_array, 'sqrt')
-        merged_bin_counts = \
-            profiler.histogram_methods['sqrt']['histogram']['bin_counts']
-        merged_bin_edges = \
-            profiler.histogram_methods['sqrt']['histogram']['bin_edges']
+        merged_hist = profiler._histogram_for_profile('sqrt')[0]
+
         expected_bin_counts, expected_bin_edges = \
             [5, 2, 2], [0.5, 2.0, 3.5, 5.0]
-        self.assertCountEqual(merged_bin_counts, expected_bin_counts)
-        self.assertCountEqual(merged_bin_edges, expected_bin_edges)
+        self.assertCountEqual(expected_bin_counts, merged_hist['bin_counts'])
+        self.assertCountEqual(expected_bin_edges, merged_hist['bin_edges'])
 
     def test_profiled_quantiles(self):
         """
@@ -586,17 +584,12 @@ class TestFloatColumn(unittest.TestCase):
         est_Q2 = est_quantiles[499]
         est_Q3 = est_quantiles[749]
 
-        data_to_num = [float(item) for item in data]
-        exact_Q1 = np.percentile(data_to_num, 25)
-        exact_Q2 = np.percentile(data_to_num, 50)
-        exact_Q3 = np.percentile(data_to_num, 75)
-
         self.assertEqual(999, len(est_quantiles))
-        self.assertAlmostEqual(1.003, est_quantiles[0])
-        self.assertEqual(est_Q1, exact_Q1)
-        self.assertEqual(est_Q2, exact_Q2)
-        self.assertEqual(est_Q3, exact_Q3)
-        self.assertAlmostEqual(3.997, est_quantiles[-1])
+        self.assertAlmostEqual(1.000012, est_quantiles[0])
+        self.assertEqual(est_Q1, 1.003)
+        self.assertEqual(est_Q2, 2.5)
+        self.assertEqual(est_Q3, 3.001)
+        self.assertAlmostEqual(3.999988, est_quantiles[-1])
 
     def test_data_type_ratio(self):
         data = np.linspace(-5, 5, 4)
@@ -627,9 +620,9 @@ class TestFloatColumn(unittest.TestCase):
                 'bin_edges': np.array([2.5, 5.0, 7.5, 10.0, 12.5]),
             },
             quantiles={
-                0: 4.375 ,  # (5 - 2.5) * .75 + 2.5 (histogram based)
-                1: 6.25  ,  # halfway between 5.0 and 7.5 (histogram based)
-                2: 10.625,  # (12.5 - 10) * .25 + 10 (histogram based)
+                0: 2.5075,
+                1: 5.005 ,
+                2: 12.4925,
             },
             times=defaultdict(float, {'histogram_and_quantiles': 15.0,
                                       'precision': 1.0, 'max': 1.0, 'min': 1.0,

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -627,9 +627,9 @@ class TestFloatColumn(unittest.TestCase):
                 'bin_edges': np.array([2.5, 5.0, 7.5, 10.0, 12.5]),
             },
             quantiles={
-                0: 4.375,  # 75% between 2.5 and 5 (histogram based)
-                1: 6.25,  # 50% between 5.0 and 7.5 (histogram based)
-                2: 10.625,  # 25% between 10.0 and 12.5 (histogram based)
+                0: 4.375 ,  # (5 - 2.5) * .75 + 2.5 (histogram based)
+                1: 6.25  ,  # halfway between 5.0 and 7.5 (histogram based)
+                2: 10.625,  # (12.5 - 10) * .25 + 10 (histogram based)
             },
             times=defaultdict(float, {'histogram_and_quantiles': 15.0,
                                       'precision': 1.0, 'max': 1.0, 'min': 1.0,

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -493,18 +493,6 @@ class TestFloatColumn(unittest.TestCase):
         # max number of bin is increased to 10000
         profiler2 = FloatColumn(df2.name)
         profiler2.max_histogram_bin = 10000
-        profiler2.histogram_methods = dict()
-        # set method to auto which uses 10000 bins
-        profiler2.histogram_bin_method_names = ['auto']
-        profiler2.histogram_methods['auto'] = {
-            'total_loss': 0,
-            'current_loss': 0,
-            'suggested_bin_count': 10,
-            'histogram': {
-                'bin_counts': None,
-                'bin_edges': None
-            }
-        }
         profiler2.update(df2)
         num_bins = len(profiler2.profile['histogram']['bin_counts'])
         self.assertEqual(10000, num_bins)

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -428,8 +428,9 @@ class TestFloatColumn(unittest.TestCase):
         }
         list_data_test.append([df1, expected_histogram1])
 
-        # this data has 4 bins, range of 12
-        # with equal bin size, each bin has the width of 3.0
+        # this data will be the second update of the profile.
+        # this results in the combination of the previous data and this data.
+        # the range should update to 12 from 3.
         df2 = pd.Series(["1.0", "5.0", "8.0", "13.0"])
         expected_histogram2 = {
             'bin_counts': np.array([4, 1, 1, 1, 0, 1]),

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -343,8 +343,10 @@ class TestFloatColumn(unittest.TestCase):
             'bin_edges': np.array([-2., -1.,  0.,  1.,  2.]),
         }
 
-        self.assertCountEqual(histogram['bin_counts'], expected_histogram['bin_counts'])
-        self.assertCountEqual(histogram['bin_edges'], expected_histogram['bin_edges'])
+        self.assertEqual(expected_histogram['bin_counts'].tolist(),
+                         histogram['bin_counts'].tolist())
+        self.assertCountEqual(expected_histogram['bin_edges'],
+                              histogram['bin_edges'])
 
     def test_profiled_histogram(self):
         """
@@ -403,8 +405,8 @@ class TestFloatColumn(unittest.TestCase):
             profile = profiler.profile
             histogram = profile['histogram']
 
-            self.assertCountEqual(expected_histogram['bin_counts'],
-                                  histogram['bin_counts'])
+            self.assertEqual(expected_histogram['bin_counts'].tolist(),
+                                  histogram['bin_counts'].tolist())
             if i != 4:
                 self.assertCountEqual(np.round(expected_histogram['bin_edges'], 12),
                                   np.round(histogram['bin_edges'], 12))
@@ -447,8 +449,8 @@ class TestFloatColumn(unittest.TestCase):
             self.assertIsNotNone(profiler.histogram_selection)
             histogram = profile['histogram']
 
-            self.assertCountEqual(expected_histogram['bin_counts'],
-                                  histogram['bin_counts'])
+            self.assertEqual(expected_histogram['bin_counts'].tolist(),
+                             histogram['bin_counts'].tolist())
             self.assertCountEqual(np.round(expected_histogram['bin_edges'], 12),
                                   np.round(histogram['bin_edges'], 12))
 
@@ -464,8 +466,8 @@ class TestFloatColumn(unittest.TestCase):
         profile = merged_profiler.profile
         self.assertIsNotNone(merged_profiler.histogram_selection)
         histogram = profile['histogram']
-        self.assertCountEqual(expected_histogram['bin_counts'],
-                              histogram['bin_counts'])
+        self.assertEqual(expected_histogram['bin_counts'].tolist(),
+                         histogram['bin_counts'].tolist())
         self.assertCountEqual(np.round(expected_histogram['bin_edges'], 12),
                               np.round(histogram['bin_edges'], 12))
 
@@ -597,7 +599,7 @@ class TestFloatColumn(unittest.TestCase):
             np.array([1.0, 3.0, 5.0, 7.0])
         array_from_histogram = profiler._histogram_to_array()
         expected_array = [1.0, 1.0, 1.0, 3.0, 3.0, 7.0]
-        self.assertCountEqual(array_from_histogram, expected_array)
+        self.assertEqual(expected_array, array_from_histogram.tolist())
 
     def test_merge_histogram(self):
         data = pd.Series([], dtype=object)
@@ -613,7 +615,8 @@ class TestFloatColumn(unittest.TestCase):
 
         expected_bin_counts, expected_bin_edges = \
             [5, 2, 2], [0.5, 2.0, 3.5, 5.0]
-        self.assertCountEqual(expected_bin_counts, merged_hist['bin_counts'])
+        self.assertEqual(expected_bin_counts,
+                         merged_hist['bin_counts'].tolist())
         self.assertCountEqual(expected_bin_edges, merged_hist['bin_edges'])
 
     def test_profiled_quantiles(self):
@@ -707,8 +710,8 @@ class TestFloatColumn(unittest.TestCase):
             print(profile['times'])
             self.assertDictEqual(expected_profile, profile)
             self.assertDictEqual(expected_profile['precision'], profile['precision'])
-            self.assertCountEqual(expected_histogram['bin_counts'],
-                                  histogram['bin_counts'])
+            self.assertEqual(expected_histogram['bin_counts'].tolist(),
+                             histogram['bin_counts'].tolist())
             self.assertCountEqual(np.round(expected_histogram['bin_edges'], 12),
                                   np.round(histogram['bin_edges'], 12))
 
@@ -815,8 +818,8 @@ class TestFloatColumn(unittest.TestCase):
         self.assertEqual(profiler3.histogram_selection, 'doane')
         self.assertEqual(profiler3.min, expected_profile.pop('min'))
         self.assertEqual(profiler3.max, expected_profile.pop('max'))
-        self.assertCountEqual(histogram['bin_counts'],
-                              expected_histogram['bin_counts'])
+        self.assertEqual(histogram['bin_counts'].tolist(),
+                         expected_histogram['bin_counts'].tolist())
         self.assertCountEqual(histogram['bin_edges'],
                               expected_histogram['bin_edges'])
 

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -371,7 +371,7 @@ class TestIntColumn(unittest.TestCase):
             stddev=np.sqrt(30.916),
             histogram={
                 'bin_counts': np.array([1, 1, 1, 1]),
-                'bin_edges': np.array([2.,5.25,8.5,11.75,15.])
+                'bin_edges': np.array([2., 5.25, 8.5, 11.75, 15.])
             },
         )
 

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -277,8 +277,8 @@ class TestIntColumn(unittest.TestCase):
                 'bin_edges': np.array([2.0, 10.0/3.0, 14.0/3.0, 6.0])
             },
             quantiles={
-                0: 8 / 3,  # halfway between 2 and 3.333 (histogram based)
-                1: 10 / 3,  # 50% achieved at 10 / 3 (histogram based)
+                0: 8 /  3,  # halfway between 2 and 3.333 (histogram based)
+                1: 4.0   ,  # median between 2 and 6
                 2: 16 / 3,  # halfway between between 14 / 3 and 6
             },
             times=defaultdict(

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -277,9 +277,9 @@ class TestIntColumn(unittest.TestCase):
                 'bin_edges': np.array([2.0, 10.0/3.0, 14.0/3.0, 6.0])
             },
             quantiles={
-                0: 2.002,  # halfway between 2 and 3.333 (histogram based)
-                1: 4,  # median between 2 and 6
-                2: 5.998,  # halfway between between 14 / 3 and 6
+                0: 2.002,
+                1: 4,
+                2: 5.998,
             },
             times=defaultdict(
                 float, {'histogram_and_quantiles': 1.0, 'max': 1.0, 'min': 1.0,

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -302,8 +302,8 @@ class TestIntColumn(unittest.TestCase):
             expected_quartiles = expected_profile.pop('quantiles')
 
             self.assertDictEqual(expected_profile, profile)
-            self.assertCountEqual(expected_histogram['bin_counts'],
-                                  histogram['bin_counts'])
+            self.assertEqual(expected_histogram['bin_counts'].tolist(),
+                             histogram['bin_counts'].tolist())
             self.assertCountEqual(np.round(expected_histogram['bin_edges'], 12),
                                   np.round(histogram['bin_edges'], 12))
 
@@ -389,8 +389,8 @@ class TestIntColumn(unittest.TestCase):
         self.assertEqual(profiler3.histogram_selection, 'doane')
         self.assertEqual(profiler3.min,expected_profile.pop('min'))
         self.assertEqual(profiler3.max,expected_profile.pop('max'))
-        self.assertCountEqual(histogram['bin_counts'],
-                              expected_histogram['bin_counts'])
+        self.assertEqual(histogram['bin_counts'].tolist(),
+                         expected_histogram['bin_counts'].tolist())
         self.assertCountEqual(histogram['bin_edges'],
                               expected_histogram['bin_edges'])
 

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -277,9 +277,9 @@ class TestIntColumn(unittest.TestCase):
                 'bin_edges': np.array([2.0, 10.0/3.0, 14.0/3.0, 6.0])
             },
             quantiles={
-                0: 8.0/3.0,
-                1: 8.0/3.0,
-                2: 4.0
+                0: 8 / 3,  # halfway between 2 and 3.333 (histogram based)
+                1: 10 / 3,  # 50% achieved at 10 / 3 (histogram based)
+                2: 14 / 3,  # halfway between between 10 / 3 and 6
             },
             times=defaultdict(
                 float, {'histogram_and_quantiles': 15.0, 'max': 1.0, 'min': 1.0,
@@ -294,8 +294,8 @@ class TestIntColumn(unittest.TestCase):
 
             # Validate the time in the datetime class has the expected time.
             profile = profiler.profile
-            # pop out the histogram and quartiles to test separately from the rest
-            # of the dict as we need comparison with some precision
+            # pop out the histogram and quartiles to test separately from the
+            # rest of the dict as we need comparison with some precision
             histogram = profile.pop('histogram')
             expected_histogram = expected_profile.pop('histogram')
             quartiles = profile.pop('quantiles')
@@ -307,21 +307,21 @@ class TestIntColumn(unittest.TestCase):
             self.assertCountEqual(np.round(expected_histogram['bin_edges'], 12),
                                   np.round(histogram['bin_edges'], 12))
 
-            self.assertEqual(round(expected_quartiles[0], 12),
-                             round(quartiles[249], 12))
-            self.assertEqual(round(expected_quartiles[1], 12),
-                             round(quartiles[499], 12))
-            self.assertEqual(round(expected_quartiles[2], 12),
-                             round(quartiles[724], 12))
+            self.assertAlmostEqual(expected_quartiles[0], quartiles[249])
+            self.assertAlmostEqual(expected_quartiles[1], quartiles[499])
+            self.assertAlmostEqual(expected_quartiles[2], quartiles[749])
 
-            expected = defaultdict(float, {'min': 1.0, 'max': 1.0, 'sum': 1.0, 'variance': 1.0, \
-                                           'histogram_and_quantiles': 15.0})
+            expected = defaultdict(
+                float, {'min': 1.0, 'max': 1.0, 'sum': 1.0, 'variance': 1.0,
+                        'histogram_and_quantiles': 15.0})
             self.assertEqual(expected, profile['times'])
 
-            # Validate time in datetime class has expected time after second update
+            # Validate time in datetime class has expected time after second
+            # update
             profiler.update(df)
-            expected = defaultdict(float, {'min': 2.0, 'max': 2.0, 'sum': 2.0, 'variance': 2.0, \
-                                           'histogram_and_quantiles': 30.0})
+            expected = defaultdict(
+                float, {'min': 2.0, 'max': 2.0, 'sum': 2.0, 'variance': 2.0,
+                        'histogram_and_quantiles': 30.0})
             self.assertEqual(expected, profiler.profile['times'])
 
     def test_option_timing(self):

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -282,7 +282,7 @@ class TestIntColumn(unittest.TestCase):
                 2: 5.998,  # halfway between between 14 / 3 and 6
             },
             times=defaultdict(
-                float, {'histogram_and_quantiles': 15.0, 'max': 1.0, 'min': 1.0,
+                float, {'histogram_and_quantiles': 1.0, 'max': 1.0, 'min': 1.0,
                         'sum': 1.0, 'variance': 1.0})
             
         )
@@ -313,7 +313,7 @@ class TestIntColumn(unittest.TestCase):
 
             expected = defaultdict(
                 float, {'min': 1.0, 'max': 1.0, 'sum': 1.0, 'variance': 1.0,
-                        'histogram_and_quantiles': 15.0})
+                        'histogram_and_quantiles': 1.0})
             self.assertEqual(expected, profile['times'])
 
             # Validate time in datetime class has expected time after second
@@ -321,7 +321,7 @@ class TestIntColumn(unittest.TestCase):
             profiler.update(df)
             expected = defaultdict(
                 float, {'min': 2.0, 'max': 2.0, 'sum': 2.0, 'variance': 2.0,
-                        'histogram_and_quantiles': 30.0})
+                        'histogram_and_quantiles': 2.0})
             self.assertEqual(expected, profiler.profile['times'])
 
     def test_option_timing(self):
@@ -343,13 +343,13 @@ class TestIntColumn(unittest.TestCase):
             profile = profiler.profile
 
             expected = defaultdict(float, {'max': 1.0, 'sum': 1.0, 'variance': 1.0, \
-                                           'histogram_and_quantiles': 15.0})
+                                           'histogram_and_quantiles': 1.0})
             self.assertCountEqual(expected, profile['times'])
 
             # Validate time in datetime class has expected time after second update
             profiler.update(df)
             expected = defaultdict(float, {'max': 2.0, 'sum': 2.0, 'variance': 2.0, \
-                                           'histogram_and_quantiles': 30.0})
+                                           'histogram_and_quantiles': 2.0})
             self.assertCountEqual(expected, profiler.profile['times'])
 
     def test_profile_merge(self):
@@ -386,7 +386,7 @@ class TestIntColumn(unittest.TestCase):
         self.assertAlmostEqual(profiler3.variance,
                                expected_profile.pop('variance'), places=3)
         self.assertEqual(profiler3.mean,expected_profile.pop('mean'))
-        self.assertEqual(profiler3.histogram_selection, 'rice')
+        self.assertEqual(profiler3.histogram_selection, 'doane')
         self.assertEqual(profiler3.min,expected_profile.pop('min'))
         self.assertEqual(profiler3.max,expected_profile.pop('max'))
         self.assertCountEqual(histogram['bin_counts'],
@@ -518,8 +518,9 @@ class TestIntColumn(unittest.TestCase):
             profiler3 = profiler1 + profiler2
         
         # Assert that these features are still merged
+        profile = profiler3.profile
         self.assertIsNotNone(profiler3.histogram_selection)
-        self.assertIsNotNone(profiler3.variance)
+        self.assertIsNotNone(profile['variance'])
         self.assertIsNotNone(profiler3.sum)
         
         # Assert that these features are not calculated
@@ -563,7 +564,7 @@ class TestIntColumn(unittest.TestCase):
         # case when more than 1 unique value, by virtue of a streaming update
         num_profiler.update(pd.Series(['2']))
         self.assertEqual(
-            100,
-            len(num_profiler.histogram_methods['custom']['histogram'][
-                    'bin_counts'])
-        )
+            100, len(num_profiler._stored_histogram['histogram']['bin_counts']))
+
+        histogram, _ = num_profiler._histogram_for_profile('custom')
+        self.assertEqual(100, len(histogram['bin_counts']))

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -230,8 +230,8 @@ class TestIntColumn(unittest.TestCase):
         # with equal bin size, each bin has the width of 1
         data3 = ["1", "1", "3", "4"]  # 3 bins, range of 3
         expected_histogram3 = {
-            'bin_counts': np.array([2, 0, 2]),
-            'bin_edges': np.array([1.0, 2.0, 3.0, 4.0]),
+            'bin_counts': np.array([1, 1, 0, 2]),
+            'bin_edges': np.array([1.0, 1.75, 2.5, 3.25, 4.0]),
         }
         list_data_test.append([data3, expected_histogram3])
 
@@ -277,9 +277,9 @@ class TestIntColumn(unittest.TestCase):
                 'bin_edges': np.array([2.0, 10.0/3.0, 14.0/3.0, 6.0])
             },
             quantiles={
-                0: 8 /  3,  # halfway between 2 and 3.333 (histogram based)
-                1: 4.0   ,  # median between 2 and 6
-                2: 16 / 3,  # halfway between between 14 / 3 and 6
+                0: 2.002,  # halfway between 2 and 3.333 (histogram based)
+                1: 4,  # median between 2 and 6
+                2: 5.998,  # halfway between between 14 / 3 and 6
             },
             times=defaultdict(
                 float, {'histogram_and_quantiles': 15.0, 'max': 1.0, 'min': 1.0,

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -279,7 +279,7 @@ class TestIntColumn(unittest.TestCase):
             quantiles={
                 0: 8 / 3,  # halfway between 2 and 3.333 (histogram based)
                 1: 10 / 3,  # 50% achieved at 10 / 3 (histogram based)
-                2: 14 / 3,  # halfway between between 10 / 3 and 6
+                2: 16 / 3,  # halfway between between 14 / 3 and 6
             },
             times=defaultdict(
                 float, {'histogram_and_quantiles': 15.0, 'max': 1.0, 'min': 1.0,

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -230,7 +230,7 @@ class TestIntColumn(unittest.TestCase):
         # with equal bin size, each bin has the width of 1
         data3 = ["1", "1", "3", "4"]  # 3 bins, range of 3
         expected_histogram3 = {
-            'bin_counts': np.array([1, 1, 0, 2]),
+            'bin_counts': np.array([2, 0, 1, 1]),
             'bin_edges': np.array([1.0, 1.75, 2.5, 3.25, 4.0]),
         }
         list_data_test.append([data3, expected_histogram3])
@@ -243,8 +243,8 @@ class TestIntColumn(unittest.TestCase):
             profile = profiler.profile
             histogram = profile['histogram']
 
-            self.assertCountEqual(expected_histogram['bin_counts'],
-                                  histogram['bin_counts'])
+            self.assertEqual(expected_histogram['bin_counts'].tolist(),
+                             histogram['bin_counts'].tolist())
             self.assertCountEqual(np.round(expected_histogram['bin_edges'], 12),
                                   np.round(histogram['bin_edges'], 12))
 

--- a/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
+++ b/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
@@ -200,8 +200,8 @@ class TestNumericStatsMixin(unittest.TestCase):
         other2.histogram_selection = "auto"
         other1.histogram_bin_method_names = ['auto']
         other2.histogram_bin_method_names = ['auto']
-        other1.histogram_methods['auto']['histogram'] = mock_histogram
-        other2.histogram_methods['auto']['histogram'] = mock_histogram
+        other1._stored_histogram['histogram'] = mock_histogram
+        other2._stored_histogram['histogram'] = mock_histogram
         other1.histogram_selection = 'auto'
 
         time_array = [float(i) for i in range(2, 0, -1)]
@@ -266,7 +266,7 @@ class TestNumericStatsMixin(unittest.TestCase):
             self.assertEqual(expected, num_profiler.times)
 
             # Validate _get_histogram_and_quantiles is timed.
-            expected['histogram_and_quantiles'] = 15.0
+            expected['histogram_and_quantiles'] = 1.0
             num_profiler._get_histogram_and_quantiles(
                 df_series, prev_dependent_properties, subset_properties)
             self.assertEqual(expected, num_profiler.times)

--- a/dataprofiler/tests/profilers/test_text_column_profile.py
+++ b/dataprofiler/tests/profilers/test_text_column_profile.py
@@ -332,8 +332,9 @@ class TestTextColumnProfiler(unittest.TestCase):
             profiler3 = profiler1 + profiler2
 
         # Assert that these features are still merged
+        profile = profiler3.profile
         self.assertEqual("doane", profiler3.histogram_selection)
-        self.assertAlmostEqual(6.20467836, profiler3.variance)
+        self.assertAlmostEqual(6.20467836, profile['variance'])
         self.assertEqual(62.0, profiler3.sum)
 
         # Assert that these features are not calculated
@@ -406,8 +407,8 @@ class TestTextColumnProfiler(unittest.TestCase):
         # case when more than 1 unique value, by virtue of a streaming update
         num_profiler.update(pd.Series(['22']))
         self.assertEqual(
-            100,
-            len(num_profiler.histogram_methods['custom']['histogram'][
-                    'bin_counts'])
-        )
+            100, len(num_profiler._stored_histogram['histogram']['bin_counts']))
+
+        histogram, _ = num_profiler._histogram_for_profile('custom')
+        self.assertEqual(100, len(histogram['bin_counts']))
 


### PR DESCRIPTION
Reduction in histogram time by refactoring get_percentiles:

TLDR;

--profile time--
Old method, optimized old method, new method
all bin methods: 8.37,7.80,6.78
auto only method: 7.18,6.81,6.66

--merge time--
Old method, optimized old method, new method
all bin methods: 6.61,5.17,0.46
auto only method: 1.56,0.84,0.39



===========================================================================

All tests are ran on a 23MB file with 1 col of each type plus a NAN col (index was accidentally included so extra int).
Old time, all binning:
```
profile time: 8.37269401550293
merge time: 6.606444835662842
Wrote profile results to profile.py.lprof
Timer unit: 1e-06 s

Total time: 6.46363 s
File: data-profiler/dataprofiler/profilers/numerical_column_stats.py
Function: _add_helper_merge_profile_histograms at line 100

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   100                                               @BaseColumnProfiler._timeit(name="histogram_and_quantiles")
   101                                               @profile
   102                                               def _add_helper_merge_profile_histograms(self, other1, other2):
   103                                                   """
   104                                                   Adds histogram of two profiles together
   105
   106                                                   :param other1: profile1 being added to self
   107                                                   :type other1: BaseColumnProfiler
   108                                                   :param other2: profile2 being added to self
   109                                                   :type other2: BaseColumnProfiler
   110                                                   :return: None
   111                                                   """
   112                                                   # get available bin methods and set to current
   113        28         90.0      3.2      0.0          bin_methods = list(set(other1.histogram_bin_method_names) &
   114        14         24.0      1.7      0.0                             set(other2.histogram_bin_method_names))
   115        14          8.0      0.6      0.0          if not bin_methods:
   116                                                       raise ValueError('Profiles have no overlapping bin methods and '
   117                                                                        'therefore cannot be added together.')
   118        14         16.0      1.1      0.0          elif other1.user_set_histogram_bin and other2.user_set_histogram_bin:
   119                                                       if other1.user_set_histogram_bin != other2.user_set_histogram_bin:
   120                                                           warnings.warn('User set histogram bin counts did not match. '
   121                                                                         'Choosing the larger bin count.')
   122                                                       self.user_set_histogram_bin = max(other1.user_set_histogram_bin,
   123                                                                                         other2.user_set_histogram_bin)
   124
   125                                                   # initial creation of the profiler creates all methods, but
   126                                                   # only the methods which intersect should exist.
   127        14         11.0      0.8      0.0          self.histogram_bin_method_names = bin_methods
   128        14         19.0      1.4      0.0          self.histogram_methods = dict()
   129       112         74.0      0.7      0.0          for method in self.histogram_bin_method_names:
   130        98        114.0      1.2      0.0              self.histogram_methods[method] = {
   131        98         43.0      0.4      0.0                  'total_loss': 0,
   132        98         42.0      0.4      0.0                  'current_loss': 0,
   133        98         55.0      0.6      0.0                  'histogram': {
   134        98         35.0      0.4      0.0                      'bin_counts': None,
   135        98         39.0      0.4      0.0                      'bin_edges': None
   136                                                           }
   137                                                       }
   138
   139       112        124.0      1.1      0.0          for i, method in enumerate(self.histogram_bin_method_names):
   140       294    1208478.0   4110.5     18.7              combined_values = other1._histogram_to_array(
   141       196    1128633.0   5758.3     17.5                  method) + other2._histogram_to_array(method)
   142       196    2023978.0  10326.4     31.3              bin_counts, bin_edges = self._get_histogram(
   143        98         52.0      0.5      0.0                  combined_values, method)
   144        98        353.0      3.6      0.0              self.histogram_methods[method]['histogram']['bin_counts'] = \
   145        98        112.0      1.1      0.0                  bin_counts
   146        98        130.0      1.3      0.0              self.histogram_methods[method]['histogram']['bin_edges'] = bin_edges
   147
   148                                                   # Select histogram: always choose first profile selected method
   149                                                   # Either both profiles have the same selection or you at least use one
   150                                                   # of the profiles selected method
   151        14         21.0      1.5      0.0          self.histogram_selection = other1.histogram_selection
   152        14    2101176.0 150084.0     32.5          self._get_quantiles()
```

Sped up old method using optimized old technique, all bins:
```
profile time: 7.8034539222717285
merge time: 5.167731046676636
Wrote profile results to profile.py.lprof
Timer unit: 1e-06 s

Total time: 5.02375 s
File: data-profiler/dataprofiler/profilers/numerical_column_stats.py
Function: _add_helper_merge_profile_histograms at line 100

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   100                                               @BaseColumnProfiler._timeit(name="histogram_and_quantiles")
   101                                               @profile
   102                                               def _add_helper_merge_profile_histograms(self, other1, other2):
   103                                                   """
   104                                                   Adds histogram of two profiles together
   105
   106                                                   :param other1: profile1 being added to self
   107                                                   :type other1: BaseColumnProfiler
   108                                                   :param other2: profile2 being added to self
   109                                                   :type other2: BaseColumnProfiler
   110                                                   :return: None
   111                                                   """
   112                                                   # get available bin methods and set to current
   113        28         92.0      3.3      0.0          bin_methods = list(set(other1.histogram_bin_method_names) &
   114        14         24.0      1.7      0.0                             set(other2.histogram_bin_method_names))
   115        14         12.0      0.9      0.0          if not bin_methods:
   116                                                       raise ValueError('Profiles have no overlapping bin methods and '
   117                                                                        'therefore cannot be added together.')
   118        14         19.0      1.4      0.0          elif other1.user_set_histogram_bin and other2.user_set_histogram_bin:
   119                                                       if other1.user_set_histogram_bin != other2.user_set_histogram_bin:
   120                                                           warnings.warn('User set histogram bin counts did not match. '
   121                                                                         'Choosing the larger bin count.')
   122                                                       self.user_set_histogram_bin = max(other1.user_set_histogram_bin,
   123                                                                                         other2.user_set_histogram_bin)
   124
   125                                                   # initial creation of the profiler creates all methods, but
   126                                                   # only the methods which intersect should exist.
   127        14         12.0      0.9      0.0          self.histogram_bin_method_names = bin_methods
   128        14         22.0      1.6      0.0          self.histogram_methods = dict()
   129       112         75.0      0.7      0.0          for method in self.histogram_bin_method_names:
   130        98        116.0      1.2      0.0              self.histogram_methods[method] = {
   131        98         46.0      0.5      0.0                  'total_loss': 0,
   132        98         35.0      0.4      0.0                  'current_loss': 0,
   133        98         56.0      0.6      0.0                  'histogram': {
   134        98         44.0      0.4      0.0                      'bin_counts': None,
   135        98         45.0      0.5      0.0                      'bin_edges': None
   136                                                           }
   137                                                       }
   138
   139       112        147.0      1.3      0.0          for i, method in enumerate(self.histogram_bin_method_names):
   140       294    1380331.0   4695.0     27.5              combined_values = other1._histogram_to_array(
   141       196    1266846.0   6463.5     25.2                  method) + other2._histogram_to_array(method)
   142       196    2322834.0  11851.2     46.2              bin_counts, bin_edges = self._get_histogram(
   143        98         63.0      0.6      0.0                  combined_values, method)
   144        98        530.0      5.4      0.0              self.histogram_methods[method]['histogram']['bin_counts'] = \
   145        98        157.0      1.6      0.0                  bin_counts
   146        98        142.0      1.4      0.0              self.histogram_methods[method]['histogram']['bin_edges'] = bin_edges
   147
   148                                                   # Select histogram: always choose first profile selected method
   149                                                   # Either both profiles have the same selection or you at least use one
   150                                                   # of the profiles selected method
   151        14         29.0      2.1      0.0          self.histogram_selection = other1.histogram_selection
   152        14      52076.0   3719.7      1.0          self._get_quantiles()
```

New method, all binning methods:
```
profile time: 6.7768378257751465
merge time: 0.4640200138092041
Wrote profile results to profile.py.lprof
Timer unit: 1e-06 s

Total time: 0.328324 s
File: data-profiler/dataprofiler/profilers/numerical_column_stats.py
Function: _add_helper_merge_profile_histograms at line 115

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   115                                               @BaseColumnProfiler._timeit(name="histogram_and_quantiles")
   116                                               @profile
   117                                               def _add_helper_merge_profile_histograms(self, other1, other2):
   118                                                   """
   119                                                   Adds histogram of two profiles together
   120
   121                                                   :param other1: profile1 being added to self
   122                                                   :type other1: BaseColumnProfiler
   123                                                   :param other2: profile2 being added to self
   124                                                   :type other2: BaseColumnProfiler
   125                                                   :return: None
   126                                                   """
   127                                                   # get available bin methods and set to current
   128        28         75.0      2.7      0.0          bin_methods = list(set(other1.histogram_bin_method_names) &
   129        14         26.0      1.9      0.0                             set(other2.histogram_bin_method_names))
   130        14          8.0      0.6      0.0          if not bin_methods:
   131                                                       raise ValueError('Profiles have no overlapping bin methods and '
   132                                                                        'therefore cannot be added together.')
   133        14         15.0      1.1      0.0          elif other1.user_set_histogram_bin and other2.user_set_histogram_bin:
   134                                                       if other1.user_set_histogram_bin != other2.user_set_histogram_bin:
   135                                                           warnings.warn('User set histogram bin counts did not match. '
   136                                                                         'Choosing the larger bin count.')
   137                                                       self.user_set_histogram_bin = max(other1.user_set_histogram_bin,
   138                                                                                         other2.user_set_histogram_bin)
   139
   140                                                   # initial creation of the profiler creates all methods, but
   141                                                   # only the methods which intersect should exist.
   142        14          9.0      0.6      0.0          self.histogram_bin_method_names = bin_methods
   143        14         20.0      1.4      0.0          self.histogram_methods = dict()
   144       112         61.0      0.5      0.0          for method in self.histogram_bin_method_names:
   145        98        116.0      1.2      0.0              self.histogram_methods[method] = {
   146        98         44.0      0.4      0.0                  'total_loss': 0,
   147        98         44.0      0.4      0.0                  'current_loss': 0,
   148        98         47.0      0.5      0.0                  'histogram': {
   149        98         34.0      0.3      0.0                      'bin_counts': None,
   150        98         41.0      0.4      0.0                      'bin_edges': None
   151                                                           }
   152                                                       }
   153
   154        28     101747.0   3633.8     31.0          combined_values = np.concatenate([other1._histogram_to_array(),
   155        14      77088.0   5506.3     23.5                                            other2._histogram_to_array()])
   156        14     145988.0  10427.7     44.5          bin_counts, bin_edges = self._get_histogram(combined_values)
   157        14         55.0      3.9      0.0          self._stored_histogram['histogram']['bin_counts'] = bin_counts
   158        14         21.0      1.5      0.0          self._stored_histogram['histogram']['bin_edges'] = bin_edges
   159
   160        14       2885.0    206.1      0.9          self._get_quantiles()
```

Old method, only `auto` binning:
```
profile time: 7.176765203475952
merge time: 1.5585100650787354
Wrote profile results to profile.py.lprof
Timer unit: 1e-06 s

Total time: 1.41826 s
File: data-profiler/dataprofiler/profilers/numerical_column_stats.py
Function: _add_helper_merge_profile_histograms at line 100

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   100                                               @BaseColumnProfiler._timeit(name="histogram_and_quantiles")
   101                                               @profile
   102                                               def _add_helper_merge_profile_histograms(self, other1, other2):
   103                                                   """
   104                                                   Adds histogram of two profiles together
   105
   106                                                   :param other1: profile1 being added to self
   107                                                   :type other1: BaseColumnProfiler
   108                                                   :param other2: profile2 being added to self
   109                                                   :type other2: BaseColumnProfiler
   110                                                   :return: None
   111                                                   """
   112                                                   # get available bin methods and set to current
   113        28         63.0      2.2      0.0          bin_methods = list(set(other1.histogram_bin_method_names) &
   114        14         21.0      1.5      0.0                             set(other2.histogram_bin_method_names))
   115        14          5.0      0.4      0.0          if not bin_methods:
   116                                                       raise ValueError('Profiles have no overlapping bin methods and '
   117                                                                        'therefore cannot be added together.')
   118        14         18.0      1.3      0.0          elif other1.user_set_histogram_bin and other2.user_set_histogram_bin:
   119                                                       if other1.user_set_histogram_bin != other2.user_set_histogram_bin:
   120                                                           warnings.warn('User set histogram bin counts did not match. '
   121                                                                         'Choosing the larger bin count.')
   122                                                       self.user_set_histogram_bin = max(other1.user_set_histogram_bin,
   123                                                                                         other2.user_set_histogram_bin)
   124
   125                                                   # initial creation of the profiler creates all methods, but
   126                                                   # only the methods which intersect should exist.
   127        14         11.0      0.8      0.0          self.histogram_bin_method_names = bin_methods
   128        14         21.0      1.5      0.0          self.histogram_methods = dict()
   129        28         22.0      0.8      0.0          for method in self.histogram_bin_method_names:
   130        14         19.0      1.4      0.0              self.histogram_methods[method] = {
   131        14          7.0      0.5      0.0                  'total_loss': 0,
   132        14          6.0      0.4      0.0                  'current_loss': 0,
   133        14          9.0      0.6      0.0                  'histogram': {
   134        14          5.0      0.4      0.0                      'bin_counts': None,
   135        14          7.0      0.5      0.0                      'bin_edges': None
   136                                                           }
   137                                                       }
   138
   139        28         34.0      1.2      0.0          for i, method in enumerate(self.histogram_bin_method_names):
   140        42     175435.0   4177.0     12.4              combined_values = other1._histogram_to_array(
   141        28     167254.0   5973.4     11.8                  method) + other2._histogram_to_array(method)
   142        28     300897.0  10746.3     21.2              bin_counts, bin_edges = self._get_histogram(
   143        14          7.0      0.5      0.0                  combined_values, method)
   144        14         50.0      3.6      0.0              self.histogram_methods[method]['histogram']['bin_counts'] = \
   145        14         16.0      1.1      0.0                  bin_counts
   146        14         19.0      1.4      0.0              self.histogram_methods[method]['histogram']['bin_edges'] = bin_edges
   147
   148                                                   # Select histogram: always choose first profile selected method
   149                                                   # Either both profiles have the same selection or you at least use one
   150                                                   # of the profiles selected method
   151        14         24.0      1.7      0.0          self.histogram_selection = other1.histogram_selection
   152        14     774312.0  55308.0     54.6          self._get_quantiles()
```

Optimized old method, `auto only method:
```
profile time: 6.806349992752075
merge time: 0.839846134185791
Wrote profile results to profile.py.lprof
Timer unit: 1e-06 s

Total time: 0.696243 s
File: data-profiler/dataprofiler/profilers/numerical_column_stats.py
Function: _add_helper_merge_profile_histograms at line 100

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   100                                               @BaseColumnProfiler._timeit(name="histogram_and_quantiles")
   101                                               @profile
   102                                               def _add_helper_merge_profile_histograms(self, other1, other2):
   103                                                   """
   104                                                   Adds histogram of two profiles together
   105
   106                                                   :param other1: profile1 being added to self
   107                                                   :type other1: BaseColumnProfiler
   108                                                   :param other2: profile2 being added to self
   109                                                   :type other2: BaseColumnProfiler
   110                                                   :return: None
   111                                                   """
   112                                                   # get available bin methods and set to current
   113        28         65.0      2.3      0.0          bin_methods = list(set(other1.histogram_bin_method_names) &
   114        14         22.0      1.6      0.0                             set(other2.histogram_bin_method_names))
   115        14          9.0      0.6      0.0          if not bin_methods:
   116                                                       raise ValueError('Profiles have no overlapping bin methods and '
   117                                                                        'therefore cannot be added together.')
   118        14         18.0      1.3      0.0          elif other1.user_set_histogram_bin and other2.user_set_histogram_bin:
   119                                                       if other1.user_set_histogram_bin != other2.user_set_histogram_bin:
   120                                                           warnings.warn('User set histogram bin counts did not match. '
   121                                                                         'Choosing the larger bin count.')
   122                                                       self.user_set_histogram_bin = max(other1.user_set_histogram_bin,
   123                                                                                         other2.user_set_histogram_bin)
   124
   125                                                   # initial creation of the profiler creates all methods, but
   126                                                   # only the methods which intersect should exist.
   127        14         10.0      0.7      0.0          self.histogram_bin_method_names = bin_methods
   128        14         19.0      1.4      0.0          self.histogram_methods = dict()
   129        28         22.0      0.8      0.0          for method in self.histogram_bin_method_names:
   130        14         20.0      1.4      0.0              self.histogram_methods[method] = {
   131        14          6.0      0.4      0.0                  'total_loss': 0,
   132        14          7.0      0.5      0.0                  'current_loss': 0,
   133        14         11.0      0.8      0.0                  'histogram': {
   134        14          8.0      0.6      0.0                      'bin_counts': None,
   135        14          7.0      0.5      0.0                      'bin_edges': None
   136                                                           }
   137                                                       }
   138
   139        28         44.0      1.6      0.0          for i, method in enumerate(self.histogram_bin_method_names):
   140        42     180334.0   4293.7     25.9              combined_values = other1._histogram_to_array(
   141        28     169105.0   6039.5     24.3                  method) + other2._histogram_to_array(method)
   142        28     304290.0  10867.5     43.7              bin_counts, bin_edges = self._get_histogram(
   143        14          7.0      0.5      0.0                  combined_values, method)
   144        14         48.0      3.4      0.0              self.histogram_methods[method]['histogram']['bin_counts'] = \
   145        14         18.0      1.3      0.0                  bin_counts
   146        14         18.0      1.3      0.0              self.histogram_methods[method]['histogram']['bin_edges'] = bin_edges
   147
   148                                                   # Select histogram: always choose first profile selected method
   149                                                   # Either both profiles have the same selection or you at least use one
   150                                                   # of the profiles selected method
   151        14         22.0      1.6      0.0          self.histogram_selection = other1.histogram_selection
   152        14      42133.0   3009.5      6.1          self._get_quantiles()
```

New method, only `auto` binning:
```
profile time: 6.662765741348267
merge time: 0.3878898620605469
Wrote profile results to profile.py.lprof
Timer unit: 1e-06 s

Total time: 0.250335 s
File: data-profiler/dataprofiler/profilers/numerical_column_stats.py
Function: _add_helper_merge_profile_histograms at line 115

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   115                                               @BaseColumnProfiler._timeit(name="histogram_and_quantiles")
   116                                               @profile
   117                                               def _add_helper_merge_profile_histograms(self, other1, other2):
   118                                                   """
   119                                                   Adds histogram of two profiles together
   120
   121                                                   :param other1: profile1 being added to self
   122                                                   :type other1: BaseColumnProfiler
   123                                                   :param other2: profile2 being added to self
   124                                                   :type other2: BaseColumnProfiler
   125                                                   :return: None
   126                                                   """
   127                                                   # get available bin methods and set to current
   128        28         63.0      2.2      0.0          bin_methods = list(set(other1.histogram_bin_method_names) &
   129        14         24.0      1.7      0.0                             set(other2.histogram_bin_method_names))
   130        14          5.0      0.4      0.0          if not bin_methods:
   131                                                       raise ValueError('Profiles have no overlapping bin methods and '
   132                                                                        'therefore cannot be added together.')
   133        14         16.0      1.1      0.0          elif other1.user_set_histogram_bin and other2.user_set_histogram_bin:
   134                                                       if other1.user_set_histogram_bin != other2.user_set_histogram_bin:
   135                                                           warnings.warn('User set histogram bin counts did not match. '
   136                                                                         'Choosing the larger bin count.')
   137                                                       self.user_set_histogram_bin = max(other1.user_set_histogram_bin,
   138                                                                                         other2.user_set_histogram_bin)
   139
   140                                                   # initial creation of the profiler creates all methods, but
   141                                                   # only the methods which intersect should exist.
   142        14          9.0      0.6      0.0          self.histogram_bin_method_names = bin_methods
   143        14         19.0      1.4      0.0          self.histogram_methods = dict()
   144        28         22.0      0.8      0.0          for method in self.histogram_bin_method_names:
   145        14         17.0      1.2      0.0              self.histogram_methods[method] = {
   146        14          4.0      0.3      0.0                  'total_loss': 0,
   147        14          5.0      0.4      0.0                  'current_loss': 0,
   148        14         10.0      0.7      0.0                  'histogram': {
   149        14          6.0      0.4      0.0                      'bin_counts': None,
   150        14          6.0      0.4      0.0                      'bin_edges': None
   151                                                           }
   152                                                       }
   153
   154        28      98122.0   3504.4     39.2          combined_values = np.concatenate([other1._histogram_to_array(),
   155        14      76511.0   5465.1     30.6                                            other2._histogram_to_array()])
   156        14      72508.0   5179.1     29.0          bin_counts, bin_edges = self._get_histogram(combined_values)
   157        14         52.0      3.7      0.0          self._stored_histogram['histogram']['bin_counts'] = bin_counts
   158        14         19.0      1.4      0.0          self._stored_histogram['histogram']['bin_edges'] = bin_edges
   159
   160        14       2917.0    208.4      1.2          self._get_quantiles()
```