### PR TITLE
Profiler is now a factory class and can create both structured and unstructured

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1520,9 +1520,9 @@ class Profiler(object):
 
         :param data: Data to be profiled
         :type data: Data class object
-        :param samples_per_update: Number of samples to use in generating profile
+        :param samples_per_update: Number of samples to use to generate profile
         :type samples_per_update: int
-        :param min_true_samples: Minimum number of samples required for the profiler
+        :param min_true_samples: Min number of samples required for the profiler
         :type min_true_samples: int
         :param options: Options for the profiler.
         :type options: ProfilerOptions Object
@@ -1538,7 +1538,7 @@ class Profiler(object):
             return UnstructuredProfiler(data, samples_per_update,
                                         min_true_samples, options)
         elif profiler_type is not None:
-            raise ValueError("Must specify 'profiler_type' to be 'structured'"
+            raise ValueError("Must specify 'profiler_type' to be 'structured' "
                              "or 'unstructured'.")
 
         # If user doesn't specify, and data is Data object, use is_structured

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1572,7 +1572,7 @@ class Profiler(object):
                 len_mean = sample_lens.mean()
                 len_range = sample_lens.max() - sample_lens.min()
                 # If strings are very long or varied, use unstructured
-                if len_mean > 20 or len_range > 20:
+                if len_mean > 25 or len_range > 25:
                     warnings.warn("Singular column string data given to "
                                   "Profiler inferred to be unstructured, will "
                                   "create UnstructuredProfiler.")

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1636,7 +1636,8 @@ class StructuredProfiler(BaseProfiler):
         return profile
 
 
-def Profiler(data, samples_per_update=None, min_true_samples=0, options=None):
+def Profiler(data, samples_per_update=None, min_true_samples=0, options=None,
+             profiler_type=None):
     """
     Wrapper function for instantiating Structured and Unstructured Profilers
 
@@ -1648,11 +1649,67 @@ def Profiler(data, samples_per_update=None, min_true_samples=0, options=None):
     :type min_true_samples: int
     :param options: Options for the profiler.
     :type options: ProfilerOptions Object
+    :param profiler_type: Type of Profiler ("structured"/"unstructured")
+    :type profiler_type: str
     :return: BaseProfiler
     """
-    # Will want to add 'profiler_type' parameter similar to 'labeler_type'
-    # for specifying structured/unstructured profiler
+    # Attempt to construct according to user kwarg input
+    if profiler_type == "structured":
+        return StructuredProfiler(data, samples_per_update, min_true_samples,
+                                  options)
+    elif profiler_type == "unstructured":
+        return UnstructuredProfiler(data, samples_per_update, min_true_samples,
+                                    options)
+    elif profiler_type is not None:
+        raise ValueError("Must specify 'profiler_type' to be 'structured'"
+                         "or 'unstructured'.")
 
-    # TODO: Add support for creating unstructured profilers via this wrapper
-    return StructuredProfiler(data, samples_per_update, min_true_samples,
-                              options)
+    # If user doesn't specify, and data is Data object, use is_structured
+    if isinstance(data, data_readers.base_data.BaseData):
+        if data.is_structured:
+            return StructuredProfiler(data, samples_per_update,
+                                      min_true_samples, options)
+        else:
+            return UnstructuredProfiler(data, samples_per_update,
+                                        min_true_samples, options)
+
+    # If user doesn't specify, and data is Pandas object, need to infer
+    if isinstance(data, pd.DataFrame) or isinstance(data, pd.Series):
+        # If empty, default to structured
+        if not len(data):
+            warnings.warn("Empty data given to Profiler, will assume data"
+                          "is structured and create StructuredProfiler")
+            return StructuredProfiler(data, samples_per_update,
+                                      min_true_samples, options)
+
+        # If multi column df, data is structured
+        if isinstance(data, pd.DataFrame) and len(data.columns) > 1:
+            return StructuredProfiler(data, samples_per_update,
+                                      min_true_samples, options)
+
+        # If single column, look at string length and variance
+        d_type = data.dtype if isinstance(data, pd.Series) else data.dtypes[0]
+        if d_type == "object":
+            sample = data if isinstance(data, pd.Series) else data[0]
+            if len(sample) > 5:
+                sample = sample.sample(n=5)
+            sample_lens = sample.apply(len)
+            len_mean = sample_lens.mean()
+            len_range = sample_lens.max() - sample_lens.min()
+            # If strings are very long or varied, use unstructured
+            if len_mean > 20 or len_range > 20:
+                warnings.warn("Singular column string data given to Profiler "
+                              "inferred to be unstructured, will create "
+                              "UnstructuredProfiler.")
+                return UnstructuredProfiler(data, samples_per_update,
+                                            min_true_samples, options)
+            else:
+                warnings.warn("Singular column string data given to Profiler "
+                              "inferred to be structured, will create "
+                              "StructuredProfiler.")
+
+        return StructuredProfiler(data, samples_per_update, min_true_samples,
+                                  options)
+
+    raise ValueError("Data must either be imported using the data_readers, "
+                     "pd.Series, or pd.DataFrame.")

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1519,6 +1519,12 @@ class TestProfilerFactoryClass(unittest.TestCase):
         self.assertIsInstance(Profiler(unstruct_str_df), UnstructuredProfiler)
         self.assertIsInstance(Profiler(unstruct_str_ser), UnstructuredProfiler)
 
+        # User gives mixed data types, but they are relatively uniform length
+        mixed_df = pd.DataFrame([1, "two", 3, "four"])
+        mixed_ser = mixed_df[0]
+        self.assertIsInstance(Profiler(mixed_df), StructuredProfiler)
+        self.assertIsInstance(Profiler(mixed_ser), StructuredProfiler)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1457,38 +1457,67 @@ class TestProfilerFactoryClass(unittest.TestCase):
                                                 "pd.Series, or pd.DataFrame."):
             Profiler("whoops")
 
