### PR TITLE
Mitigated type bug in json output & runtime improvements 

### DIFF
--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -123,27 +123,35 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         histogram_method = self.histogram_bin_method_names[0]
         if self.histogram_selection is not None:
             histogram_method = self.histogram_selection
-            
+
+        def np_type_to_type(val):
+            if isinstance(val, np.integer):
+                return int(val)
+            if isinstance(val, np.float):
+                return float(val)
+            return val
+        
         profile = dict(
-            min=self.min,
-            max=self.max,
-            mean=self.mean,
-            variance=self.variance,
-            stddev=self.stddev,
+            min=np_type_to_type(self.min),
+            max=np_type_to_type(self.max),
+            mean=np_type_to_type(self.mean),
+            variance=np_type_to_type(self.variance),
+            stddev=np_type_to_type(self.stddev),
             histogram=self.histogram_methods[histogram_method]['histogram'],
             quantiles=self.quantiles,
             times=self.times,
             precision=dict(
-                min=self.precision['min'],
-                max=self.precision['max'],
-                mean=self.precision['mean'],
-                var=self.precision['var'],
-                std=self.precision['std'],
-                sample_size=self.precision['sample_size'],
-                margin_of_error=self.precision['margin_of_error'],
-                confidence_level=self.precision['confidence_level']
+                min=np_type_to_type(self.precision['min']),
+                max=np_type_to_type(self.precision['max']),
+                mean=np_type_to_type(self.precision['mean']),
+                var=np_type_to_type(self.precision['var']),
+                std=np_type_to_type(self.precision['std']),
+                sample_size=np_type_to_type(self.precision['sample_size']),
+                margin_of_error=np_type_to_type(self.precision['margin_of_error']),
+                confidence_level=np_type_to_type(self.precision['confidence_level'])
             )
         )
+        
         return profile
 
     @property

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -124,31 +124,24 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         if self.histogram_selection is not None:
             histogram_method = self.histogram_selection
 
-        def np_type_to_type(val):
-            if isinstance(val, np.integer):
-                return int(val)
-            if isinstance(val, np.float):
-                return float(val)
-            return val
-        
         profile = dict(
-            min=np_type_to_type(self.min),
-            max=np_type_to_type(self.max),
-            mean=np_type_to_type(self.mean),
-            variance=np_type_to_type(self.variance),
-            stddev=np_type_to_type(self.stddev),
+            min=self.np_type_to_type(self.min),
+            max=self.np_type_to_type(self.max),
+            mean=self.np_type_to_type(self.mean),
+            variance=self.np_type_to_type(self.variance),
+            stddev=self.np_type_to_type(self.stddev),
             histogram=self.histogram_methods[histogram_method]['histogram'],
             quantiles=self.quantiles,
             times=self.times,
             precision=dict(
-                min=np_type_to_type(self.precision['min']),
-                max=np_type_to_type(self.precision['max']),
-                mean=np_type_to_type(self.precision['mean']),
-                var=np_type_to_type(self.precision['var']),
-                std=np_type_to_type(self.precision['std']),
-                sample_size=np_type_to_type(self.precision['sample_size']),
-                margin_of_error=np_type_to_type(self.precision['margin_of_error']),
-                confidence_level=np_type_to_type(self.precision['confidence_level'])
+                min=self.np_type_to_type(self.precision['min']),
+                max=self.np_type_to_type(self.precision['max']),
+                mean=self.np_type_to_type(self.precision['mean']),
+                var=self.np_type_to_type(self.precision['var']),
+                std=self.np_type_to_type(self.precision['std']),
+                sample_size=self.np_type_to_type(self.precision['sample_size']),
+                margin_of_error=self.np_type_to_type(self.precision['margin_of_error']),
+                confidence_level=self.np_type_to_type(self.precision['confidence_level'])
             )
         )
         

--- a/dataprofiler/profilers/int_column_profile.py
+++ b/dataprofiler/profilers/int_column_profile.py
@@ -64,19 +64,12 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         if self.histogram_selection is not None:
             histogram_method = self.histogram_selection
 
