### PR TITLE
Fix multiprocessing for osx and slight speed improvements

### DIFF
--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -126,7 +126,6 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         max_precision = float(len_per_float.max())
 
         return min_precision
-    
 
     @classmethod
     def _is_each_row_float(cls, df_series):
@@ -143,7 +142,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         :rtype: list
         """
         if len(df_series) == 0: return list()
-        return [NumericStatsMixin.is_float(x) for x in df_series]
+        return df_series.map(NumericStatsMixin.is_float)
 
     @BaseColumnProfiler._timeit(name='precision')
     def _update_precision(self, df_series, prev_dependent_properties,

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -112,20 +112,8 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         # Scientific Notation: (?<=[e])(.*) Any non-digits: \D
         r = re.compile(r'^[+-.0\s]+|\.?0+(\s|$)|(?<=[e])(.*)|\D')
 
-        # Take a sampling of the dataset. If small use full dataset,
-        # OR 20k samples or 5% of the dataset which ever is larger.
-        sample_size = min(len(df_series_clean),
-                          max(20000, int(len(df_series_clean)/20)))
-
-        # length of sampled cells after all punctuation removed
-        len_per_float = df_series_clean.sample(sample_size).replace(
-            to_replace=r, value='').map(len)
-
-        # Determine the max and min precision
-        min_precision = float(len_per_float.min())
-        max_precision = float(len_per_float.max())
-
-        return min_precision
+        return float(df_series_clean.replace(
+            to_replace=r, value='').map(len).min())
 
     @classmethod
     def _is_each_row_float(cls, df_series):

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -143,8 +143,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         :rtype: list
         """
         if len(df_series) == 0: return list()
