### PR TITLE
Null counts are displayed, regardless of a type being active

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -188,13 +188,16 @@ class StructuredDataProfile(object):
             "column_name": name,
             "samples": self.sample,
         })
-                
+
+        unordered_profile["statistics"].update({
+            "sample_size": self.sample_size,
+            "null_count": self.null_count,
+            "null_types": self.null_types,
+            "null_types_index": self.null_types_index
+        })
+        
         if unordered_profile.get("data_type", None) is not None:
             unordered_profile["statistics"].update({
-                "sample_size": self.sample_size,
-                "null_count": self.null_count,
-                "null_types": self.null_types,
-                "null_types_index": self.null_types_index,
                 "data_type_representation":
                 unordered_profile["data_type_representation"]
             })

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -111,7 +111,12 @@ class TestProfilerOptions(unittest.TestCase):
             self.assertTrue("data_label" not in profile_column.keys())
             self.assertIsNone(profile_column["categorical"])
             self.assertIsNone(profile_column["order"])
-            self.assertDictEqual({}, profile_column["statistics"])
+            self.assertDictEqual({
+                'sample_size': 2,
+                'null_count': 0,
+                'null_types': [],
+                'null_types_index': {}
+            }, profile_column["statistics"])
 
     @mock.patch('dataprofiler.profilers.text_column_profile.TextColumn'
                 '._update_vocab')


### PR DESCRIPTION
#156 