-    def test_profiler_factory_class_creates_correct_profiler(self):
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnPrimitiveTypeProfileCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnStatsProfileCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnDataLabelerCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
+    @mock.patch('dataprofiler.profilers.profile_builder.UnstructuredCompiler')
+    def test_profiler_factory_class_creates_correct_profiler(self, *mocks):
         """
         Ensure Profiler factory class either respects user input or makes
         reasonable inference in the absence of user specificity.
         """
         # User specifies via profiler_type
-        pass
-        pass
+        empty_df = pd.DataFrame([])
+        empty_ser = pd.Series([])
+        self.assertIsInstance(Profiler(empty_df, profiler_type="structured"),
+                              StructuredProfiler)
+        self.assertIsInstance(Profiler(empty_df, profiler_type="unstructured"),
+                              UnstructuredProfiler)
 
         # User gives data that has .is_structured == True
-        pass
+        empty_csv_df = dp.Data(data=empty_df, data_type="csv")
+        self.assertIsInstance(Profiler(empty_csv_df), StructuredProfiler)
 
         # User gives data that has .is_structured == False
-        pass
+        empty_csv_rec = dp.Data(data=empty_df, data_type="csv",
+                                options={"data_format": "records"})
+        self.assertIsInstance(Profiler(empty_csv_rec), UnstructuredProfiler)
 
-        # User gives empty data (should default to StructuredProfiler)
-        pass
-        pass
+        # User gives empty data w/o specifying profiler type
+        self.assertIsInstance(Profiler(empty_df), StructuredProfiler)
+        self.assertIsInstance(Profiler(empty_ser), StructuredProfiler)
 
         # User gives 2D DF
-        pass
+        df_2d = pd.DataFrame([[1, "two"], [3, "four"]])
+        self.assertIsInstance(Profiler(df_2d), StructuredProfiler)
 
         # User gives 1 col int data
-        pass
-        pass
+        col_int_df = pd.DataFrame([1, 2, 3, 4])
+        col_int_ser = col_int_df[0]
+        self.assertIsInstance(Profiler(col_int_df), StructuredProfiler)
+        self.assertIsInstance(Profiler(col_int_ser), StructuredProfiler)
 
         # User gives 1 col data with short, uniform strings
-        pass
-        pass
+        struct_str_df = pd.DataFrame(["Bob", "Bill", "Linda", "Brady", "Tom"])
+        struct_str_ser = struct_str_df[0]
+        self.assertIsInstance(Profiler(struct_str_df), StructuredProfiler)
+        self.assertIsInstance(Profiler(struct_str_ser), StructuredProfiler)
 
         # User gives 1 col data with strings of varying lengths
