### PR TITLE
Handling index overlap when merging and updating profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ report  = profile.report(report_options={"output_format":"pretty"})
 print(json.dumps(report, indent=4))
 ```
 
+Note that if the data you update the profile with contains integer indices that overlap with the indices on data originally profiled, when null rows are calculated the indices will be "shifted" to uninhabited values so that null counts and ratios are still accurate.
+
 ### Merging Profiles
 
 If you have two files with the same schema (but different data), it is possible to merge the two profiles together via an addition operator. 
@@ -261,6 +263,8 @@ profile3 = profile1 + profile2
 report  = profile3.report(report_options={"output_format":"pretty"})
 print(json.dumps(report, indent=4))
 ```
+
+Note that if merged profiles had overlapping integer indices, when null rows are calculated the indices will be "shifted" to uninhabited values so that null counts and ratios are still accurate.
 
 ### Profile a Pandas DataFrame
 ```python

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -383,10 +383,10 @@ class StructuredDataProfile(object):
             min_id = min(df_series.index)
             max_id = max(df_series.index)
         else:
-            warnings.warn("Unable to detect minimum and maximum index values. "
-                          "There may be future overlapping in indices when "
-                          "updating/merging which could result in inaccurate "
-                          "null row index reporting.")
+            warnings.warn("Unable to detect minimum and maximum index values "
+                          "for overlap detection. Updating/merging profiles "
+                          "may result in inaccurate null row index reporting "
+                          "due to unhandled overlapping indices.")
 
         # Select generator depending if sample_ids availability
         if sample_ids is None:

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -648,7 +648,7 @@ class Profiler(object):
     def _get_duplicate_row_count(self):
         return self.total_samples - len(self.hashed_row_dict)
 
-    def _update_row_statistics(self, data, sample_ids=None):
+    def _update_row_statistics(self, data, sample_ids):
         """
         Iterate over the provided dataset row by row and calculate
         the row statistics. Specifically, number of unique rows,
@@ -680,11 +680,8 @@ class Profiler(object):
             if null_type_dict:
                 null_row_indices = set.union(*null_type_dict.values())
 
-            if sample_ids is not None:
-                # If sample ids provided, only consider nulls in rows that
-                # were fully sampled
-                null_row_indices = null_row_indices.intersection(
-                    data.index[sample_ids[:self._min_col_samples_used]])
+            null_row_indices = null_row_indices.intersection(
+                data.index[sample_ids[:self._min_col_samples_used]])
 
             # Find the common null indices between the columns
             if first_col_flag:
@@ -885,12 +882,7 @@ class Profiler(object):
             pool.close()  # Close pool for new tasks
             pool.join()  # Wait for all workers to complete
 
-        # Only pass along sample ids if necessary
-        samples_for_row_stats = None
-        if min_true_samples not in [None, 0]:
-            samples_for_row_stats = np.concatenate(sample_ids)
-
-        self._update_row_statistics(df, samples_for_row_stats)
+        self._update_row_statistics(df, np.concatenate(sample_ids))
 
     def _remove_data_labelers(self):
         """

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -294,20 +294,6 @@ class StructuredDataProfile(object):
             sample_size = self._get_sample_size(df_series)
         if not min_true_samples:
             min_true_samples = self._min_true_samples
-
-        if utils.overlap(self.min_id, self.max_id,
-                         min(df_series.index), max(df_series.index)):
-            # Increment df_series index so that no overlap with current data
-            warnings.warn("Overlapping indices detected between data given "
-                          "to update_profile and profiled data, indices of "
-                          "provided data will be shifted to resolve this.")
-            if isinstance(df_series.index, pd.RangeIndex):
-                new_start = df_series.index.start + self.max_id + 1
-                new_stop = df_series.index.stop + self.max_id + 1
-                df_series.index = pd.RangeIndex(start=new_start, stop=new_stop,
-                                                step=df_series.index.step)
-            else:
-                df_series.index = [i + self.max_id + 1 for i in df_series.index]
         
         clean_sampled_df, base_stats = self.clean_data_and_get_base_stats(
             df_series=df_series, sample_size=sample_size,

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -232,14 +232,16 @@ class StructuredDataProfile(object):
             self.null_types, list(base_stats["null_types"].keys())
         )
 
-        if self.min_id is None:
-            self.min_id = base_stats["min_id"]
-        else:
-            self.min_id = min(self.min_id, base_stats["min_id"])
-        if self.max_id is None:
-            self.max_id = base_stats["max_id"]
-        else:
-            self.max_id = max(self.max_id, base_stats["max_id"])
+        if base_stats["min_id"] is not None:
+            if self.min_id is None:
+                self.min_id = base_stats["min_id"]
+            else:
+                self.min_id = min(self.min_id, base_stats["min_id"])
+        if base_stats["max_id"] is not None:
+            if self.max_id is None:
+                self.max_id = base_stats["max_id"]
+            else:
+                self.max_id = max(self.max_id, base_stats["max_id"])
 
         for null_type, null_rows in base_stats["null_types"].items():
             if type(null_rows) is list:

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -160,9 +160,9 @@ class StructuredDataProfile(object):
         other_max_id = other.max_id
         other_nti = copy.deepcopy(other.null_types_index)
         if utils.overlap(self.min_id, self.max_id, other.min_id, other.max_id):
-            warnings.warn(f"Attempted to merge profiles {self.name} and "
-                          f"{other.name} with overlapping indices. The indices "
-                          f"in {other.name} will be shifted to resolve this.")
+            warnings.warn(f"Attempted to merge profiles with overlapping "
+                          f"indices. The indices in {other.name} will be "
+                          f"shifted in the merged profile to resolve this.")
 
             other_min_id = other.min_id + self.max_id + 1
             other_max_id = other.max_id + self.max_id + 1
@@ -376,10 +376,8 @@ class StructuredDataProfile(object):
         # Record min and max index values if index is int
         min_id = None
         max_id = None
-        if isinstance(df_series.index, pd.RangeIndex):
-            min_id = df_series.index.start
-            max_id = df_series.index.stop
-        elif all([isinstance(i, int) for i in df_series.index]):
+        if isinstance(df_series.index, pd.RangeIndex) or \
+                all([isinstance(i, int) for i in df_series.index]):
             min_id = min(df_series.index)
             max_id = max(df_series.index)
         else:

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -236,13 +236,13 @@ class StructuredDataProfile(object):
             self.null_types, list(base_stats["null_types"].keys())
         )
 
-        if base_stats["min_id"] is not None:
-            if self.min_id is None:
+        if isinstance(base_stats["min_id"], int):
+            if isinstance(self.min_id, int):
                 self.min_id = base_stats["min_id"]
             else:
                 self.min_id = min(self.min_id, base_stats["min_id"])
-        if base_stats["max_id"] is not None:
-            if self.max_id is None:
+        if isinstance(base_stats["max_id"], int):
+            if isinstance(self.max_id, int):
                 self.max_id = base_stats["max_id"]
             else:
                 self.max_id = max(self.max_id, base_stats["max_id"])
@@ -284,7 +284,7 @@ class StructuredDataProfile(object):
                     (x1 <= y1 <= x2) or
                     (x1 <= y2 <= x2))
 
-        if (None not in [self.max_id, self.min_id] and
+        if (isinstance(self.min_id, int) and isinstance(self.max_id, int) and
                 all([isinstance(i, int) for i in df_series.index])):
             if overlap(self.min_id, self.max_id,
                        min(df_series.index), max(df_series.index)):

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -696,7 +696,7 @@ class Profiler(object):
                 null_in_row_count = null_in_row_count.union(null_row_indices)
 
         # If sample_ids provided, increment since that means only new data read
-        if sample_ids:
+        if sample_ids is not None:
             self.row_has_null_count += len(null_in_row_count)
             self.row_is_null_count += len(null_rows)
         else:

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -156,19 +156,23 @@ class StructuredDataProfile(object):
         )
 
         # Check if indices overlap, if they do, adjust attributes accordingly
+        other_min_id = other.min_id
+        other_max_id = other.max_id
+        other_nti = copy.deepcopy(other.null_types_index)
         if utils.overlap(self.min_id, self.max_id, other.min_id, other.max_id):
             warnings.warn(f"Attempted to merge profiles {self.name} and "
                           f"{other.name} with overlapping indices. The indices "
                           f"in {other.name} will be shifted to resolve this.")
-            other.min_id = other.min_id + self.max_id + 1
-            other.max_id = other.max_id + self.max_id + 1
+
+            other_min_id = other.min_id + self.max_id + 1
+            other_max_id = other.max_id + self.max_id + 1
 
             # Increment values (indices) in s by self.max_id + 1
             def increment(s):
                 return {x + self.max_id + 1 for x in s}
 
-            other.null_types_index = {k: increment(v) for k, v in
-                                      other.null_types_index.items()}
+            other_nti = {k: increment(v) for k, v in
+                         other.null_types_index.items()}
 
         merged_profile.name = self.name
         merged_profile._update_base_stats(
@@ -183,9 +187,9 @@ class StructuredDataProfile(object):
             {"sample": other.sample,
              "sample_size": other.sample_size,
              "null_count": other.null_count,
-             "null_types": copy.deepcopy(other.null_types_index),
-             "min_id": other.min_id,
-             "max_id": other.max_id}
+             "null_types": other_nti,
+             "min_id": other_min_id,
+             "max_id": other_max_id}
         )
         samples = list(dict.fromkeys(self.sample + other.sample))
         merged_profile.sample = random.sample(samples, min(len(samples), 5))

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -246,6 +246,7 @@ class StructuredDataProfile(object):
                           f"where null data present will be shifted forward "
                           f"when stored in profile: {self.name}")
 
+            # Shift indices (min, max, and all indices in null types index
             base_min = base_min + self.max_id + 1
             base_max = base_max + self.max_id + 1
 

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -63,6 +63,8 @@ class StructuredDataProfile(object):
         self.null_count = 0
         self.null_types = list()
         self.null_types_index = {}
+        self.min_id = None
+        self.max_id = None
         self.profiles = {}
                          
         if df_series is not None and len(df_series) > 0:
@@ -230,6 +232,15 @@ class StructuredDataProfile(object):
             self.null_types, list(base_stats["null_types"].keys())
         )
 
+        if self.min_id is None:
+            self.min_id = base_stats["min_id"]
+        else:
+            self.min_id = min(self.min_id, base_stats["min_id"])
+        if self.max_id is None:
+            self.max_id = base_stats["max_id"]
+        else:
+            self.max_id = max(self.max_id, base_stats["max_id"])
+
         for null_type, null_rows in base_stats["null_types"].items():
             if type(null_rows) is list:
                 null_rows.sort()
@@ -329,13 +340,12 @@ class StructuredDataProfile(object):
         # Pandas reads empty values in the csv files as nan
         df_series = df_series.apply(str)
 
-        # Record min and max index values (if index is int)
-        try:
+        # Record min and max index values if index is int
+        min_id = None
+        max_id = None
+        if all([isinstance(i, int) for i in df_series.index]):
             min_id = min(df_series.index)
             max_id = max(df_series.index)
-        except:
-            min_id = None
-            max_id = None
 
         # Select generator depending if sample_ids availability
         if sample_ids is None:

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -364,13 +364,17 @@ class StructuredDataProfile(object):
         df_series = df_series.apply(str)
 
         # Record min and max index values if index is int
-        min_id = None
-        max_id = None
-        if isinstance(df_series.index, pd.RangeIndex) or \
-                all([isinstance(i, int) for i in df_series.index]):
+        is_index_all_ints = True
+        try:
             min_id = min(df_series.index)
             max_id = max(df_series.index)
-        else:
+            if not (isinstance(min_id, int) and isinstance(max_id, int)):
+                is_index_all_ints = False
+        except TypeError:
+            is_index_all_ints = False
+
+        if not is_index_all_ints:
+            min_id = max_id = None
             warnings.warn("Unable to detect minimum and maximum index values "
                           "for overlap detection. Updating/merging profiles "
                           "may result in inaccurate null row index reporting "

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -63,8 +63,8 @@ class StructuredDataProfile(object):
         self.null_count = 0
         self.null_types = list()
         self.null_types_index = {}
-        self.min_id = None
-        self.max_id = None
+        self._min_id = None
+        self._max_id = None
         self.profiles = {}
                          
         if df_series is not None and len(df_series) > 0:
@@ -161,16 +161,16 @@ class StructuredDataProfile(object):
              "sample_size": self.sample_size,
              "null_count": self.null_count,
              "null_types": copy.deepcopy(self.null_types_index),
-             "min_id": self.min_id,
-             "max_id": self.max_id}
+             "min_id": self._min_id,
+             "max_id": self._max_id}
         )
         merged_profile._update_base_stats(
             {"sample": other.sample,
              "sample_size": other.sample_size,
              "null_count": other.null_count,
              "null_types": copy.deepcopy(other.null_types_index),
-             "min_id": other.min_id,
-             "max_id": other.max_id}
+             "min_id": other._min_id,
+             "max_id": other._max_id}
         )
         samples = list(dict.fromkeys(self.sample + other.sample))
         merged_profile.sample = random.sample(samples, min(len(samples), 5))
@@ -241,29 +241,29 @@ class StructuredDataProfile(object):
         base_nti = base_stats["null_types"]
 
         # Check if indices overlap, if they do, adjust attributes accordingly
-        if utils.overlap(self.min_id, self.max_id, base_min, base_max):
+        if utils.overlap(self._min_id, self._max_id, base_min, base_max):
             warnings.warn(f"Overlapping indices detected. To resolve, indices "
                           f"where null data present will be shifted forward "
                           f"when stored in profile: {self.name}")
 
             # Shift indices (min, max, and all indices in null types index
-            base_min = base_min + self.max_id + 1
-            base_max = base_max + self.max_id + 1
+            base_min = base_min + self._max_id + 1
+            base_max = base_max + self._max_id + 1
 
-            base_nti = {k: {x + self.max_id + 1 for x in v} for k, v in
+            base_nti = {k: {x + self._max_id + 1 for x in v} for k, v in
                         base_stats["null_types"].items()}
 
         # Store/compare min/max id with current
         if isinstance(base_min, int):
-            if not isinstance(self.min_id, int):
-                self.min_id = base_min
+            if not isinstance(self._min_id, int):
+                self._min_id = base_min
             else:
-                self.min_id = min(self.min_id, base_min)
+                self._min_id = min(self._min_id, base_min)
         if isinstance(base_max, int):
-            if not isinstance(self.max_id, int):
-                self.max_id = base_max
+            if not isinstance(self._max_id, int):
+                self._max_id = base_max
             else:
-                self.max_id = max(self.max_id, base_max)
+                self._max_id = max(self._max_id, base_max)
 
         # Update null row indices
         for null_type, null_rows in base_nti.items():

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -384,8 +384,9 @@ class StructuredDataProfile(object):
             max_id = max(df_series.index)
         else:
             warnings.warn("Unable to detect minimum and maximum index values. "
-                          "As a result overlap when merging/updating cannot be "
-                          "detected and may result in an inaccurate profile.")
+                          "There may be future overlapping in indices when "
+                          "updating/merging which could result in inaccurate "
+                          "null row index reporting.")
 
         # Select generator depending if sample_ids availability
         if sample_ids is None:

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -254,16 +254,14 @@ class StructuredDataProfile(object):
                         base_stats["null_types"].items()}
 
         # Store/compare min/max id with current
-        if isinstance(base_min, int):
-            if not isinstance(self._min_id, int):
-                self._min_id = base_min
-            else:
-                self._min_id = min(self._min_id, base_min)
-        if isinstance(base_max, int):
-            if not isinstance(self._max_id, int):
-                self._max_id = base_max
-            else:
-                self._max_id = max(self._max_id, base_max)
+        if self._min_id is None:
+            self._min_id = base_min
+        elif base_min is not None:
+            self._min_id = min(self._min_id, base_min)
+        if self._max_id is None:
+            self._max_id = base_max
+        elif base_max is not None:
+            self._max_id = max(self._max_id, base_max)
 
         # Update null row indices
         for null_type, null_rows in base_nti.items():

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -250,7 +250,7 @@ class StructuredDataProfile(object):
             base_min = base_min + self.max_id + 1
             base_max = base_max + self.max_id + 1
 
-            base_nti = {k: utils.increment(v, self.max_id + 1) for k, v in
+            base_nti = {k: {x + self.max_id + 1 for x in v} for k, v in
                         base_stats["null_types"].items()}
 
         # Store/compare min/max id with current

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -376,9 +376,16 @@ class StructuredDataProfile(object):
         # Record min and max index values if index is int
         min_id = None
         max_id = None
-        if all([isinstance(i, int) for i in df_series.index]):
+        if isinstance(df_series.index, pd.RangeIndex):
+            min_id = df_series.index.start
+            max_id = df_series.index.stop
+        elif all([isinstance(i, int) for i in df_series.index]):
             min_id = min(df_series.index)
             max_id = max(df_series.index)
+        else:
+            warnings.warn("Unable to detect minimum and maximum index values. "
+                          "As a result overlap when merging/updating cannot be "
+                          "detected and may result in inaccurate profile.")
 
         # Select generator depending if sample_ids availability
         if sample_ids is None:

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -276,6 +276,20 @@ class StructuredDataProfile(object):
             sample_size = self._get_sample_size(df_series)
         if not min_true_samples:
             min_true_samples = self._min_true_samples
+
+        # Return True iff [x1:x2] overlaps with [y1:y2]
+        def overlap(x1, x2, y1, y2):
+            return ((y1 <= x1 <= y2) or
+                    (y1 <= x2 <= y2) or
+                    (x1 <= y1 <= x2) or
+                    (x1 <= y2 <= x2))
+
+        if (None not in [self.max_id, self.min_id] and
+                all([isinstance(i, int) for i in df_series.index])):
+            if overlap(self.min_id, self.max_id,
+                       min(df_series.index), max(df_series.index)):
+                # Increment df_series index so that no overlap with current data
+                df_series.index = [i + self.max_id + 1 for i in df_series.index]
         
         clean_sampled_df, base_stats = self.clean_data_and_get_base_stats(
             df_series=df_series, sample_size=sample_size,

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -322,11 +322,20 @@ class StructuredDataProfile(object):
         if not len_df:
             return df_series, {
                 "sample_size": 0, "null_count": 0,
-                "null_types": dict(), "sample": []
+                "null_types": dict(), "sample": [],
+                "min_id": None, "max_id": None
             }
 
         # Pandas reads empty values in the csv files as nan
         df_series = df_series.apply(str)
+
+        # Record min and max index values (if index is int)
+        try:
+            min_id = min(df_series.index)
+            max_id = max(df_series.index)
+        except:
+            min_id = None
+            max_id = None
 
         # Select generator depending if sample_ids availability
         if sample_ids is None:
@@ -380,7 +389,9 @@ class StructuredDataProfile(object):
             "null_count": total_na,
             "null_types": na_columns,
             "sample": random.sample(list(df_series.values),
-                                    min(len(df_series), 5))
+                                    min(len(df_series), 5)),
+            "min_id": min_id,
+            "max_id": max_id
         }
 
         return df_series, base_stats

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -746,6 +746,9 @@ class Profiler(object):
             )
 
         if not len(data):
+            # Need to reflect that no samples in this batch
+            for column in self._profile:
+                self._profile[column]._last_batch_size = 0
             return
         if not min_true_samples:
             min_true_samples = self._min_true_samples

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -648,7 +648,7 @@ class Profiler(object):
     def _get_duplicate_row_count(self):
         return self.total_samples - len(self.hashed_row_dict)
 
-    def _update_row_statistics(self, data, sample_ids):
+    def _update_row_statistics(self, data, sample_ids=None):
         """
         Iterate over the provided dataset row by row and calculate
         the row statistics. Specifically, number of unique rows,
@@ -680,8 +680,11 @@ class Profiler(object):
             if null_type_dict:
                 null_row_indices = set.union(*null_type_dict.values())
 
-            null_row_indices = null_row_indices.intersection(
-                data.index[sample_ids[:self._min_col_samples_used]])
+            if sample_ids is not None:
+                # If sample ids provided, only consider nulls in rows that
+                # were fully sampled
+                null_row_indices = null_row_indices.intersection(
+                    data.index[sample_ids[:self._min_col_samples_used]])
 
             # Find the common null indices between the columns
             if first_col_flag:
@@ -692,8 +695,13 @@ class Profiler(object):
                 null_rows = null_rows.intersection(null_row_indices)
                 null_in_row_count = null_in_row_count.union(null_row_indices)
 
-        self.row_has_null_count += len(null_in_row_count)
-        self.row_is_null_count += len(null_rows)
+        # If sample_ids provided, increment since that means only new data read
+        if sample_ids:
+            self.row_has_null_count += len(null_in_row_count)
+            self.row_is_null_count += len(null_rows)
+        else:
+            self.row_has_null_count = len(null_in_row_count)
+            self.row_is_null_count = len(null_rows)
 
     def update_profile(self, data, sample_size=None, min_true_samples=None):
         """
@@ -882,7 +890,12 @@ class Profiler(object):
             pool.close()  # Close pool for new tasks
             pool.join()  # Wait for all workers to complete
 
-        self._update_row_statistics(df, np.concatenate(sample_ids))
+        # Only pass along sample ids if necessary
+        samples_for_row_stats = None
+        if min_true_samples not in [None, 0]:
+            samples_for_row_stats = np.concatenate(sample_ids)
+
+        self._update_row_statistics(df, samples_for_row_stats)
 
     def _remove_data_labelers(self):
         """

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -155,6 +155,21 @@ class StructuredDataProfile(object):
             options=self.options,
         )
 
+        # Check if indices overlap, if they do, adjust attributes accordingly
+        if utils.overlap(self.min_id, self.max_id, other.min_id, other.max_id):
+            warnings.warn(f"Attempted to merge profiles {self.name} and "
+                          f"{other.name} with overlapping indices. The indices "
+                          f"in {other.name} will be shifted to resolve this.")
+            other.min_id = other.min_id + self.max_id + 1
+            other.max_id = other.max_id + self.max_id + 1
+
+            # Increment values (indices) in s by self.max_id + 1
+            def increment(s):
+                return {x + self.max_id + 1 for x in s}
+
+            other.null_types_index = {k: increment(v) for k, v in
+                                      other.null_types_index.items()}
+
         merged_profile.name = self.name
         merged_profile._update_base_stats(
             {"sample": self.sample,
@@ -277,22 +292,13 @@ class StructuredDataProfile(object):
         if not min_true_samples:
             min_true_samples = self._min_true_samples
 
-        # Return True iff [x1:x2] overlaps with [y1:y2]
-        def overlap(x1, x2, y1, y2):
-            return ((y1 <= x1 <= y2) or
-                    (y1 <= x2 <= y2) or
-                    (x1 <= y1 <= x2) or
-                    (x1 <= y2 <= x2))
-
-        if (isinstance(self.min_id, int) and isinstance(self.max_id, int) and
-                all([isinstance(i, int) for i in df_series.index])):
-            if overlap(self.min_id, self.max_id,
-                       min(df_series.index), max(df_series.index)):
-                # Increment df_series index so that no overlap with current data
-                warnings.warn("Overlapping indices detected between data given "
-                              "to update_profile and profiled data, indices of "
-                              "provided data will be shifted to resolve this.")
-                df_series.index = [i + self.max_id + 1 for i in df_series.index]
+        if utils.overlap(self.min_id, self.max_id,
+                         min(df_series.index), max(df_series.index)):
+            # Increment df_series index so that no overlap with current data
+            warnings.warn("Overlapping indices detected between data given "
+                          "to update_profile and profiled data, indices of "
+                          "provided data will be shifted to resolve this.")
+            df_series.index = [i + self.max_id + 1 for i in df_series.index]
         
         clean_sampled_df, base_stats = self.clean_data_and_get_base_stats(
             df_series=df_series, sample_size=sample_size,

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -692,8 +692,8 @@ class Profiler(object):
                 null_rows = null_rows.intersection(null_row_indices)
                 null_in_row_count = null_in_row_count.union(null_row_indices)
 
-        self.row_has_null_count = len(null_in_row_count)
-        self.row_is_null_count = len(null_rows)
+        self.row_has_null_count += len(null_in_row_count)
+        self.row_is_null_count += len(null_rows)
 
     def update_profile(self, data, sample_size=None, min_true_samples=None):
         """

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -167,11 +167,7 @@ class StructuredDataProfile(object):
             other_min_id = other.min_id + self.max_id + 1
             other_max_id = other.max_id + self.max_id + 1
 
-            # Increment values (indices) in s by self.max_id + 1
-            def increment(s):
-                return {x + self.max_id + 1 for x in s}
-
-            other_nti = {k: increment(v) for k, v in
+            other_nti = {k: utils.increment(v, self.max_id + 1) for k, v in
                          other.null_types_index.items()}
 
         merged_profile.name = self.name
@@ -302,7 +298,11 @@ class StructuredDataProfile(object):
             warnings.warn("Overlapping indices detected between data given "
                           "to update_profile and profiled data, indices of "
                           "provided data will be shifted to resolve this.")
-            df_series.index = [i + self.max_id + 1 for i in df_series.index]
+            if isinstance(df_series.index, pd.RangeIndex):
+                df_series.index.start += (self.max_id + 1)
+                df_series.index.stop += (self.max_id + 1)
+            else:
+                df_series.index = [i + self.max_id + 1 for i in df_series.index]
         
         clean_sampled_df, base_stats = self.clean_data_and_get_base_stats(
             df_series=df_series, sample_size=sample_size,

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -385,7 +385,7 @@ class StructuredDataProfile(object):
         else:
             warnings.warn("Unable to detect minimum and maximum index values. "
                           "As a result overlap when merging/updating cannot be "
-                          "detected and may result in inaccurate profile.")
+                          "detected and may result in an inaccurate profile.")
 
         # Select generator depending if sample_ids availability
         if sample_ids is None:

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -693,9 +693,11 @@ class Profiler(object):
                 # event of overlap
                 shift = self._profile[column]._index_shift
                 if shift is None:
+                    # Shift is None if index is str or if no overlap detected
                     null_row_indices = null_row_indices.intersection(
                         data.index[sample_ids[:self._min_sampled_from_batch]])
                 else:
+                    # Only shift if index shift detected (must be ints)
                     null_row_indices = null_row_indices.intersection(
                         data.index[sample_ids[:self._min_sampled_from_batch]] +
                         shift)

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -299,8 +299,10 @@ class StructuredDataProfile(object):
                           "to update_profile and profiled data, indices of "
                           "provided data will be shifted to resolve this.")
             if isinstance(df_series.index, pd.RangeIndex):
-                df_series.index.start += (self.max_id + 1)
-                df_series.index.stop += (self.max_id + 1)
+                new_start = df_series.index.start + self.max_id + 1
+                new_stop = df_series.index.stop + self.max_id + 1
+                df_series.index = pd.RangeIndex(start=new_start, stop=new_stop,
+                                                step=df_series.index.step)
             else:
                 df_series.index = [i + self.max_id + 1 for i in df_series.index]
         

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -237,12 +237,12 @@ class StructuredDataProfile(object):
         )
 
         if isinstance(base_stats["min_id"], int):
-            if isinstance(self.min_id, int):
+            if not isinstance(self.min_id, int):
                 self.min_id = base_stats["min_id"]
             else:
                 self.min_id = min(self.min_id, base_stats["min_id"])
         if isinstance(base_stats["max_id"], int):
-            if isinstance(self.max_id, int):
+            if not isinstance(self.max_id, int):
                 self.max_id = base_stats["max_id"]
             else:
                 self.max_id = max(self.max_id, base_stats["max_id"])
@@ -289,6 +289,9 @@ class StructuredDataProfile(object):
             if overlap(self.min_id, self.max_id,
                        min(df_series.index), max(df_series.index)):
                 # Increment df_series index so that no overlap with current data
+                warnings.warn("Overlapping indices detected between data given "
+                              "to update_profile and profiled data, indices of "
+                              "provided data will be shifted to resolve this.")
                 df_series.index = [i + self.max_id + 1 for i in df_series.index]
         
         clean_sampled_df, base_stats = self.clean_data_and_get_base_stats(

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -160,13 +160,17 @@ class StructuredDataProfile(object):
             {"sample": self.sample,
              "sample_size": self.sample_size,
              "null_count": self.null_count,
-             "null_types": copy.deepcopy(self.null_types_index)}
+             "null_types": copy.deepcopy(self.null_types_index),
+             "min_id": self.min_id,
+             "max_id": self.max_id}
         )
         merged_profile._update_base_stats(
             {"sample": other.sample,
              "sample_size": other.sample_size,
              "null_count": other.null_count,
-             "null_types": copy.deepcopy(other.null_types_index)}
+             "null_types": copy.deepcopy(other.null_types_index),
+             "min_id": other.min_id,
+             "max_id": other.max_id}
         )
         samples = list(dict.fromkeys(self.sample + other.sample))
         merged_profile.sample = random.sample(samples, min(len(samples), 5))

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -245,3 +245,13 @@ def overlap(x1, x2, y1, y2):
             (y1 <= x2 <= y2) or
             (x1 <= y1 <= x2) or
             (x1 <= y2 <= x2))
+
+
+def increment(set_or_list, inc):
+    """
+    Increments each value in set_or_list by inc
+    """
+    incremented = [x + inc for x in set_or_list]
+    if isinstance(set_or_list, set):
+        return set(incremented)
+    return incremented

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -233,3 +233,15 @@ def generate_pool(max_pool_size=None, data_size=None, cols=None):
             )            
 
     return pool, max_pool_size
+
+
+def overlap(x1, x2, y1, y2):
+    """
+    Return True iff [x1:x2] overlaps with [y1:y2]
+    """
+    if not all([isinstance(i, int) for i in [x1, x2, y1, y2]]):
+        return False
+    return ((y1 <= x1 <= y2) or
+            (y1 <= x2 <= y2) or
+            (x1 <= y1 <= x2) or
+            (x1 <= y2 <= x2))

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -245,13 +245,3 @@ def overlap(x1, x2, y1, y2):
             (y1 <= x2 <= y2) or
             (x1 <= y1 <= x2) or
             (x1 <= y2 <= x2))
-
-
-def increment(set_or_list, inc):
-    """
-    Increments each value in set_or_list by inc
-    """
-    incremented = [x + inc for x in set_or_list]
-    if isinstance(set_or_list, set):
-        return set(incremented)
-    return incremented

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import unittest
 from unittest import mock
+from io import BytesIO
 import builtins
 import random
 import six
@@ -10,7 +11,6 @@ import re
 
 import numpy as np
 import pandas as pd
-from io import BytesIO
 
 from . import utils as test_utils
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -887,16 +887,14 @@ class TestProfilerNullValues(unittest.TestCase):
                 'ColumnDataLabelerCompiler')
     @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
     def test_null_row_stats_correct_after_updates(self, *mocks):
-        data = pd.DataFrame([[1, None],
-                             [1, 1],
-                             [None, None],
-                             [None, 1],
-                             [1, None],
+        data1 = pd.DataFrame([[1, None],
                              [1, 1],
                              [None, None],
                              [None, 1]])
-        data1 = data[:4]
-        data2 = data[4:]
+        data2 = pd.DataFrame([[None, None],
+                             [1, None],
+                             [None, None],
+                             [None, 1]])
         opts = ProfilerOptions()
         opts.structured_options.multiprocess.is_enabled = False
 
@@ -910,10 +908,10 @@ class TestProfilerNullValues(unittest.TestCase):
         self.assertEqual(4, profile._min_sampled_from_batch)
 
         profile.update_profile(data2, min_true_samples=2, sample_size=2)
-        self.assertEqual(6, profile.row_has_null_count)
-        self.assertEqual(2, profile.row_is_null_count)
-        self.assertEqual(0.75, profile._get_row_has_null_ratio())
-        self.assertEqual(0.25, profile._get_row_is_null_ratio())
+        self.assertEqual(7, profile.row_has_null_count)
+        self.assertEqual(3, profile.row_is_null_count)
+        self.assertEqual(0.875, profile._get_row_has_null_ratio())
+        self.assertEqual(0.375, profile._get_row_is_null_ratio())
         self.assertEqual(4, profile._min_sampled_from_batch)
 
         # When not setting min true samples/samples per update
@@ -927,10 +925,10 @@ class TestProfilerNullValues(unittest.TestCase):
         self.assertEqual(4, profile._min_sampled_from_batch)
 
         profile.update_profile(data2)
-        self.assertEqual(6, profile.row_has_null_count)
-        self.assertEqual(2, profile.row_is_null_count)
-        self.assertEqual(0.75, profile._get_row_has_null_ratio())
-        self.assertEqual(0.25, profile._get_row_is_null_ratio())
+        self.assertEqual(7, profile.row_has_null_count)
+        self.assertEqual(3, profile.row_is_null_count)
+        self.assertEqual(0.875, profile._get_row_has_null_ratio())
+        self.assertEqual(0.375, profile._get_row_is_null_ratio())
         self.assertEqual(4, profile._min_sampled_from_batch)
 
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -549,7 +549,8 @@ class TestStructuredDataProfileClass(unittest.TestCase):
         self.assertTrue(np.issubdtype(np.object_, df_series.dtype))
         self.assertCountEqual({'sample': ['4.0', '6.0', '3.0'],
                                'sample_size': 5, 'null_count': 2,
-                               'null_types': dict(nan=['e', 'b'])}, base_stats)
+                               'null_types': dict(nan=['e', 'b']),
+                               'min_id': None, 'max_id': None}, base_stats)
 
     def test_column_names(self):
         data = [['a', 1], ['b', 2], ['c', 3]]

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -662,6 +662,13 @@ class TestStructuredDataProfileClass(unittest.TestCase):
         profiler._sampling_ratio = 0.2
         self.assertEqual(10000, update_mock.call_args[0][1])
 
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnPrimitiveTypeProfileCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnStatsProfileCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnDataLabelerCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
     def test_index_overlap_resolved_for_update_profile(self):
         data = pd.Series([0, None, 1, 2, None])
         profile = StructuredDataProfile(data)
@@ -675,6 +682,13 @@ class TestStructuredDataProfileClass(unittest.TestCase):
         self.assertEqual(9, profile.max_id)
         self.assertDictEqual(profile.null_types_index, {'nan': {1, 4, 6, 9}})
 
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnPrimitiveTypeProfileCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnStatsProfileCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnDataLabelerCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
     def test_index_overlap_resolved_for_merge(self):
         data = pd.Series([0, None, 1, 2, None])
         profile1 = StructuredDataProfile(data)

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -875,7 +875,7 @@ class TestProfilerNullValues(unittest.TestCase):
         self.assertEqual(0.75, profile._get_row_has_null_ratio())
         self.assertEqual(0.25, profile._get_row_is_null_ratio())
 
-        profile.update_profile(data2)
+        profile.update_profile(data2, min_true_samples=2)
         self.assertEqual(5, profile.row_has_null_count)
         self.assertEqual(1, profile.row_is_null_count)
         self.assertEqual(0.625, profile._get_row_has_null_ratio())

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -718,15 +718,18 @@ class TestStructuredDataProfileClass(unittest.TestCase):
         profile1 = StructuredDataProfile(data[:2])
         profile2 = StructuredDataProfile(data[2:])
 
+        # Base initialization
         self.assertEqual(0, profile1.min_id)
         self.assertEqual(1, profile1.max_id)
         self.assertEqual(2, profile2.min_id)
         self.assertEqual(6, profile2.max_id)
 
+        # Needs to work with merge
         profile3 = profile1 + profile2
         self.assertEqual(0, profile3.min_id)
         self.assertEqual(6, profile3.max_id)
 
+        # Needs to work with update_profile
         profile = StructuredDataProfile(data[:2])
         profile.update_profile(data[2:])
         self.assertEqual(0, profile.min_id)

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -860,24 +860,25 @@ class TestProfilerNullValues(unittest.TestCase):
                              [None, None],
                              [None, 1],
                              [1, None],
-                             [None, 1],
                              [1, 1],
-                             [1, 1]])
+                             [None, None],
+                             [None, 1]])
         data1 = data[:4]
         data2 = data[4:]
         opts = ProfilerOptions()
         opts.structured_options.multiprocess.is_enabled = False
-        profile = dp.Profiler(data1, min_true_samples=2, profiler_options=opts)
+        profile = dp.Profiler(data1, min_true_samples=2, samples_per_update=2,
+                              profiler_options=opts)
         self.assertEqual(3, profile.row_has_null_count)
         self.assertEqual(1, profile.row_is_null_count)
         self.assertEqual(0.75, profile._get_row_has_null_ratio())
         self.assertEqual(0.25, profile._get_row_is_null_ratio())
 
-        profile.update_profile(data2, min_true_samples=2)
-        self.assertEqual(5, profile.row_has_null_count)
-        self.assertEqual(1, profile.row_is_null_count)
-        self.assertEqual(0.625, profile._get_row_has_null_ratio())
-        self.assertEqual(0.125, profile._get_row_is_null_ratio())
+        profile.update_profile(data2, min_true_samples=2, sample_size=2)
+        self.assertEqual(6, profile.row_has_null_count)
+        self.assertEqual(2, profile.row_is_null_count)
+        self.assertEqual(0.75, profile._get_row_has_null_ratio())
+        self.assertEqual(0.25, profile._get_row_is_null_ratio())
 
 
 if __name__ == '__main__':

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -667,13 +667,29 @@ class TestStructuredDataProfileClass(unittest.TestCase):
         profile = StructuredDataProfile(data)
         self.assertEqual(0, profile.min_id)
         self.assertEqual(4, profile.max_id)
-        expected_dict = {'nan': {1, 4}}
-        self.assertDictEqual(profile.null_types_index, expected_dict)
+        self.assertDictEqual(profile.null_types_index, {'nan': {1, 4}})
         profile.update_profile(data)
         # Now all indices will be shifted by max_id + 1 (5)
         # So the 2 None will move from indices 1, 4 to 6, 9
-        expected_dict = {'nan': {1, 4, 6, 9}}
-        self.assertDictEqual(profile.null_types_index, expected_dict)
+        self.assertEqual(0, profile.min_id)
+        self.assertEqual(9, profile.max_id)
+        self.assertDictEqual(profile.null_types_index, {'nan': {1, 4, 6, 9}})
+
+    def test_index_overlap_resolved_for_merge(self):
+        data = pd.Series([0, None, 1, 2, None], index=[0, 1, 2, 3, 4])
+        profile1 = StructuredDataProfile(data)
+        profile2 = StructuredDataProfile(data)
+
+        # Ensure merged profile included shifted indices
+        profile3 = profile1 + profile2
+        self.assertEqual(0, profile3.min_id)
+        self.assertEqual(9, profile3.max_id)
+        self.assertDictEqual(profile3.null_types_index, {'nan': {1, 4, 6, 9}})
+
+        # Ensure original profile not overwritten
+        self.assertEqual(0, profile2.min_id)
+        self.assertEqual(4, profile2.max_id)
+        self.assertDictEqual(profile2.null_types_index, {'nan': {1, 4}})
 
 
 class TestProfilerNullValues(unittest.TestCase):

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -849,6 +849,38 @@ class TestProfilerNullValues(unittest.TestCase):
         self.assertEqual(0.5, profile2._get_row_is_null_ratio())
         self.assertEqual(1, profile2._get_row_has_null_ratio())
 
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnPrimitiveTypeProfileCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnStatsProfileCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnDataLabelerCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
+    def test_null_row_stats_correct_after_updates(self, *mocks):
+        data = pd.DataFrame([[1, None],
+                             [1, 1],
+                             [None, None],
+                             [None, 1],
+                             [1, None],
+                             [None, 1],
+                             [1, 1],
+                             [1, 1]])
+        data1 = data[:4]
+        data2 = data[4:]
+        opts = ProfilerOptions()
+        opts.structured_options.multiprocess.is_enabled = False
+        profile = dp.Profiler(data1, min_true_samples=2, profiler_options=opts)
+        self.assertEqual(3, profile.row_has_null_count)
+        self.assertEqual(1, profile.row_is_null_count)
+        self.assertEqual(0.75, profile._get_row_has_null_ratio())
+        self.assertEqual(0.25, profile._get_row_is_null_ratio())
+
+        profile.update_profile(data2)
+        self.assertEqual(5, profile.row_has_null_count)
+        self.assertEqual(1, profile.row_is_null_count)
+        self.assertEqual(0.625, profile._get_row_has_null_ratio())
+        self.assertEqual(0.125, profile._get_row_is_null_ratio())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -662,6 +662,19 @@ class TestStructuredDataProfileClass(unittest.TestCase):
         profiler._sampling_ratio = 0.2
         self.assertEqual(10000, update_mock.call_args[0][1])
 
+    def test_index_overlap_resolved_for_update_profile(self):
+        data = pd.Series([0, None, 1, 2, None], index=[0, 1, 2, 3, 4])
+        profile = StructuredDataProfile(data)
+        self.assertEqual(0, profile.min_id)
+        self.assertEqual(4, profile.max_id)
+        expected_dict = {'nan': {1, 4}}
+        self.assertDictEqual(profile.null_types_index, expected_dict)
+        profile.update_profile(data)
+        # Now all indices will be shifted by max_id + 1 (5)
+        # So the 2 None will move from indices 1, 4 to 6, 9
+        expected_dict = {'nan': {1, 4, 6, 9}}
+        self.assertDictEqual(profile.null_types_index, expected_dict)
+
 
 class TestProfilerNullValues(unittest.TestCase):
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -673,14 +673,14 @@ class TestStructuredDataProfileClass(unittest.TestCase):
     def test_index_overlap_for_update_profile(self, *mocks):
         data = pd.Series([0, None, 1, 2, None])
         profile = StructuredDataProfile(data)
-        self.assertEqual(0, profile.min_id)
-        self.assertEqual(4, profile.max_id)
+        self.assertEqual(0, profile._min_id)
+        self.assertEqual(4, profile._max_id)
         self.assertDictEqual(profile.null_types_index, {'nan': {1, 4}})
         profile.update_profile(data)
         # Now all indices will be shifted by max_id + 1 (5)
         # So the 2 None will move from indices 1, 4 to 6, 9
-        self.assertEqual(0, profile.min_id)
-        self.assertEqual(9, profile.max_id)
+        self.assertEqual(0, profile._min_id)
+        self.assertEqual(9, profile._max_id)
         self.assertDictEqual(profile.null_types_index, {'nan': {1, 4, 6, 9}})
 
     @mock.patch('dataprofiler.profilers.profile_builder.'
@@ -697,16 +697,16 @@ class TestStructuredDataProfileClass(unittest.TestCase):
 
         # Ensure merged profile included shifted indices
         profile3 = profile1 + profile2
-        self.assertEqual(0, profile3.min_id)
-        self.assertEqual(9, profile3.max_id)
+        self.assertEqual(0, profile3._min_id)
+        self.assertEqual(9, profile3._max_id)
         self.assertDictEqual(profile3.null_types_index, {'nan': {1, 4, 6, 9}})
 
         # Ensure original profiles not overwritten
-        self.assertEqual(0, profile1.min_id)
-        self.assertEqual(4, profile1.max_id)
+        self.assertEqual(0, profile1._min_id)
+        self.assertEqual(4, profile1._max_id)
         self.assertDictEqual(profile1.null_types_index, {'nan': {1, 4}})
-        self.assertEqual(0, profile2.min_id)
-        self.assertEqual(4, profile2.max_id)
+        self.assertEqual(0, profile2._min_id)
+        self.assertEqual(4, profile2._max_id)
         self.assertDictEqual(profile2.null_types_index, {'nan': {1, 4}})
 
     @mock.patch('dataprofiler.profilers.profile_builder.'
@@ -722,21 +722,21 @@ class TestStructuredDataProfileClass(unittest.TestCase):
         profile2 = StructuredDataProfile(data[2:])
 
         # Base initialization
-        self.assertEqual(0, profile1.min_id)
-        self.assertEqual(1, profile1.max_id)
-        self.assertEqual(2, profile2.min_id)
-        self.assertEqual(6, profile2.max_id)
+        self.assertEqual(0, profile1._min_id)
+        self.assertEqual(1, profile1._max_id)
+        self.assertEqual(2, profile2._min_id)
+        self.assertEqual(6, profile2._max_id)
 
         # Needs to work with merge
         profile3 = profile1 + profile2
-        self.assertEqual(0, profile3.min_id)
-        self.assertEqual(6, profile3.max_id)
+        self.assertEqual(0, profile3._min_id)
+        self.assertEqual(6, profile3._max_id)
 
         # Needs to work with update_profile
         profile = StructuredDataProfile(data[:2])
         profile.update_profile(data[2:])
-        self.assertEqual(0, profile.min_id)
-        self.assertEqual(6, profile.max_id)
+        self.assertEqual(0, profile._min_id)
+        self.assertEqual(6, profile._max_id)
 
 
 class TestProfilerNullValues(unittest.TestCase):

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -663,7 +663,7 @@ class TestStructuredDataProfileClass(unittest.TestCase):
         self.assertEqual(10000, update_mock.call_args[0][1])
 
     def test_index_overlap_resolved_for_update_profile(self):
-        data = pd.Series([0, None, 1, 2, None], index=[0, 1, 2, 3, 4])
+        data = pd.Series([0, None, 1, 2, None])
         profile = StructuredDataProfile(data)
         self.assertEqual(0, profile.min_id)
         self.assertEqual(4, profile.max_id)
@@ -676,7 +676,7 @@ class TestStructuredDataProfileClass(unittest.TestCase):
         self.assertDictEqual(profile.null_types_index, {'nan': {1, 4, 6, 9}})
 
     def test_index_overlap_resolved_for_merge(self):
-        data = pd.Series([0, None, 1, 2, None], index=[0, 1, 2, 3, 4])
+        data = pd.Series([0, None, 1, 2, None])
         profile1 = StructuredDataProfile(data)
         profile2 = StructuredDataProfile(data)
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -706,6 +706,32 @@ class TestStructuredDataProfileClass(unittest.TestCase):
         self.assertEqual(4, profile2.max_id)
         self.assertDictEqual(profile2.null_types_index, {'nan': {1, 4}})
 
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnPrimitiveTypeProfileCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnStatsProfileCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnDataLabelerCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
+    def test_min_max_id_properly_update(self, *mocks):
+        data = pd.Series([1, None, 3, 4, 5, None, 1])
+        profile1 = StructuredDataProfile(data[:2])
+        profile2 = StructuredDataProfile(data[2:])
+
+        self.assertEqual(0, profile1.min_id)
+        self.assertEqual(1, profile1.max_id)
+        self.assertEqual(2, profile2.min_id)
+        self.assertEqual(6, profile2.max_id)
+
+        profile3 = profile1 + profile2
+        self.assertEqual(0, profile3.min_id)
+        self.assertEqual(6, profile3.max_id)
+
+        profile = StructuredDataProfile(data[:2])
+        profile.update_profile(data[2:])
+        self.assertEqual(0, profile.min_id)
+        self.assertEqual(6, profile.max_id)
+
 
 class TestProfilerNullValues(unittest.TestCase):
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -793,13 +793,11 @@ class TestProfilerNullValues(unittest.TestCase):
         for i in range(2):
             
             # Profile Once
-            # TODO: bc currently don't handle overlapping indexes
             data.index = pd.RangeIndex(0, 8)
             profile = dp.Profiler(data, profiler_options=profiler_options,
                                   samples_per_update=2)
 
             # Profile Twice
-            # TODO: bc currently don't handle overlapping indexes
             data.index = pd.RangeIndex(8, 16)
             profile.update_profile(data)
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -10,6 +10,7 @@ import re
 
 import numpy as np
 import pandas as pd
+from io import BytesIO
 
 from . import utils as test_utils
 
@@ -26,13 +27,13 @@ from dataprofiler.profilers.helpers.report_helpers import _prepare_report
 
 test_root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
-from io import BytesIO
 
 def setup_save_mock_open(mock_open):
     mock_file = BytesIO()
     mock_file.close = lambda: None
     mock_open.side_effect = lambda *args: mock_file
     return mock_file
+
 
 class TestProfiler(unittest.TestCase):
 
@@ -669,7 +670,7 @@ class TestStructuredDataProfileClass(unittest.TestCase):
     @mock.patch('dataprofiler.profilers.profile_builder.'
                 'ColumnDataLabelerCompiler')
     @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
-    def test_index_overlap_resolved_for_update_profile(self):
+    def test_index_overlap_resolved_for_update_profile(self, *mocks):
         data = pd.Series([0, None, 1, 2, None])
         profile = StructuredDataProfile(data)
         self.assertEqual(0, profile.min_id)
@@ -689,7 +690,7 @@ class TestStructuredDataProfileClass(unittest.TestCase):
     @mock.patch('dataprofiler.profilers.profile_builder.'
                 'ColumnDataLabelerCompiler')
     @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
-    def test_index_overlap_resolved_for_merge(self):
+    def test_index_overlap_resolved_for_merge(self, *mocks):
         data = pd.Series([0, None, 1, 2, None])
         profile1 = StructuredDataProfile(data)
         profile2 = StructuredDataProfile(data)

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -907,12 +907,14 @@ class TestProfilerNullValues(unittest.TestCase):
         self.assertEqual(1, profile.row_is_null_count)
         self.assertEqual(0.75, profile._get_row_has_null_ratio())
         self.assertEqual(0.25, profile._get_row_is_null_ratio())
+        self.assertEqual(4, profile._min_sampled_from_batch)
 
         profile.update_profile(data2, min_true_samples=2, sample_size=2)
         self.assertEqual(6, profile.row_has_null_count)
         self.assertEqual(2, profile.row_is_null_count)
         self.assertEqual(0.75, profile._get_row_has_null_ratio())
         self.assertEqual(0.25, profile._get_row_is_null_ratio())
+        self.assertEqual(4, profile._min_sampled_from_batch)
 
         # When not setting min true samples/samples per update
         opts = ProfilerOptions()
@@ -922,12 +924,14 @@ class TestProfilerNullValues(unittest.TestCase):
         self.assertEqual(1, profile.row_is_null_count)
         self.assertEqual(0.75, profile._get_row_has_null_ratio())
         self.assertEqual(0.25, profile._get_row_is_null_ratio())
+        self.assertEqual(4, profile._min_sampled_from_batch)
 
         profile.update_profile(data2)
         self.assertEqual(6, profile.row_has_null_count)
         self.assertEqual(2, profile.row_is_null_count)
         self.assertEqual(0.75, profile._get_row_has_null_ratio())
         self.assertEqual(0.25, profile._get_row_is_null_ratio())
+        self.assertEqual(4, profile._min_sampled_from_batch)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
See #167 

Shifts indices in StructuredProfile.update_profile and StructuredProfile.__add__ to make null row index dictionary accurate.

Also fixes separate issue discovered where when updating a Profile due to the fix in a previous PR where the null rows where truncated only to consider ones that were fully sampled, at update this accidentally removed all former null row statistics and the return from update_row_statistics only reflected data given to a specific update not the entire data set.