### PR TITLE
Fixes save bug and add tests

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -698,12 +698,13 @@ class BaseProfiler(object):
             # unstructured: _profile is a compiler
             # structured: StructuredColProfiler.profiles['data_label_profile']
             if isinstance(self, StructuredProfiler):
-                profiler = profiler.profiles['data_label_profile']
+                profiler = profiler.profiles.get('data_label_profile', None)
 
-            if use_data_labeler and data_labeler is None:
+            if profiler and use_data_labeler and data_labeler is None:
                 data_labeler = profiler._profiles['data_labeler'].data_labeler
 
-            profiler._profiles['data_labeler'].data_labeler = None
+            if profiler and 'data_labeler' in profiler._profiles:
+                profiler._profiles['data_labeler'].data_labeler = None
 
         return data_labeler
 
@@ -753,14 +754,15 @@ class BaseProfiler(object):
         # Restore data labelers for all columns
         for profiler in profilers:
 
-            # profiles stored differently in Struct/Unstruct, this unifies
-            # label replacement
-            # unstructured: _profile is a compiler
-            # structured: StructuredColProfiler.profiles['data_label_profile']
-            if isinstance(self, StructuredProfiler):
-                profiler = profiler.profiles['data_label_profile']
-
             if use_data_labeler:
+
+                # profiles stored differently in Struct/Unstruct, this unifies
+                # label replacement
+                # unstructured: _profile is a compiler
+                # structured: StructuredColProfiler.profiles['data_label_profile']
+                if isinstance(self, StructuredProfiler):
+                    profiler = profiler.profiles['data_label_profile']
+
                 data_labeler_profile = profiler._profiles['data_labeler']
                 data_labeler_profile.data_labeler = data_labeler
 


### PR DESCRIPTION
addresses: https://github.com/capitalone/DataProfiler/issues/256

If case where options is False, but a labeler still exists in profiles, want to remove anyways to be sure. This guarantees all labers get removed if they exist at all. in profilers but don't cause a bug if they don't exist.