### PR TITLE
Bug fix for dicts being passed to structured

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1270,9 +1270,14 @@ class StructuredProfiler(BaseProfiler):
                              "not a DataFrame")
         
         self.total_samples += len(data)
-        self.hashed_row_dict.update(dict.fromkeys(
-            pd.util.hash_pandas_object(data, index=False), True
-        ))
+        try:
+            self.hashed_row_dict.update(dict.fromkeys(
+                pd.util.hash_pandas_object(data, index=False), True
+            ))
+        except TypeError:
+            self.hashed_row_dict.update(dict.fromkeys(
+                pd.util.hash_pandas_object(data.astype(str), index=False), True
+            ))
 
         # Calculate Null Column Count
         null_rows = set()

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1525,6 +1525,18 @@ class TestProfilerFactoryClass(unittest.TestCase):
         self.assertIsInstance(Profiler(mixed_df), StructuredProfiler)
         self.assertIsInstance(Profiler(mixed_ser), StructuredProfiler)
 
+        # Test dict input, struct
+        dict_df = pd.DataFrame({0: [{"test": 'test'}]})
+        dict_ser = dict_df[0]
+        self.assertIsInstance(Profiler(dict_df), StructuredProfiler)
+        self.assertIsInstance(Profiler(dict_ser), StructuredProfiler)
+
+        # Test dict input, unstruct
+        dict_df = pd.DataFrame({0: [{"test": 'test' * 100}]})
+        dict_ser = dict_df[0]
+        self.assertIsInstance(Profiler(dict_df), UnstructuredProfiler)
+        self.assertIsInstance(Profiler(dict_ser), UnstructuredProfiler)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If a list of dicts were passed to StructuredProfiler, it would error when hashing the rows.