### PR TITLE
CSVData shouldn't combine all records -> single sample, default 1

### DIFF
--- a/dataprofiler/data_readers/csv_data.py
+++ b/dataprofiler/data_readers/csv_data.py
@@ -35,24 +35,22 @@ class CSVData(SpreadSheetDataMixin, BaseData):
             options = dict(
                 delimiter= type: str
                 data_format= type: str, choices: "dataframe", "records"
+                record_samples_per_line= type: int (only for "records")
                 selected_columns= type: list(str)
                 header= type: any
             )
 
         delimiter: delimiter used to decipher the csv input file
-
         data_format: user selected format in which to return data
         can only be of specified types:
         ```
         dataframe - (default) loads the dataset as a pandas.DataFrame
-        records - loads the data as rows of text values, the extra parameter
-        "record_samples_per_line" how many rows are combined into a single line
+        records   - loads the data as rows of text values, the extra parameter
+            "record_samples_per_line" determines how many rows are combined into
+            a single line
         ```
-
         selected_columns: columns being selected from the entire dataset
-
         header: location of the header in the file
-
         quotechar: quote character used in the delimited file
 
         :param input_file_path: path to the file being loaded or None

--- a/dataprofiler/data_readers/csv_data.py
+++ b/dataprofiler/data_readers/csv_data.py
@@ -43,7 +43,8 @@ class CSVData(SpreadSheetDataMixin, BaseData):
         data_format: user selected format in which to return data
         can only be of specified types
         selected_columns: columns being selected from the entire dataset
-        header: any information pertaining to the file header.
+        header: location of the header in the file
+        quotechar: quote character used in the delimited file
         :param input_file_path: path to the file being loaded or None
         :type input_file_path: str
         :param data: data being loaded into the class instead of an input file
@@ -66,6 +67,8 @@ class CSVData(SpreadSheetDataMixin, BaseData):
         #  _selected_columns: columns being selected from the entire dataset
         #  _header: any information pertaining to the file header.
         self._data_formats["records"] = self._get_data_as_records
+        self.SAMPLES_PER_LINE_DEFAULT = options.get("record_samples_per_line",
+                                                    1)
         self._selected_data_format = options.get("data_format", "dataframe")
         self._delimiter = options.get("delimiter", None)
         self._quotechar = options.get("quotechar", None)
