### PR TITLE
Fixes mock in test to use proper tf.keras

### DIFF
--- a/dataprofiler/tests/labelers/test_data_labelers.py
+++ b/dataprofiler/tests/labelers/test_data_labelers.py
@@ -308,7 +308,7 @@ def mock_open(filename, *args):
         return StringIO('{}')
 
 
-@mock.patch("keras.models.load_model")
+@mock.patch("tensorflow.keras.models.load_model")
 @mock.patch("builtins.open", side_effect=mock_open)
 class TestLoadedDataLabeler(unittest.TestCase):
 

--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -1,6 +1,6 @@
 scikit-learn>=0.23.2
 scipy>=1.4.1
 keras>=2.4.3
-tensorflow-gpu>=2.3.0,<2.5.0; sys.platform == 'linux'
-tensorflow>=2.3.0,<2.5.0; sys.platform == 'darwin'
+tensorflow-gpu>=2.3.0; sys.platform == 'linux'
+tensorflow>=2.3.0; sys.platform == 'darwin'
 tqdm>=4.0.0


### PR DESCRIPTION
Allows TF2.5.0 with fix to test which was incorrectly calling `'keras....` instead of `tf.keras....`

Reverts the TF version lock from: https://github.com/capitalone/DataProfiler/pull/220