-        def np_type_to_type(val):
-            if isinstance(val, np.integer):
-                return int(val)
-            if isinstance(val, np.float):
-                return float(val)
-            return val
-            
         profile = dict(
-            min=np_type_to_type(self.min),
-            max=np_type_to_type(self.max),
-            mean=np_type_to_type(self.mean),
-            variance=np_type_to_type(self.variance),
-            stddev=np_type_to_type(self.stddev),
+            min=self.np_type_to_type(self.min),
+            max=self.np_type_to_type(self.max),
+            mean=self.np_type_to_type(self.mean),
+            variance=self.np_type_to_type(self.variance),
+            stddev=self.np_type_to_type(self.stddev),
             histogram=self.histogram_methods[histogram_method]['histogram'],
             quantiles=self.quantiles,
             times=self.times

--- a/dataprofiler/profilers/int_column_profile.py
+++ b/dataprofiler/profilers/int_column_profile.py
@@ -63,13 +63,20 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         histogram_method = self.histogram_bin_method_names[0]
         if self.histogram_selection is not None:
             histogram_method = self.histogram_selection
+
+        def np_type_to_type(val):
+            if isinstance(val, np.integer):
+                return int(val)
+            if isinstance(val, np.float):
+                return float(val)
+            return val
             
         profile = dict(
-            min=self.min,
-            max=self.max,
-            mean=self.mean,
-            variance=self.variance,
-            stddev=self.stddev,
+            min=np_type_to_type(self.min),
+            max=np_type_to_type(self.max),
+            mean=np_type_to_type(self.mean),
+            variance=np_type_to_type(self.variance),
+            stddev=np_type_to_type(self.stddev),
             histogram=self.histogram_methods[histogram_method]['histogram'],
             quantiles=self.quantiles,
             times=self.times

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -592,3 +592,19 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
             return False
         else:
             return a == b
+
+    @staticmethod
+    def np_type_to_type(val):
+        """
+        Converts numpy variables to base python type variables
+        
+        :param val: value to check & change
+        :type val: numpy type or base type
+        :return val: base python type
+        :rtype val: int or float
+        """
+        if isinstance(val, np.integer):
+            return int(val)
+        if isinstance(val, np.float):
+            return float(val)
+        return val

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -332,9 +332,10 @@ class StructuredDataProfile(object):
         if sample_ids is None:
             sample_ind_generator.close()
 
-        if min_true_samples is None:
+        # If min_true_samples exists, sort
+        if min_true_samples is not None and min_true_samples > 0:
             true_sample_list = sorted(true_sample_list)
-            
+        
         # iloc should work here, there appears to be a bug
         df_series = df_series.loc[true_sample_list]
         non_na = len(df_series)
@@ -631,13 +632,14 @@ class Profiler(object):
         sample_ids = [*utils.shuffle_in_chunks(len(df), len(df))]
 
         # If there are no minimum true samples, you can sort to save time
-        if min_true_samples is None and len(sample_ids) > 0:
+        if (min_true_samples is None or min_true_samples == 0) \
+           and len(sample_ids) > 0:
             # If there's a sample size, truncate
             if sample_size is not None:
                 sample_ids[0] = sample_ids[0][:sample_size]
             # Sort the sample_ids anre replace prior
             sample_ids[0] = sorted(sample_ids[0])
-
+        
         pool = None
         if options.structured_options.multiprocess.is_enabled:
             cpu_count = 1

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -332,8 +332,11 @@ class StructuredDataProfile(object):
         if sample_ids is None:
             sample_ind_generator.close()
 
+        if min_true_samples is None:
+            true_sample_list = sorted(true_sample_list)
+            
         # iloc should work here, there appears to be a bug
-        df_series = df_series.loc[sorted(true_sample_list)]
+        df_series = df_series.loc[true_sample_list]
         non_na = len(df_series)
         total_na = total_sample_size - non_na
 
@@ -626,6 +629,14 @@ class Profiler(object):
 
         # Shuffle indices ones and share with columns
         sample_ids = [*utils.shuffle_in_chunks(len(df), len(df))]
+
+        # If there are no minimum true samples, you can sort to save time
+        if min_true_samples is None and len(sample_ids) > 0:
+            # If there's a sample size, truncate
+            if sample_size is not None:
+                sample_ids[0] = sample_ids[0][:sample_size]
+            # Sort the sample_ids anre replace prior
+            sample_ids[0] = sorted(sample_ids[0])
 
         pool = None
         if options.structured_options.multiprocess.is_enabled:

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -632,8 +632,8 @@ class TestFloatColumn(unittest.TestCase):
                                       'precision': 1.0, 'max': 1.0, 'min': 1.0,\
                                       'sum': 1.0, 'variance': 1.0}),
             precision={
-                'min': 1.0,
-                'max': 3.0,
+                'min': 1,
+                'max': 3,
                 'mean': 2.0,
                 'var': 1.0,
                 'std': 1.0,
@@ -648,7 +648,6 @@ class TestFloatColumn(unittest.TestCase):
             # Validate that the times dictionary is empty
             self.assertEqual(defaultdict(float), profiler.profile['times'])
             profiler.update(df)
-
             profile = profiler.profile
             # pop out the histogram to test separately from the rest of the dict
             # as we need comparison with some precision

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -471,7 +471,7 @@ class TestStructuredDataProfileClass(unittest.TestCase):
         self.assertEqual(10, profile.null_count)
 
 
-    def test_generating_report_for_floats(self):
+    def test_generating_report_ensure_no_error(self):
         file_path = os.path.join(test_root_path, 'data', 'csv/diamonds.csv')
         data = pd.read_csv(file_path)
         profile = dp.Profiler(data[:1000])

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -471,6 +471,12 @@ class TestStructuredDataProfileClass(unittest.TestCase):
         self.assertEqual(10, profile.null_count)
 
 
+    def test_generating_report_for_floats(self):
+        file_path = os.path.join(test_root_path, 'data', 'csv/diamonds.csv')
+        data = pd.read_csv(file_path)
+        profile = dp.Profiler(data[:1000])
+        readable_report = profile.report(report_options={"output_format":"compact"})
+
 class TestProfilerNullValues(unittest.TestCase):
 
     def setUp(self):
@@ -537,7 +543,7 @@ class TestProfilerNullValues(unittest.TestCase):
             report['data_stats'][' NUMBERS']['statistics']['null_types_index'],
             {'': '[5, 6, 8]', ' ': '[2, 4]'}
         )
-
+       
     def test_correct_total_sample_size_and_counts_and_mutability(self):
         file_path = os.path.join(test_root_path, 'data', 'csv/empty_rows.txt')
         data = pd.read_csv(file_path)


### PR DESCRIPTION
File tested: `United_States_Drought_Monitor__2000-2016.csv` (6 int columns)

Should be directly related to how many columns there are in the dataset, so the more columns there are the more this improvement will be apparent

**Master** (current):
```
         56426689 function calls (56287010 primitive calls) in 58.344 seconds

   Ordered by: internal time
   List reduced from 9647 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1304   19.401    0.015   19.401    0.015 {method 'acquire' of '_thread.lock' objects}
  466/460    9.783    0.021    9.783    0.021 {built-in method numpy.array}
        6    4.674    0.779   29.565    4.928 profile_builder.py:254(get_base_props_and_clean_null_params)
```

**This PR**:
```
         73147049 function calls (73007354 primitive calls) in 53.684 seconds

   Ordered by: internal time
   List reduced from 9655 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1304   19.312    0.015   19.312    0.015 {method 'acquire' of '_thread.lock' objects}
        6    6.153    1.026   22.929    3.822 profile_builder.py:254(get_base_props_and_clean_null_params)
```