-        pass
+        unstruct_str_df = pd.DataFrame(["short",
+                                        "this one here is a tad bit longer",
+                                        "oh wow this one is really long, like, "
+                                        "who would give this much string data, "
+                                        "this can't possibly be structured.",
+                                        "haha its short again now",
+                                        "k bye"])
+        unstruct_str_ser = unstruct_str_df[0]
+        self.assertIsInstance(Profiler(unstruct_str_df), UnstructuredProfiler)
+        self.assertIsInstance(Profiler(unstruct_str_ser), UnstructuredProfiler)
         pass
 
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1444,5 +1444,22 @@ class TestStructuredProfilerNullValues(unittest.TestCase):
         self.assertSetEqual({8}, profile._profile[1].null_types_index['None'])
 
 
+class TestProfilerFactoryClass(unittest.TestCase):
+
+    def test_profiler_factory_class_bad_input(self):
+        with self.assertRaisesRegex(ValueError, "Must specify 'profiler_type' "
+                                                "to be 'structured' or "
+                                                "'unstructured'."):
+            dp.Profiler(pd.DataFrame([]), profiler_type="whoops")
+
+        with self.assertRaisesRegex(ValueError, "Data must either be imported "
+                                                "using the data_readers, "
+                                                "pd.Series, or pd.DataFrame."):
+            dp.Profiler("whoops")
+
+    def test_profiler_factory_class_creates_correct_profiler(self):
+        pass
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -15,7 +15,7 @@ from . import utils as test_utils
 
 import dataprofiler as dp
 from dataprofiler.profilers.profile_builder import StructuredColProfiler, \
-    UnstructuredProfiler, UnstructuredCompiler
+    UnstructuredProfiler, UnstructuredCompiler, StructuredProfiler, Profiler
 from dataprofiler.profilers.profiler_options import ProfilerOptions, \
     StructuredOptions, UnstructuredOptions
 from dataprofiler.profilers.column_profile_compilers import \
@@ -1450,14 +1450,45 @@ class TestProfilerFactoryClass(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Must specify 'profiler_type' "
                                                 "to be 'structured' or "
                                                 "'unstructured'."):
-            dp.Profiler(pd.DataFrame([]), profiler_type="whoops")
+            Profiler(pd.DataFrame([]), profiler_type="whoops")
 
         with self.assertRaisesRegex(ValueError, "Data must either be imported "
                                                 "using the data_readers, "
                                                 "pd.Series, or pd.DataFrame."):
-            dp.Profiler("whoops")
+            Profiler("whoops")
 
     def test_profiler_factory_class_creates_correct_profiler(self):
+        """
+        Ensure Profiler factory class either respects user input or makes
+        reasonable inference in the absence of user specificity.
+        """
+        # User specifies via profiler_type
+        pass
+        pass
+
+        # User gives data that has .is_structured == True
+        pass
+
+        # User gives data that has .is_structured == False
+        pass
+
+        # User gives empty data (should default to StructuredProfiler)
+        pass
+        pass
+
+        # User gives 2D DF
+        pass
+
+        # User gives 1 col int data
+        pass
+        pass
+
+        # User gives 1 col data with short, uniform strings
+        pass
+        pass
+
+        # User gives 1 col data with strings of varying lengths
+        pass
         pass
 
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1518,7 +1518,6 @@ class TestProfilerFactoryClass(unittest.TestCase):
         unstruct_str_ser = unstruct_str_df[0]
         self.assertIsInstance(Profiler(unstruct_str_df), UnstructuredProfiler)
         self.assertIsInstance(Profiler(unstruct_str_ser), UnstructuredProfiler)
-        pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`Profiler` now mimics the factory class structure of `Data` for creating profilers, and can create both structured and unstructured. As of now, the logic for choosing which to create is as follows:

- If user specifies via kwarg, return the one they specify
- If user doesn't specify, and data is a `Data` object, refer to `is_structured`
- If user doesn't specify, and data is a pandas object:
        - Empty df/series -> Structured
        - Multi dimensional df -> Structured
        - If single col of string data that is varied in length or very long -> Unstructured
        - All other single col cases (uniform strings or any other dtype) -> Structured

Warnings are given every time inference is made in case the user intended for a specific profiler but didn't specify.
Test function written to ensure inference behaves as expected (laid out above).