### PR TITLE
Allows user to reload data that already was loaded if no file path specified originally

### DIFF
--- a/dataprofiler/data_readers/avro_data.py
+++ b/dataprofiler/data_readers/avro_data.py
@@ -62,6 +62,8 @@ class AVROData(JSONData, BaseData):
         :return: is file a avro file or not
         :rtype: bool
         """
+        if options is None:
+            options = dict()
 
         is_valid_avro = fastavro.is_avro(file_path)
         return is_valid_avro

--- a/dataprofiler/data_readers/base_data.py
+++ b/dataprofiler/data_readers/base_data.py
@@ -142,8 +142,9 @@ class BaseData(object):
             raise ValueError(
                 "Reloaded dataset does not match the specified data_type"
             )
+        elif input_file_path:
+            self.input_file_path = input_file_path
         self._data = None
-        self.input_file_path = None
         self._tmp_file_name = None
         self.options = None
         self._batch_info = dict(perm=list(), iter=0)

--- a/dataprofiler/data_readers/csv_data.py
+++ b/dataprofiler/data_readers/csv_data.py
@@ -1,11 +1,8 @@
-import re
 import csv
 import re
-from itertools import islice
 from six import StringIO
 
 import random
-import dateutil
 from collections import Counter
 
 import numpy as np
@@ -567,6 +564,9 @@ class CSVData(SpreadSheetDataMixin, BaseData):
         if JSONData.is_match(file_path) or ParquetData.is_match(file_path) \
                 or AVROData.is_match(file_path):
             return False
+
+        if options is None:
+            options = dict()
 
         file_encoding = data_utils.detect_file_encoding(file_path=file_path)
         delimiter = options.get("delimiter", None)

--- a/dataprofiler/data_readers/csv_data.py
+++ b/dataprofiler/data_readers/csv_data.py
@@ -677,4 +677,4 @@ class CSVData(SpreadSheetDataMixin, BaseData):
             header=self.header, delimiter=self.delimiter, quotechar=self.quotechar
         )
         super(CSVData, self).reload(input_file_path, data, options)
-        self.__init__(input_file_path, data, options)
+        self.__init__(self.input_file_path, data, options)

--- a/dataprofiler/data_readers/csv_data.py
+++ b/dataprofiler/data_readers/csv_data.py
@@ -41,7 +41,6 @@ class CSVData(SpreadSheetDataMixin, BaseData):
             )
 
         delimiter: delimiter used to decipher the csv input file
-
         data_format: user selected format in which to return data
         can only be of specified types:
         ```
@@ -51,9 +50,7 @@ class CSVData(SpreadSheetDataMixin, BaseData):
             a single line
         ```
         selected_columns: columns being selected from the entire dataset
-
         header: location of the header in the file
-
         quotechar: quote character used in the delimited file
 
         :param input_file_path: path to the file being loaded or None

--- a/dataprofiler/data_readers/csv_data.py
+++ b/dataprofiler/data_readers/csv_data.py
@@ -41,6 +41,7 @@ class CSVData(SpreadSheetDataMixin, BaseData):
             )
 
         delimiter: delimiter used to decipher the csv input file
+
         data_format: user selected format in which to return data
         can only be of specified types:
         ```
@@ -50,7 +51,9 @@ class CSVData(SpreadSheetDataMixin, BaseData):
             a single line
         ```
         selected_columns: columns being selected from the entire dataset
+
         header: location of the header in the file
+
         quotechar: quote character used in the delimited file
 
         :param input_file_path: path to the file being loaded or None

--- a/dataprofiler/data_readers/json_data.py
+++ b/dataprofiler/data_readers/json_data.py
@@ -352,6 +352,9 @@ class JSONData(SpreadSheetDataMixin, BaseData):
         valid_json_line_count = 0
         total_line_count = 0
 
+        if options is None:
+            options = dict()
+
         file_encoding = data_utils.detect_file_encoding(file_path=file_path)
         with open(file_path, 'r', encoding=file_encoding) as data_file:
             try:

--- a/dataprofiler/data_readers/json_data.py
+++ b/dataprofiler/data_readers/json_data.py
@@ -397,4 +397,4 @@ class JSONData(SpreadSheetDataMixin, BaseData):
         """
         self._selected_keys = None
         super(JSONData, self).reload(input_file_path, data, options)
-        self.__init__(input_file_path, data, options)
+        self.__init__(self.input_file_path, data, options)

--- a/dataprofiler/data_readers/parquet_data.py
+++ b/dataprofiler/data_readers/parquet_data.py
@@ -124,4 +124,4 @@ class ParquetData(SpreadSheetDataMixin, BaseData):
         :return: None
         """
         super(ParquetData, self).reload(input_file_path, data, options)
-        self.__init__(input_file_path, data, options)
+        self.__init__(self.input_file_path, data, options)

--- a/dataprofiler/data_readers/parquet_data.py
+++ b/dataprofiler/data_readers/parquet_data.py
@@ -102,6 +102,9 @@ class ParquetData(SpreadSheetDataMixin, BaseData):
         :return: is file a parquet file or not
         :rtype: bool
         """
+        if options is None:
+            options = dict()
+
         try:
             pfile = pq.ParquetFile(file_path)
             is_valid_parquet = True

--- a/dataprofiler/data_readers/text_data.py
+++ b/dataprofiler/data_readers/text_data.py
@@ -123,4 +123,4 @@ class TextData(BaseData):
         :return: None
         """
         super(TextData, self).reload(input_file_path, data, options)
-        self.__init__(input_file_path, data, options)
+        self.__init__(self.input_file_path, data, options)


### PR DESCRIPTION
Previous:
```python
filepath = "../dataprofiler/tests/data/csv/diamonds.csv"

data = dp.Data(filepath)
data.reload(options={...}) 
# RAISES ERROR, FAILES
```
PR fix:
```python
filepath = "../dataprofiler/tests/data/csv/diamonds.csv"

data = dp.Data(filepath)
data.reload(options={...}) 
# RELOADS ORIGINAL DATA WITH NEW OPTIONS
```