### PR TITLE
add save / load to unstructured profiler

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -780,6 +780,76 @@ class UnstructuredProfiler(object):
 
         self._update_profile_from_chunk(data, sample_size, min_true_samples)
 
+    def _remove_data_labelers(self):
+        """
+        Helper method for removing all data labelers before saving to disk.
+
+        :return: data_labeler use for unstructured labeling
+        :rtype: DataLabeler
+        """
+        data_labeler = None
+
+        # Delete data labeler for profiler
+        # TODO: fix to correct options when unstructured options avail
+        use_data_labeler = True
+        if self.options and isinstance(self.options, ProfilerOptions):
+            data_labeler_options = self.options.structured_options.data_labeler
+            use_data_labeler = data_labeler_options.is_enabled
+        if use_data_labeler \
+                and data_labeler_options.data_labeler_object is not None:
+            data_labeler = data_labeler_options.data_labeler_object
+            data_labeler_options.data_labeler_object = None
+
+        # remove data labelers
+        # TODO: fix to correct options when unstructured options avail
+        if use_data_labeler:
+            if data_labeler is None:
+                data_labeler = \
+                    self._profile._profiles['data_labeler'].data_labeler
+            self._profile._profiles['data_labeler'].data_labeler = None
+
+        return data_labeler
+
+    def _restore_data_labelers(self, data_labeler=None):
+        """
+        Helper method for restoring all data labelers after saving to or
+        loading from disk.
+
+        :param data_labeler: unstructured data_labeler
+        :type data_labeler: DataLabeler
+        """
+        # Restore data labeler for profiler
+        # TODO: fix to correct options when unstructured options avail
+        use_data_labeler = True
+        data_labeler_options = None
+        if self.options and isinstance(self.options, ProfilerOptions):
+            data_labeler_options = self.options.structured_options.data_labeler
+            use_data_labeler = data_labeler_options.is_enabled
+
+        if use_data_labeler:
+            try:
+                if data_labeler is None and data_labeler_options is None:
+                    data_labeler = DataLabeler(
+                        labeler_type='unstructured',
+                        dirpath=None,
+                        load_options=None)
+                elif data_labeler is None:
+                    data_labeler = DataLabeler(
+                        labeler_type='unstructured',
+                        dirpath=data_labeler_options.data_labeler_dirpath,
+                        load_options=None)
+                self.options.set(
+                    {'data_labeler.data_labeler_object': data_labeler})
+
+            except Exception as e:
+                utils.warn_on_profile('data_labeler', e)
+                self.options.set({'data_labeler.is_enabled': False})
+
+        # Restore data labelers for all columns
+        if use_data_labeler:
+            data_labeler_profile = self._profile._profiles['data_labeler']
+            data_labeler_profile.data_labeler = data_labeler
+
     def save(self, filepath=None):
         """
         Save profiler to disk
@@ -788,7 +858,31 @@ class UnstructuredProfiler(object):
         :type filepath: String
         :return: None
         """
-        raise NotImplementedError()
+        # Set Default filepath
+        if filepath is None:
+            filepath = "profile-{}.pkl".format(
+                datetime.now().strftime("%d-%b-%Y-%H:%M:%S.%f"))
+
+        # Remove the data labeler as they can't be pickled
+        data_labeler = self._remove_data_labelers()
+
+        # Create dictionary for all metadata, options, and profile
+        data = {
+            "total_samples": self.total_samples,
+            "encoding": self.encoding,
+            "file_type": self.file_type,
+            "_samples_per_update": self._samples_per_update,
+            "_min_true_samples": self._min_true_samples,
+            "options": self.options,
+            "_profile": self.profile
+        }
+
+        # Pickle and save profile to disk
+        with open(filepath, "wb") as outfile:
+            pickle.dump(data, outfile)
+
+        # Restore all data labelers
+        self._restore_data_labelers(data_labeler)
 
     @classmethod
     def load(cls, filepath):
@@ -799,7 +893,28 @@ class UnstructuredProfiler(object):
         :type filepath: String
         :return: None
         """
-        raise NotImplementedError()
+        # Create Empty Profile
+        # TODO: fix options when unstructured options is available
+        profile_options = ProfilerOptions()
+        profile_options.structured_options.data_labeler.is_enabled = False
+        profile = cls(pd.DataFrame([]), options=profile_options)
+
+        # Load profile from disk
+        with open(filepath, "rb") as infile:
+            data = pickle.load(infile)
+
+            profile.total_samples = data["total_samples"]
+            profile.encoding = data["encoding"]
+            profile.file_type = data["file_type"]
+            profile._samples_per_update = data["_samples_per_update"]
+            profile._min_true_samples = data["_min_true_samples"]
+            profile._profile = data["_profile"]
+            profile.options = data["options"]
+
+        # Restore all data labelers
+        profile._restore_data_labelers()
+
+        return profile
 
 
 class Profiler(object):

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -789,19 +789,20 @@ class UnstructuredProfiler(object):
         """
         data_labeler = None
 
-        # Delete data labeler for profiler
+        # determine if the data labeler is enabled
         # TODO: fix to correct options when unstructured options avail
         use_data_labeler = True
         if self.options and isinstance(self.options, ProfilerOptions):
             data_labeler_options = self.options.structured_options.data_labeler
             use_data_labeler = data_labeler_options.is_enabled
+
+        # remove the data labeler from options
         if use_data_labeler \
                 and data_labeler_options.data_labeler_object is not None:
             data_labeler = data_labeler_options.data_labeler_object
             data_labeler_options.data_labeler_object = None
 