-        query = r'^[\s]*[+-]?[\d]+[\.]*[\d]*[ ]?[*eE]*[ ]?[+-]?[\d]*[\s]*$'
-        return df_series.str.count(query).astype(bool)
+        return [NumericStatsMixin.is_float(x) for x in df_series]
 
     @BaseColumnProfiler._timeit(name='precision')
     def _update_precision(self, df_series, prev_dependent_properties,

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -209,7 +209,6 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         if len(df_series) == 0:
             return self
         
-        df_series = df_series.reset_index(drop=True) # TODO
         is_each_row_float = self._is_each_row_float(df_series)
         sample_size = len(is_each_row_float)
         float_count = np.sum(is_each_row_float)

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -30,7 +30,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         BaseColumnPrimitiveTypeProfiler.__init__(self, name)
         self.precision = 0
         self.__calculations = {
-            "precision": FloatColumn._update_precision
+            "precision": FloatColumn._update_precision,
         }
         self._filter_properties_w_options(self.__calculations, options)
 
@@ -108,7 +108,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         """
         if not len(df_series_clean): return 0
 
-        # Lead zeros: ^[+-.0\s]+ End zeros: \.?0+(\s|$) 
+        # Lead zeros: ^[+-.0\s]+ End zeros: \.?0+(\s|$)
         # Scientific Notation: (?<=[e])(.*) Any non-digits: \D
         r = re.compile(r'^[+-.0\s]+|\.?0+(\s|$)|(?<=[e])(.*)|\D')
 

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -631,17 +631,18 @@ class Profiler(object):
         sample_ids = [*utils.shuffle_in_chunks(len(df), len(df))]
 
         pool = None
-        if options.structured_options.multiprocess.is_enabled:
+        if options.structured_options.multiprocess.is_enabled:            
             cpu_count = 1
             try:
+                mp.set_start_method('fork')
                 cpu_count = mp.cpu_count()
             except NotImplementedError as e:
                 cpu_count = 1
 
-            # No additional advantage beyond 8 processes
+            # No additional advantage beyond 5 processes
             # Always leave 1 cores free
             if cpu_count > 2:
-                cpu_count = min(cpu_count-1, 8)
+                cpu_count = min(cpu_count-1, 5)
                 pool = mp.Pool(cpu_count)
                 print("Utilizing",cpu_count, "processes for profiling")
         

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -631,7 +631,7 @@ class Profiler(object):
         sample_ids = [*utils.shuffle_in_chunks(len(df), len(df))]
 
         pool = None
-        if options.structured_options.multiprocess.is_enabled:            
+        if options.structured_options.multiprocess.is_enabled:
             cpu_count = 1
             try:
                 mp.set_start_method('fork')

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -634,17 +634,25 @@ class Profiler(object):
         if options.structured_options.multiprocess.is_enabled:
             cpu_count = 1
             try:
-                mp.set_start_method('fork')
                 cpu_count = mp.cpu_count()
             except NotImplementedError as e:
                 cpu_count = 1
 
             # No additional advantage beyond 5 processes
             # Always leave 1 cores free
+            # https://docs.python.org/3/library/multiprocessing.html#multiprocessing.set_start_method            
             if cpu_count > 2:
                 cpu_count = min(cpu_count-1, 5)
-                pool = mp.Pool(cpu_count)
-                print("Utilizing",cpu_count, "processes for profiling")
+                try: 
+                    pool = mp.Pool(cpu_count)
+                    print("Utilizing",cpu_count, "processes for profiling")
+                except Exception as e:
+                    pool = None
+                    warnings.warn(
+                        'Multiprocessing disabled, please change the multiprocessing'+
+                        ' start method, via: multiprocessing.set_start_method(<method>)'+
+                        ' Possible methods include: fork, spawn, forkserver, None'
+                    )
         
         for col in tqdm(df.columns):
             if col in profile:

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -638,11 +638,11 @@ class Profiler(object):
             except NotImplementedError as e:
                 cpu_count = 1
 
-            # No additional advantage beyond 5 processes
+            # No additional advantage beyond 4 processes
             # Always leave 1 cores free
             # https://docs.python.org/3/library/multiprocessing.html#multiprocessing.set_start_method            
             if cpu_count > 2:
-                cpu_count = min(cpu_count-1, 5)
+                cpu_count = min(cpu_count-1, 4)
                 try: 
                     pool = mp.Pool(cpu_count)
                     print("Utilizing",cpu_count, "processes for profiling")

--- a/dataprofiler/version.py
+++ b/dataprofiler/version.py
@@ -4,7 +4,7 @@ File containers the version number for the package
 
 MAJOR               = 0
 MINOR               = 4
-MICRO               = 2
+MICRO               = 3
 
 VERSION             = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Dataset: `United_States_Drought_Monitor__2000-2016.csv`

Below times only account for the sampling change(s) for the precision detection.

Added a follow up issue #150 related to tracking min/max precision per column and providing them to the integer column.

**New Method, all profilers, multi-process**:
```
         39713706 function calls (39574075 primitive calls) in 59.896 seconds

   Ordered by: internal time
   List reduced from 9661 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1328   20.783    0.016   20.783    0.016 {method 'acquire' of '_thread.lock' objects}
  496/478    9.925    0.020    9.925    0.021 {built-in method numpy.array}
     8375    3.974    0.000    3.975    0.000 {built-in method builtins.sorted}
 16716568    3.969    0.000    3.969    0.000 {method 'search' of 're.Pattern' objects}
        6    3.216    0.536   29.766    4.961 profile_builder.py:256(get_base_props_and_clean_null_params)
        2    3.151    1.576    3.600    1.800 utils.py:73(shuffle_in_chunks)
        6    2.483    0.414    8.394    1.399 {pandas._libs.lib.map_infer_mask}
 16716402    1.942    0.000    5.910    0.000 object_array.py:120(<lambda>)
        6    1.251    0.208    1.252    0.209 {pandas._libs.lib.map_infer}
       30    1.219    0.041    1.219    0.041 {method 'take' of 'numpy.ndarray' objects}
       34    1.082    0.032    1.083    0.032 {pandas._libs.lib.infer_dtype}
      500    0.610    0.001    0.610    0.001 {built-in method fromkeys}
        1    0.475    0.475    0.540    0.540 {method 'read' of 'pandas._libs.parsers.TextReader' objects}
```

**Old Method, all profilers, multi-process (currently in master)**:
```
         39713698 function calls (39574067 primitive calls) in 98.034 seconds

   Ordered by: internal time
   List reduced from 9661 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1328   58.938    0.044   58.938    0.044 {method 'acquire' of '_thread.lock' objects}
  496/478   10.023    0.020   10.023    0.021 {built-in method numpy.array}
     8375    3.995    0.000    3.996    0.000 {built-in method builtins.sorted}
 16716568    3.938    0.000    3.938    0.000 {method 'search' of 're.Pattern' objects}
        6    3.195    0.533   29.728    4.955 profile_builder.py:256(get_base_props_and_clean_null_params)
        2    3.151    1.576    3.597    1.798 utils.py:73(shuffle_in_chunks)
        6    2.484    0.414    8.372    1.395 {pandas._libs.lib.map_infer_mask}
 16716402    1.949    0.000    5.887    0.000 object_array.py:120(<lambda>)
        6    1.203    0.201    1.205    0.201 {pandas._libs.lib.map_infer}
       30    1.175    0.039    1.175    0.039 {method 'take' of 'numpy.ndarray' objects}
       34    1.069    0.031    1.069    0.031 {pandas._libs.lib.infer_dtype}
      500    0.608    0.001    0.608    0.001 {built-in method fromkeys}
        1    0.497    0.497    0.564    0.564 {method 'read' of 'pandas._libs.parsers.TextReader' objects}
```

---------------------------------------------

**New Method, only float profiler, single process:**
```
        60744939 function calls (59890971 primitive calls) in 49.790 seconds

   Ordered by: internal time
   List reduced from 1204 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  918/864   11.172    0.012   11.172    0.013 {built-in method numpy.array}
 16716443    4.042    0.000    4.042    0.000 {method 'search' of 're.Pattern' objects}
       44    3.902    0.089    3.902    0.089 {built-in method builtins.sorted}
        6    3.596    0.599    6.433    1.072 float_column_profile.py:146(<listcomp>)
        6    3.180    0.530   29.379    4.896 profile_builder.py:256(get_base_props_and_clean_null_params)
        2    3.114    1.557    3.556    1.778 utils.py:73(shuffle_in_chunks)
 16716402    2.838    0.000    2.838    0.000 numerical_column_stats.py:530(is_float)
        6    2.447    0.408    8.448    1.408 {pandas._libs.lib.map_infer_mask}
 16716402    1.958    0.000    5.999    0.000 object_array.py:120(<lambda>)
       12    1.382    0.115    1.386    0.115 {pandas._libs.lib.map_infer}
       42    1.207    0.029    1.207    0.029 {method 'take' of 'numpy.ndarray' objects}
        6    1.173    0.195    1.331    0.222 numerical_column_stats.py:243(_total_histogram_bin_variance)
```


**Old Method, only float profiler, single process (currently in master)**:
```
         203668310 function calls (186933878 primitive calls) in 87.762 seconds

   Ordered by: internal time
   List reduced from 1200 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  912/858   11.158    0.012   11.159    0.013 {built-in method numpy.array}
 16716426    8.448    0.000    8.448    0.000 {method 'sub' of 're.Pattern' objects}
 16716402    6.824    0.000   34.672    0.000 replace.py:122(re_replacer)
50170088/33453679    6.200    0.000   17.103    0.000 {built-in method builtins.isinstance}
 16716409    5.395    0.000    7.831    0.000 typing.py:713(__subclasscheck__)
 16716409    4.521    0.000   12.351    0.000 typing.py:710(__instancecheck__)
       12    4.093    0.341    4.098    0.341 {pandas._libs.lib.map_infer}
 16716443    3.978    0.000    3.978    0.000 {method 'search' of 're.Pattern' objects}
       44    3.921    0.089    3.921    0.089 {built-in method builtins.sorted}
        6    3.528    0.588    6.278    1.046 float_column_profile.py:149(<listcomp>)
        6    3.190    0.532   29.220    4.870 profile_builder.py:256(get_base_props_and_clean_null_params)
```