@@ -108,7 +111,7 @@ class CSVData(SpreadSheetDataMixin, BaseData):
         """
         options = super()._check_and_return_options(options)
         
-        if 'header' in options.keys():
+        if 'header' in options:
             value = options["header"]
             if value != 'auto' and value is not None \
                 and not (isinstance(value, int) and value > -1):
@@ -116,22 +119,28 @@ class CSVData(SpreadSheetDataMixin, BaseData):
                                  'none for no header, or a non-negative '
                                  'integer for the row that represents the '
                                  'header (0 based index)')
-        if 'delimiter' in options.keys():
+        if 'delimiter' in options:
             value = options["delimiter"]
             if value is not None and not isinstance(value, str):
                 raise ValueError("'delimiter' must be a string or None")
-        if 'data_format' in options.keys():
+        if 'data_format' in options:
             value = options["data_format"]
             if value not in ["dataframe", "records"]:
                 raise ValueError("'data_format' must be one of the following: "
                                  "'dataframe' or 'records' ")
-        if 'selected_columns' in options.keys():
+        if 'selected_columns' in options:
             value = options["selected_columns"]
             if not isinstance(value, list):
                 raise ValueError("'selected_columns' must be a list")
             for sc in value:
                 if not isinstance(sc, str):
-                    raise ValueError("'selected_columns' must be a list of strings")
+                    raise ValueError("'selected_columns' must be a list of "
+                                     "strings")
+        if 'record_samples_per_line' in options:
+            value = options['record_samples_per_line']
+            if not isinstance(value, int) or value < 0:
+                raise ValueError("'record_samples_per_line' must be an int "
+                                 "more than 0")
         return options
 
     
@@ -519,7 +528,6 @@ class CSVData(SpreadSheetDataMixin, BaseData):
                 if count_delimiter_last == num_lines_read:
                     self._delimiter = None
 
-        
         return data_utils.read_csv_df(
             input_file_path,
             self.delimiter, self.header, self.selected_columns,

--- a/dataprofiler/data_readers/csv_data.py
+++ b/dataprofiler/data_readers/csv_data.py
@@ -40,11 +40,21 @@ class CSVData(SpreadSheetDataMixin, BaseData):
             )
 
         delimiter: delimiter used to decipher the csv input file
+
         data_format: user selected format in which to return data
-        can only be of specified types
+        can only be of specified types:
+        ```
+        dataframe - (default) loads the dataset as a pandas.DataFrame
+        records - loads the data as rows of text values, the extra parameter
+        "record_samples_per_line" how many rows are combined into a single line
+        ```
+
         selected_columns: columns being selected from the entire dataset
+
         header: location of the header in the file
+
         quotechar: quote character used in the delimited file
+
         :param input_file_path: path to the file being loaded or None
         :type input_file_path: str
         :param data: data being loaded into the class instead of an input file

--- a/dataprofiler/tests/data_readers/test_csv_data.py
+++ b/dataprofiler/tests/data_readers/test_csv_data.py
@@ -342,8 +342,14 @@ class TestCSVDataClass(unittest.TestCase):
             expected_error="'selected_columns' must be a list")
         
         _test_options(
-            "selected_columns", valid=[], invalid=[[0,1,2,3]],
+            "selected_columns", valid=[], invalid=[[0, 1, 2, 3]],
             expected_error="'selected_columns' must be a list of strings")
+
+        _test_options(
+            "record_samples_per_line", valid=[1, 10],
+            invalid=[[-1, int, '', None, dict()]],
+            expected_error="'record_samples_per_line' must be an int more than "
+                           "0")
 
         # test edge case for header being set
         file = self.input_file_names[0]


### PR DESCRIPTION
Allows the user to set how many rows are combined together when reading a CSVData with data format `records`.

Necessary change with update of examples.

```python
filepath = "dataprofiler/tests/data/csv/diamonds.csv"

options = {'data_format': 'records', 'record_samples_per_line': 1}
data = dp.Data(filepath, options=options)
data.data[:5]
```

with new code (default value 1):
```
['carat,cut,color,clarity,depth,table,price,x,y,z',
 '0.23,Ideal,E,SI2,61.5,55,326,3.95,3.98,2.43',
 '0.21,Premium,E,SI1,59.8,61,326,3.89,3.84,2.31',
 '0.23,Good,E,VS1,56.9,65,327,4.05,4.07,2.31',
 '0.29,Premium,I,VS2,62.4,58,334,4.2,4.23,2.63']
 ```
previous code:
```
['carat,cut,color,clarity,depth,table,price,x,y,z\n0.23,Ideal,E,SI2,61.5,55,326,3.95,3.98,2.43\n0.21,Premium,E,SI1,59.8,61,326,3.89,3.84,2.31\n0.23,Good,E,VS1,56.9,65,327,4.05,4.07,2.31\n0.29,Premium,I,VS2,62.4,58,334,4.2,4.23,2.63\n0.31,Good,J,SI2,63.3,58,335,4.34,4.35,2.75\n0.24,Very Good,J,VVS2,62.8,57,336,3.94,3.96,2.48\n0.24,Very Good,I,VVS1,62.3,57,336,3.95,3.98,2.47\n0.26,Very Good,H,SI1,61.9,55,337,4.07,4.11,2.53\n0.22,Fair,E,VS2,65.1,61,337,3.87,3.78,2.49\n0.23,Very Good,H,VS1,59.4,61,338,4,4.05,2.39\n0.3,Good,J,SI1,64,55,339,4.25,4.28,2.73\n0.23,Ideal,J,VS1,62.8,56,340,3.93,3.9,2.46\n0.22,Premium,F,SI1,60.4,61,342,3.88,3.84,2.33\n0.31,Ideal,J,SI2,62.2,54,344,4.35,4.37,2.71\n0.2,Premium,E,SI2,60.2,62,345,3.79,3.75,2.27\n0.32,Premium,E,I1,60.9,58,345,4.38,4.42,2.68\n0.3,Ideal,I,SI2,62,54,348,4.31,4.34,2.68\n0.3,Good,J,SI1,63.4,54,351,4.23,4.29,2.7\n0.3,Good,J,SI1,63.8,56,351,4.23,4.26,2.71\n0.3,Very Good,J,SI1,62.7,59,351,4.21,4.27, ........
.
.
.
]
```