### PR TITLE
Ensure sample size limited for large data

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -126,7 +126,6 @@ class StructuredDataProfile(object):
             for profile in self.profiles.values():
                 profile.update_profile(clean_sampled_df, pool)
 
-
     def __add__(self, other):
         """
         Merges two Structured profiles together overriding the `+` operator.
@@ -441,7 +440,8 @@ class Profiler(object):
                 utils.warn_on_profile('data_labeler', e)
                 self.options.set({'data_labeler.is_enabled': False})
 
-        self.update_profile(data)
+        if len(data):
+            self.update_profile(data)
 
     def __add__(self, other):
         """

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -426,6 +426,24 @@ class Profiler(object):
         if isinstance(data, data_readers.text_data.TextData):
             raise TypeError("Cannot provide TextData object to Profiler")
 
+        # assign data labeler
+        data_labeler_options = self.options.structured_options.data_labeler
+        if data_labeler_options.is_enabled \
+                and data_labeler_options.data_labeler_object is None:
+
+            try:
+
+                data_labeler = DataLabeler(
+                    labeler_type='structured',
+                    dirpath=data_labeler_options.data_labeler_dirpath,
+                    load_options=None)
+                self.options.set(
+                    {'data_labeler.data_labeler_object': data_labeler})
+
+            except Exception as e:
+                utils.warn_on_profile('data_labeler', e)
+                self.options.set({'data_labeler.is_enabled': False})
+
         if len(data):
             self.update_profile(data)
 
@@ -646,24 +664,6 @@ class Profiler(object):
         if len(df.columns) != len(df.columns.unique()):
             raise ValueError('`Profiler` does not currently support data which '
                              'contains columns with duplicate names.')
-
-        # assign data labeler
-        data_labeler_options = self.options.structured_options.data_labeler
-        if data_labeler_options.is_enabled \
-                and data_labeler_options.data_labeler_object is None:
-
-            try:
-
-                data_labeler = DataLabeler(
-                    labeler_type='structured',
-                    dirpath=data_labeler_options.data_labeler_dirpath,
-                    load_options=None)
-                self.options.set(
-                    {'data_labeler.data_labeler_object': data_labeler})
-
-            except Exception as e:
-                utils.warn_on_profile('data_labeler', e)
-                self.options.set({'data_labeler.is_enabled': False})
 
         try:
             from tqdm import tqdm

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -74,7 +74,7 @@ class StructuredDataProfile(object):
                               "All statistics will be based on this subsample and "
                               "not the whole dataset.".format(sample_size))
                 
-            clean_sampled_df, base_stats  = \
+            clean_sampled_df, base_stats = \
                 self.clean_data_and_get_base_stats(
                     df_series=df_series, sample_size=sample_size,
                     min_true_samples=self._min_true_samples, sample_ids=sample_ids)
@@ -420,25 +420,13 @@ class Profiler(object):
         self._min_true_samples = min_true_samples
         self._profile = dict()
 
+        # matches structured data profile
+        # TODO: allow set via options
+        self._sampling_ratio = 0.2
+        self._min_sample_size = 5000
+
         if isinstance(data, data_readers.text_data.TextData):
             raise TypeError("Cannot provide TextData object to Profiler")
-
-        # assign data labeler
-        data_labeler_options = self.options.structured_options.data_labeler
-        if data_labeler_options.is_enabled \
-                and data_labeler_options.data_labeler_object is None:
-            
-            try:
-                
-                data_labeler = DataLabeler(
-                    labeler_type='structured',
-                    dirpath=data_labeler_options.data_labeler_dirpath,
-                    load_options=None)
-                self.options.set({'data_labeler.data_labeler_object': data_labeler})
-                
-            except Exception as e:
-                utils.warn_on_profile('data_labeler', e)
-                self.options.set({'data_labeler.is_enabled': False})
 
         if len(data):
             self.update_profile(data)
@@ -488,6 +476,22 @@ class Profiler(object):
     @property
     def profile(self):
         return self._profile
