### PR TITLE
null count and row duplicate update bug fixes

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -600,9 +600,9 @@ class Profiler(object):
                              "not a DataFrame")
         
         self.total_samples += len(data)
-        self.hashed_row_dict = dict.fromkeys(
+        self.hashed_row_dict.update(dict.fromkeys(
             pd.util.hash_pandas_object(data, index=False), True
-        )
+        ))
 
         # Calculate Null Column Count
         null_rows = set()

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -629,8 +629,8 @@ class Profiler(object):
                 null_rows = null_rows.intersection(null_row_indices)
                 null_in_row_count = null_in_row_count.union(null_row_indices)
 
-        self.row_has_null_count += len(null_in_row_count)
-        self.row_is_null_count += len(null_rows)
+        self.row_has_null_count = len(null_in_row_count)
+        self.row_is_null_count = len(null_rows)
 
     def update_profile(self, data, sample_size=None, min_true_samples=None):
         """

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -706,19 +706,23 @@ class TestProfilerNullValues(unittest.TestCase):
         for i in range(2):
             
             # Profile Once
+            # TODO: bc currently don't handle overlapping indexes
+            data.index = pd.RangeIndex(0, 8)
             profile = dp.Profiler(data, profiler_options=profiler_options,
                                   samples_per_update=2)
 
             # Profile Twice
+            # TODO: bc currently don't handle overlapping indexes
+            data.index = pd.RangeIndex(8, 16)
             profile.update_profile(data)
 
             # rows sampled are [5, 6] (0 index)
             self.assertEqual(16, profile.total_samples)
             self.assertEqual(4, profile._max_col_samples_used)
-            self.assertEqual(1, profile.row_has_null_count)
-            self.assertEqual(0.25, profile._get_row_has_null_ratio())
-            self.assertEqual(1, profile.row_is_null_count)
-            self.assertEqual(0.25, profile._get_row_is_null_ratio())
+            self.assertEqual(2, profile.row_has_null_count)
+            self.assertEqual(0.5, profile._get_row_has_null_ratio())
+            self.assertEqual(2, profile.row_is_null_count)
+            self.assertEqual(0.5, profile._get_row_is_null_ratio())
             self.assertEqual(0.4375, profile._get_unique_row_ratio())
             self.assertEqual(9, profile._get_duplicate_row_count())
             

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -716,7 +716,7 @@ class TestProfilerNullValues(unittest.TestCase):
             data.index = pd.RangeIndex(8, 16)
             profile.update_profile(data)
 
-            # rows sampled are [5, 6] (0 index)
+            # rows sampled are [5, 6], [13, 14] (0 index)
             self.assertEqual(16, profile.total_samples)
             self.assertEqual(4, profile._max_col_samples_used)
             self.assertEqual(2, profile.row_has_null_count)

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -687,15 +687,22 @@ class TestProfilerNullValues(unittest.TestCase):
         )
        
     def test_correct_total_sample_size_and_counts_and_mutability(self):
-        file_path = os.path.join(test_root_path, 'data', 'csv/empty_rows.txt')
-        data = pd.read_csv(file_path)
+        data = [['test1', 1.0],
+                ['test2', 2.0],
+                ['test3', 3.0],
+                [None, None],
+                ['test5', 5.0],
+                ['test6', 6.0],
+                [None, None],
+                ['test7', 7.0]]
+        data = pd.DataFrame(data, columns=['NAME', 'VALUE'])
         profiler_options = ProfilerOptions()
         profiler_options.set({'data_labeler.is_enabled': False})
 
         col_one_len = len(data['NAME'])
-        col_two_len = len(data[' VALUE'])
+        col_two_len = len(data['VALUE'])
 
-        # Test reloading data, ensuring unmutable 
+        # Test reloading data, ensuring immutable
         for i in range(2):
             
             # Profile Once
@@ -705,17 +712,18 @@ class TestProfilerNullValues(unittest.TestCase):
             # Profile Twice
             profile.update_profile(data)
 
+            # rows sampled are [5, 6] (0 index)
             self.assertEqual(16, profile.total_samples)
             self.assertEqual(4, profile._max_col_samples_used)
-            self.assertEqual(2, profile.row_has_null_count)
-            self.assertEqual(0.5, profile._get_row_has_null_ratio())
-            self.assertEqual(2, profile.row_is_null_count)
-            self.assertEqual(0.5, profile._get_row_is_null_ratio())
+            self.assertEqual(1, profile.row_has_null_count)
+            self.assertEqual(0.25, profile._get_row_has_null_ratio())
+            self.assertEqual(1, profile.row_is_null_count)
+            self.assertEqual(0.25, profile._get_row_is_null_ratio())
             self.assertEqual(0.4375, profile._get_unique_row_ratio())
             self.assertEqual(9, profile._get_duplicate_row_count())
             
         self.assertEqual(col_one_len, len(data['NAME']))
-        self.assertEqual(col_two_len, len(data[' VALUE']))
+        self.assertEqual(col_two_len, len(data['VALUE']))
 
     def test_null_calculation_with_differently_sampled_cols(self):
         opts = ProfilerOptions()
@@ -749,7 +757,6 @@ class TestProfilerNullValues(unittest.TestCase):
         # Only 4 total rows sampled, ratio accordingly
         self.assertEqual(0.5, profile2._get_row_is_null_ratio())
         self.assertEqual(1, profile2._get_row_has_null_ratio())
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fixes errors with:
```python
data = pd.DataFrame([1, None, 3, 4, 5, None, 1, 5])
profiler = dp.Profiler(data[:2])
profiler.update_profile(data[2:])
```
null_counts and duplicate rows were not accurately being updated