### PR TITLE
Remove PAD from structured labeling output

### DIFF
--- a/dataprofiler/labelers/data_processing.py
+++ b/dataprofiler/labelers/data_processing.py
@@ -1461,6 +1461,7 @@ class StructCharPostprocessor(BaseDataPostprocessor,
         results['pred'] = labels_out
         if 'conf' in results:
             results['conf'] = confs_out
+            results['conf'] = np.delete(results['conf'], ignore_value, axis=1)
         return results
 
     def process(self, data, results, label_mapping):

--- a/dataprofiler/profilers/data_labeler_column_profile.py
+++ b/dataprofiler/profilers/data_labeler_column_profile.py
@@ -15,8 +15,6 @@ class DataLabelerColumn(BaseColumnProfiler):
         """
         Initialization of Data Label profiling for structured datasets.
 
-        :param data_labeler_dirpath: Directory path to the data labeler
-        :type data_labeler_dirpath: String
         :param options: Options for the data labeler column
         :type options: DataLabelerOptions
         """

--- a/dataprofiler/tests/labelers/test_data_processing.py
+++ b/dataprofiler/tests/labelers/test_data_processing.py
@@ -1862,18 +1862,19 @@ class TestStructCharPostprocessor(unittest.TestCase):
         results['conf'] = confidences
 
         expected_confidence_output = np.array([
-            [0, 0, 1, 0, 0],
-            [0, 0, 0, 1, 0],
-            [0, 1, 0, 0, 0],
-            [0, 0, 0, 1, 0],
-            [0, 0, 1, 0, 0],
+            [0, 1, 0, 0],
+            [0, 0, 1, 0],
+            [1, 0, 0, 0],
+            [0, 0, 1, 0],
+            [0, 1, 0, 0],
         ])
 
         output = processor.process(data, results, label_mapping)
         self.assertIn('pred', output)
         self.assertIn('conf', output)
         self.assertTrue((expected_output['pred'] == output['pred']).all())
-        self.assertTrue((expected_confidence_output == output['conf']).all())
+        self.assertTrue(np.array_equal(expected_confidence_output,
+                                       output['conf']))
 
     def test_match_sentence_lengths(self):
         processor = StructCharPostprocessor()

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -371,6 +371,7 @@ class TestDataLabelerCallWithOptions(unittest.TestCase):
         data_labeler = mock.Mock(spec=BaseDataLabeler)
         data_labeler.reverse_label_mapping = dict()
         data_labeler.model.num_labels = 0
+        data_labeler.model.requires_zero_mapping = False
         options.set({'data_labeler.data_labeler_object': data_labeler})
         with self.assertWarnsRegex(UserWarning,
                                    "The data labeler passed in will be used,"

--- a/dataprofiler/tests/profilers/test_data_labeler_column_profile.py
+++ b/dataprofiler/tests/profilers/test_data_labeler_column_profile.py
@@ -22,6 +22,7 @@ class TestDataLabelerColumnProfiler(unittest.TestCase):
         mock_DataLabeler.label_mapping = {"a": 0, "b": 1}
         mock_DataLabeler.reverse_label_mapping = {0: "a", 1: "b"}
         mock_DataLabeler.model.num_labels = 2
+        mock_DataLabeler.model.requires_zero_mapping = False
 
         def mock_predict(data, *args, **kwargs):
             len_data = len(data)
@@ -91,6 +92,7 @@ class TestDataLabelerColumnProfiler(unittest.TestCase):
         mock_DataLabeler.reverse_label_mapping = \
             {0: "a", 1: "b", 2: "c", 3: "d"}
         mock_DataLabeler.model.num_labels = 4
+        mock_DataLabeler.model.requires_zero_mapping = False
 
         def mock_low_predict(data, *args, **kwargs):
             return {'pred': None, 'conf': np.array([
@@ -139,7 +141,6 @@ class TestDataLabelerColumnProfiler(unittest.TestCase):
             expected = defaultdict(float, {'data_labeler_predict': 2.0})
             self.assertEqual(expected, profiler.profile['times'])
 
-
     def test_label_match(self, mock_instance):
         """
         Test label match between avg_prediction and data_label_representation
@@ -150,6 +151,7 @@ class TestDataLabelerColumnProfiler(unittest.TestCase):
         mock_DataLabeler.reverse_label_mapping = \
             {0: "a", 1: "c", 2: "e", 3: "f"}
         mock_DataLabeler.model.num_labels = 4
+        mock_DataLabeler.model.requires_zero_mapping = False
 
         data = pd.Series(['1', '2', '3', '4', '5', '6'])
         profiler = DataLabelerColumn(data.name)
@@ -158,7 +160,6 @@ class TestDataLabelerColumnProfiler(unittest.TestCase):
         self.assertEqual(["a", "c", "e", "f"], profiler._possible_data_labels)
         self.assertDictEqual(dict(a=0, c=0, e=0, f=0), profiler.label_representation)
         self.assertDictEqual(dict(a=0, c=0, e=0, f=0), profiler.avg_predictions)
-
 
     def test_profile_merge(self, mock_instance):
         self._setup_data_labeler_mock(mock_instance)

--- a/dataprofiler/tests/profilers/test_data_labeler_column_profile.py
+++ b/dataprofiler/tests/profilers/test_data_labeler_column_profile.py
@@ -74,6 +74,24 @@ class TestDataLabelerColumnProfiler(unittest.TestCase):
         self.assertDictEqual(dict(a=2, b=1), profiler.rank_distribution)
         self.assertDictEqual(dict(a=2/3, b=1/3), profiler.label_representation)
 
+    def test_update_reserve_label_mapping(self, mock_instance):
+        self._setup_data_labeler_mock(mock_instance)
+        mock_DataLabeler = mock_instance.return_value
+        mock_DataLabeler.model.requires_zero_mapping = True
+        mock_DataLabeler.label_mapping = {"PAD": 0, "a": 1, "b": 2}
+        mock_DataLabeler.reverse_label_mapping = {0: "PAD", 1:"a", 2: "b"}
+        mock_DataLabeler.model.num_labels = 3
+
+        data = pd.Series(['1', '2', '3'])
+        profiler = DataLabelerColumn(data.name)
+        profiler.update(data)
+
+        self.assertEqual(["a", "b"], profiler._possible_data_labels)
+        self.assertEqual("a", profiler.data_label)
+        self.assertDictEqual(dict(a=2/3, b=1/3), profiler.avg_predictions)
+        self.assertDictEqual(dict(a=2, b=1), profiler.rank_distribution)
+        self.assertDictEqual(dict(a=2/3, b=1/3), profiler.label_representation)
+
     def test_data_label_low_accuracy(self, mock_instance):
         self._setup_data_labeler_mock(mock_instance)
 


### PR DESCRIPTION
Addresses: https://github.com/capitalone/DataProfiler/issues/168

Removes PAD from postprocess output, removes pad in data labeling column profile

Since the model still can return PAD as a result as is passed to the postprocessor, label_mapping was left unchanged.