+
+    def _get_sample_size(self, data):
+        """
+        Determines the minimum sampling size for detecting column type.
+
+        :param data: data to be profiled
+        :type data: Union[data_readers.base_data.BaseData, pandas.DataFrame]
+        :return: integer sampling size
+        :rtype: int
+        """
+        len_data = len(data)
+        if self._samples_per_update:
+            return self._samples_per_update
+        if len_data <= self._min_sample_size:
+            return int(len_data)
+        return max(int(self._sampling_ratio * len_data), self._min_sample_size)
 
     @property
     def _max_col_samples_used(self):
@@ -587,7 +591,7 @@ class Profiler(object):
 
         self.row_has_null_count += len(null_in_row_count)
         self.row_is_null_count += len(null_rows)
-        
+
     def update_profile(self, data, sample_size=None, min_true_samples=None):
         """
         Update the profile for data provided. User can specify the sample
@@ -602,18 +606,16 @@ class Profiler(object):
         :type min_true_samples
         :return: None
         """
-        if not sample_size:
-            sample_size = self._samples_per_update
         if not min_true_samples:
             min_true_samples = self._min_true_samples
         if isinstance(data, data_readers.base_data.BaseData):
-            self._profile = self._update_profile_from_chunk(
+            self._update_profile_from_chunk(
                 data.data, self._profile, sample_size, min_true_samples, self.options)
             self._update_row_statistics(data.data)
             self.encoding = data.file_encoding
             self.file_type = data.data_type
         elif isinstance(data, pd.DataFrame):
-            self._profile = self._update_profile_from_chunk(
+            self._update_profile_from_chunk(
                 data, self._profile, sample_size, min_true_samples, self.options)
             self._update_row_statistics(data)
             self.file_type = str(data.__class__)
@@ -622,9 +624,8 @@ class Profiler(object):
                 "Data must either be imported using the data_readers or "
                 "pd.DataFrame."
             )
-   
-    @staticmethod
-    def _update_profile_from_chunk(df, profile=None, sample_size=None,
+
+    def _update_profile_from_chunk(self, df, sample_size=None,
                                    min_true_samples=None, options=None):
         """
         Iterate over the columns of a dataset and identify its parameters.
@@ -642,9 +643,6 @@ class Profiler(object):
         :return: list of column profile base subclasses
         :rtype: list(BaseColumnProfiler)
         """
-        
-        if not profile:
-            profile = OrderedDict()
 
         if len(df.columns) != len(df.columns.unique()):
             raise ValueError('`Profiler` does not currently support data which '
@@ -657,6 +655,9 @@ class Profiler(object):
                 for i, e in enumerate(l):
                     print("Processing Column {}/{}".format(i+1, len(l)))
                     yield e
+
+        if not sample_size:
+            self._get_sample_size(df)
 
         # Shuffle indices ones and share with columns
         sample_ids = [*utils.shuffle_in_chunks(len(df), len(df))]
@@ -678,11 +679,11 @@ class Profiler(object):
         # Create structured profile objects
         new_cols = set()
         for col in df.columns:
-            if col not in profile:
+            if col not in self._profile:
                 structured_options = None
                 if options and options.structured_options:
                     structured_options = options.structured_options
-                profile[col] = StructuredDataProfile(
+                self._profile[col] = StructuredDataProfile(
                     sample_size=sample_size,
                     min_true_samples=min_true_samples,
                     sample_ids=sample_ids,
@@ -711,10 +712,10 @@ class Profiler(object):
             # Create a bunch of simultaneous column conversions
             for col in df.columns:
                 if min_true_samples is None:
-                    min_true_samples = profile[col]._min_true_samples
+                    min_true_samples = self._profile[col]._min_true_samples
                 try:
                     multi_process_dict[col] = pool.apply_async(
-                        profile[col].clean_data_and_get_base_stats,
+                        self._profile[col].clean_data_and_get_base_stats,
                         (df[col], sample_size, min_true_samples, sample_ids))
                 except Exception as e:
                     print(e)
@@ -726,7 +727,7 @@ class Profiler(object):
                 try:
                     clean_sampled_dict[col], base_stats = \
                         multi_process_dict[col].get()
-                    profile[col]._update_base_stats(base_stats)
+                    self._profile[col]._update_base_stats(base_stats)
                 except Exception as e:
                     print(e)
                     single_process_list.add(col)
@@ -737,11 +738,11 @@ class Profiler(object):
                       len(single_process_list), "errors, reprocessing...")
                 for col in tqdm(single_process_list):
                     if min_true_samples is None:
-                        min_true_samples = profile[col]._min_true_samples
+                        min_true_samples = self._profile[col]._min_true_samples
                     clean_sampled_dict[col], base_stats = \
-                        profile[col].clean_data_and_get_base_stats(
+                        self._profile[col].clean_data_and_get_base_stats(
                             df[col], sample_size, min_true_samples, sample_ids)
-                    profile[col]._update_base_stats(base_stats)
+                    self._profile[col]._update_base_stats(base_stats)
             
             pool.close() # Close pool for new tasks
             pool.join() # Wait for all workers to complete
@@ -751,12 +752,13 @@ class Profiler(object):
             print(notification_str)
             for col in tqdm(df.columns):
                 if min_true_samples is None:
-                    min_true_samples = profile[col]._min_true_samples
+                    min_true_samples = self._profile[col]._min_true_samples
                 clean_sampled_dict[col], base_stats = \
-                    profile[col].clean_data_and_get_base_stats(
+                    self._profile[col].clean_data_and_get_base_stats(
                         df_series=df[col], sample_size=sample_size,
-                        min_true_samples=min_true_samples, sample_ids=sample_ids)
-                profile[col]._update_base_stats(base_stats)
+                        min_true_samples=min_true_samples, sample_ids=sample_ids
+                    )
+                self._profile[col]._update_base_stats(base_stats)
             
         # Process and label the data
         notification_str = "Calculating the statistics... "
@@ -768,9 +770,8 @@ class Profiler(object):
         print(notification_str)
         
         for col in tqdm(df.columns):
-            profile[col].update_column_profilers(clean_sampled_dict[col], pool)
+            self._profile[col].update_column_profilers(
+                clean_sampled_dict[col], pool)
         if pool is not None:
             pool.close() # Close pool for new tasks
             pool.join() # Wait for all workers to complete
-            
-        return profile

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -323,7 +323,6 @@ class TestProfilerOptions(unittest.TestCase):
                                     "TextOptions."):
             options.structured_options.text.is_prop_enabled("Invalid")
 
-
         # This test is to ensure is_prop_enabled works for BooleanOption objects
         options.structured_options.int.min.is_enabled = True
         self.assertTrue(options.structured_options.int.is_prop_enabled("min"))
@@ -351,6 +350,7 @@ class TestDataLabelerCallWithOptions(unittest.TestCase):
         options.structured_options.data_labeler.data_labeler_dirpath \
             = "Test_Dirpath"
         options.structured_options.data_labeler.max_sample_size = 50
+        options.structured_options.multiprocess.is_enabled = False
 
         profile = Profiler(self.data,
                            profiler_options=options)

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -493,12 +493,31 @@ class TestStructuredDataProfileClass(unittest.TestCase):
         profile = StructuredDataProfile(column, sample_size=len(column))
         self.assertEqual(10, profile.null_count)
 
-
     def test_generating_report_ensure_no_error(self):
         file_path = os.path.join(test_root_path, 'data', 'csv/diamonds.csv')
         data = pd.read_csv(file_path)
         profile = dp.Profiler(data[:1000])
-        readable_report = profile.report(report_options={"output_format":"compact"})
+        readable_report = profile.report(
+            report_options={"output_format": "compact"})
+
+    def test_get_sample_size(self):
+        data = pd.DataFrame([0] * int(50e3))
+
+        # test data size < min_sample_size = 5000 by default
+        profile = dp.Profiler(pd.DataFrame([]))
+        sample_size = profile._get_sample_size(data[:1000])
+        self.assertEqual(1000, sample_size)
+
+        # test data size * 0.20 < min_sample_size < data size
+        profile = dp.Profiler(pd.DataFrame([]))
+        sample_size = profile._get_sample_size(data[:10000])
+        self.assertEqual(5000, sample_size)
+
+        # test min_sample_size > data size * 0.20
+        profile = dp.Profiler(pd.DataFrame([]))
+        sample_size = profile._get_sample_size(data)
+        self.assertEqual(10000, sample_size)
+
 
 class TestProfilerNullValues(unittest.TestCase):
 
@@ -596,6 +615,7 @@ class TestProfilerNullValues(unittest.TestCase):
             
         self.assertEqual(col_one_len, len(data['NAME']))
         self.assertEqual(col_two_len, len(data[' VALUE']))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -203,13 +203,12 @@ class TestProfiler(unittest.TestCase):
         })
 
     def test_report_omit_keys(self):
-        omit_keys = [ 'global_stats', 'data_stats' ]
+        omit_keys = ['global_stats', 'data_stats']
                 
         report_omit_keys = self.trained_schema.report(
             report_options={ "omit_keys": omit_keys })
         
         self.assertCountEqual({}, report_omit_keys)
-
 
     def test_report_compact(self):
         report = self.trained_schema.report(
@@ -225,10 +224,9 @@ class TestProfiler(unittest.TestCase):
         report = _prepare_report(report, 'pretty', omit_keys)
         
         report_compact = self.trained_schema.report(
-            report_options={"output_format": "compact" })
+            report_options={"output_format": "compact"})
 
-        self.assertEqual(report, report_compact)        
-                
+        self.assertEqual(report, report_compact)
 
     def test_profile_key_name_without_space(self):
 
@@ -288,13 +286,16 @@ class TestProfiler(unittest.TestCase):
                                                ' to Profiler'):
             profile = dp.Profiler(dp.Data(text_file_path))
 
-    @mock.patch('dataprofiler.profilers.column_profile_compilers.'
-                'ColumnPrimitiveTypeProfileCompiler')
-    @mock.patch('dataprofiler.profilers.column_profile_compilers.'
-                'ColumnStatsProfileCompiler')
-    @mock.patch('dataprofiler.profilers.column_profile_compilers.'
-                'ColumnDataLabelerCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
+    @mock.patch('dataprofiler.profilers.profile_builder.Profiler.'
+                '_update_row_statistics')
+    @mock.patch('dataprofiler.profilers.profile_builder.StructuredDataProfile')
     def test_sample_size_warning_in_the_profiler(self, *mocks):
+        # structure data profile mock
+        sdp_mock = mock.Mock()
+        sdp_mock.clean_data_and_get_base_stats.return_value = (dict(a=1), None)
+        mocks[0].return_value = sdp_mock
+
         data = pd.DataFrame([1, None, 3, 4, 5, None])
         with self.assertWarnsRegex(UserWarning,
                                    "The data will be profiled with a sample "
@@ -464,7 +465,6 @@ class TestStructuredDataProfileClass(unittest.TestCase):
             'Column names have changed, col number does not match prior name letter',
             context
         )
-        
 
     def test_update_match_are_abstract(self):
         six.assertCountEqual(
@@ -531,6 +531,7 @@ class TestProfilerNullValues(unittest.TestCase):
         }
         test_dataset = pd.DataFrame(data=test_dict)
         profiler_options = ProfilerOptions()
+        profiler_options.structured_options.multiprocess.is_enabled = False
         profiler_options.set({'data_labeler.is_enabled': False})
         trained_schema = dp.Profiler(test_dataset, len(test_dataset),
                                      profiler_options=profiler_options)
@@ -550,6 +551,7 @@ class TestProfilerNullValues(unittest.TestCase):
         file_path = os.path.join(test_root_path, 'data', 'csv/empty_rows.txt')
         data = pd.read_csv(file_path)
         profiler_options = ProfilerOptions()
+        profiler_options.structured_options.multiprocess.is_enabled = False
         profiler_options.set({'data_labeler.is_enabled': False})
         profile = dp.Profiler(data, profiler_options=profiler_options)
         self.assertEqual(2, profile.row_has_null_count)
@@ -569,6 +571,7 @@ class TestProfilerNullValues(unittest.TestCase):
         filename_null_in_file = os.path.join(
             test_root_path, 'data', 'csv/sparse-first-and-last-column.txt')
         profiler_options = ProfilerOptions()
+        profiler_options.structured_options.multiprocess.is_enabled = False
         profiler_options.set({'data_labeler.is_enabled': False})
         data = dp.Data(filename_null_in_file)
         profile = dp.Profiler(data, profiler_options=profiler_options)
@@ -589,6 +592,7 @@ class TestProfilerNullValues(unittest.TestCase):
         file_path = os.path.join(test_root_path, 'data', 'csv/empty_rows.txt')
         data = pd.read_csv(file_path)
         profiler_options = ProfilerOptions()
+        profiler_options.structured_options.multiprocess.is_enabled = False
         profiler_options.set({'data_labeler.is_enabled': False})
 
         col_one_len = len(data['NAME'])

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -568,7 +568,6 @@ class TestProfilerNullValues(unittest.TestCase):
         }
         test_dataset = pd.DataFrame(data=test_dict)
         profiler_options = ProfilerOptions()
-        profiler_options.structured_options.multiprocess.is_enabled = False
         profiler_options.set({'data_labeler.is_enabled': False})
         trained_schema = dp.Profiler(test_dataset, len(test_dataset),
                                      profiler_options=profiler_options)
@@ -588,7 +587,6 @@ class TestProfilerNullValues(unittest.TestCase):
         file_path = os.path.join(test_root_path, 'data', 'csv/empty_rows.txt')
         data = pd.read_csv(file_path)
         profiler_options = ProfilerOptions()
-        profiler_options.structured_options.multiprocess.is_enabled = False
         profiler_options.set({'data_labeler.is_enabled': False})
         profile = dp.Profiler(data, profiler_options=profiler_options)
         self.assertEqual(2, profile.row_has_null_count)
@@ -608,7 +606,6 @@ class TestProfilerNullValues(unittest.TestCase):
         filename_null_in_file = os.path.join(
             test_root_path, 'data', 'csv/sparse-first-and-last-column.txt')
         profiler_options = ProfilerOptions()
-        profiler_options.structured_options.multiprocess.is_enabled = False
         profiler_options.set({'data_labeler.is_enabled': False})
         data = dp.Data(filename_null_in_file)
         profile = dp.Profiler(data, profiler_options=profiler_options)
@@ -629,7 +626,6 @@ class TestProfilerNullValues(unittest.TestCase):
         file_path = os.path.join(test_root_path, 'data', 'csv/empty_rows.txt')
         data = pd.read_csv(file_path)
         profiler_options = ProfilerOptions()
-        profiler_options.structured_options.multiprocess.is_enabled = False
         profiler_options.set({'data_labeler.is_enabled': False})
 
         col_one_len = len(data['NAME'])

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -293,7 +293,7 @@ class TestProfiler(unittest.TestCase):
     def test_sample_size_warning_in_the_profiler(self, *mocks):
         # structure data profile mock
         sdp_mock = mock.Mock()
-        sdp_mock.clean_data_and_get_base_stats.return_value = (dict(a=1), None)
+        sdp_mock.clean_data_and_get_base_stats.return_value = (None, None)
         mocks[0].return_value = sdp_mock
 
         data = pd.DataFrame([1, None, 3, 4, 5, None])


### PR DESCRIPTION
Address the issue: https://github.com/capitalone/DataProfiler/issues/171

Speeds are now below the original speed and the speed from the PR previous to PR #159 .

Profile time for 26MB file:
Current: 24+s
Prior to PR #159: ~8s
This PR: ~6.5s
