### PR TITLE
Refactor by abstracting __init__ for BaseProfiler

### DIFF
--- a/dataprofiler/tests/labelers/test_integration_struct_data_labeler.py
+++ b/dataprofiler/tests/labelers/test_integration_struct_data_labeler.py
@@ -295,7 +295,6 @@ class TestStructuredDataLabeler(unittest.TestCase):
             columns.append(col)
             predictions.append(results['data_stats'][col]['data_label'])
 
-
     def test_warning_tf_run_dp_multiple_times(self):
         test_root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
         test_dir = os.path.join(test_root_path, 'data')

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -21,7 +21,7 @@ from dataprofiler.profilers.profiler_options import ProfilerOptions, \
 from dataprofiler.profilers.column_profile_compilers import \
     ColumnPrimitiveTypeProfileCompiler, ColumnStatsProfileCompiler, \
     ColumnDataLabelerCompiler
-from dataprofiler import StructuredDataLabeler
+from dataprofiler import StructuredDataLabeler, UnstructuredDataLabeler
 
 from dataprofiler.profilers.helpers.report_helpers import _prepare_report
 
@@ -754,7 +754,8 @@ class TestStructuredColProfilerClass(unittest.TestCase):
 
 @mock.patch('dataprofiler.profilers.profile_builder.UnstructuredCompiler',
             spec=UnstructuredCompiler)
-@mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
+@mock.patch('dataprofiler.profilers.profile_builder.DataLabeler',
+            spec=UnstructuredDataLabeler)
 class TestUnstructuredProfiler(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
Utilizes default initialization for BaseProfiler and abstracts most repeatable code form StructuredProfiler and UnstructuredProfiler