-        # remove data labelers
-        # TODO: fix to correct options when unstructured options avail
+        # remove the data labeler from the unstructured profiler
         if use_data_labeler:
             if data_labeler is None:
                 data_labeler = \
@@ -818,7 +819,7 @@ class UnstructuredProfiler(object):
         :param data_labeler: unstructured data_labeler
         :type data_labeler: DataLabeler
         """
-        # Restore data labeler for profiler
+        # Restore data labeler for options
         # TODO: fix to correct options when unstructured options avail
         use_data_labeler = True
         data_labeler_options = None
@@ -845,7 +846,7 @@ class UnstructuredProfiler(object):
                 utils.warn_on_profile('data_labeler', e)
                 self.options.set({'data_labeler.is_enabled': False})
 
-        # Restore data labelers for all columns
+        # Restore data labelers for unstructured data labeling
         if use_data_labeler:
             data_labeler_profile = self._profile._profiles['data_labeler']
             data_labeler_profile.data_labeler = data_labeler

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1123,6 +1123,29 @@ class TestUnstructuredProfilerWData(unittest.TestCase):
             expected_word_count,
             report['data_stats']['statistics']['word_count'])
 
+    def test_save_and_load(self):
+        datapth = "dataprofiler/tests/data/"
+        test_files = ["txt/code.txt", "txt/sentence-10x.txt"]
+
+        for test_file in test_files:
+            # Create Data and Profiler objects
+            data = dp.Data(os.path.join(datapth, test_file))
+            save_profile = UnstructuredProfiler(data)
+
+            # Save and Load profile with Mock IO
+            with mock.patch('builtins.open') as m:
+                mock_file = setup_save_mock_open(m)
+                save_profile.save()
+                mock_file.seek(0)
+                with mock.patch('dataprofiler.profilers.profile_builder.'
+                                'DataLabeler'):
+                    load_profile = UnstructuredProfiler.load("mock.pkl")
+
+            # Check that reports are equivalent
+            save_report = save_profile.report()
+            load_report = load_profile.report()
+            self.assertDictEqual(save_report, load_report)
+
 
 class TestProfilerNullValues(unittest.TestCase):
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1133,6 +1133,7 @@ class TestUnstructuredProfilerWData(unittest.TestCase):
             save_profile = UnstructuredProfiler(data)
 
             # store the expected data_labeler
+            # TODO: update to use unstructured options when available
             data_labeler = save_profile.options.structured_options.data_labeler\
                 .data_labeler_object
 
@@ -1142,9 +1143,11 @@ class TestUnstructuredProfilerWData(unittest.TestCase):
                 save_profile.save()
 
                 # make sure data_labeler unchanged
+                # TODO: update to use unstructured options when available
                 self.assertIs(
                     data_labeler,
-                    save_profile.options.structured_options.data_labeler.data_labeler_object)
+                    save_profile.options.structured_options.data_labeler.
+                        data_labeler_object)
                 self.assertIs(
                     data_labeler,
                     save_profile._profile._profiles['data_labeler'].data_labeler)
@@ -1155,6 +1158,7 @@ class TestUnstructuredProfilerWData(unittest.TestCase):
                     load_profile = UnstructuredProfiler.load("mock.pkl")
 
             # validate loaded profile has same data labeler class
+            # TODO: update to use unstructured options when available
             self.assertIsInstance(
                 load_profile.options.structured_options.data_labeler.
                     data_labeler_object,

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1124,27 +1124,53 @@ class TestUnstructuredProfilerWData(unittest.TestCase):
             report['data_stats']['statistics']['word_count'])
 
     def test_save_and_load(self):
-        datapth = "dataprofiler/tests/data/"
+        data_folder = "dataprofiler/tests/data/"
         test_files = ["txt/code.txt", "txt/sentence-10x.txt"]
 
         for test_file in test_files:
             # Create Data and Profiler objects
-            data = dp.Data(os.path.join(datapth, test_file))
+            data = dp.Data(os.path.join(data_folder, test_file))
             save_profile = UnstructuredProfiler(data)
+
+            # store the expected data_labeler
+            data_labeler = save_profile.options.structured_options.data_labeler\
+                .data_labeler_object
 
             # Save and Load profile with Mock IO
             with mock.patch('builtins.open') as m:
                 mock_file = setup_save_mock_open(m)
                 save_profile.save()
+
+                # make sure data_labeler unchanged
+                self.assertIs(
+                    data_labeler,
+                    save_profile.options.structured_options.data_labeler.data_labeler_object)
+                self.assertIs(
+                    data_labeler,
+                    save_profile._profile._profiles['data_labeler'].data_labeler)
+
                 mock_file.seek(0)
                 with mock.patch('dataprofiler.profilers.profile_builder.'
-                                'DataLabeler'):
+                                'DataLabeler', return_value=data_labeler):
                     load_profile = UnstructuredProfiler.load("mock.pkl")
+
+            # validate loaded profile has same data labeler class
+            self.assertIsInstance(
+                load_profile.options.structured_options.data_labeler.
+                    data_labeler_object,
+                data_labeler.__class__)
+            self.assertIsInstance(
+                load_profile.profile._profiles['data_labeler'].data_labeler,
+                data_labeler.__class__)
 
             # Check that reports are equivalent
             save_report = save_profile.report()
             load_report = load_profile.report()
             self.assertDictEqual(save_report, load_report)
+
+            # validate both are still usable after
+            save_profile.update_profile(pd.DataFrame(['test']))
+            load_profile.update_profile(pd.DataFrame(['test']))
 
 
 class TestProfilerNullValues(unittest.TestCase):


### PR DESCRIPTION
Adds the save / load functions to the unstructured profiler: finishes addressing - https://github.com/capitalone/DataProfiler/issues/165