### PR TITLE
Option Equality

### DIFF
--- a/dataprofiler/labelers/base_data_labeler.py
+++ b/dataprofiler/labelers/base_data_labeler.py
@@ -58,6 +58,8 @@ class BaseDataLabeler(object):
         :return: Whether or not self and other are equal
         :rtype: Bool
         """
+        if other is None:
+            return False
         if self._preprocessor != other.preprocessor \
                 or self._model != other.model \
                 or self._postprocessor != other.postprocessor:

--- a/dataprofiler/labelers/base_data_labeler.py
+++ b/dataprofiler/labelers/base_data_labeler.py
@@ -58,7 +58,7 @@ class BaseDataLabeler(object):
         :return: Whether or not self and other are equal
         :rtype: Bool
         """
-        if other is None:
+        if not isinstance(other, BaseDataLabeler):
             return False
         if self._preprocessor != other.preprocessor \
                 or self._model != other.model \

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -115,14 +115,10 @@ class BaseOption(object):
         Determines equality by ensuring equality of all attributes, some of
         which may be Options objects themselves.
         """
-        self_dict = self.__dict__
-        other_dict = other.__dict__
-
-        # Ensures keys in dictionaries are the same below
         if not isinstance(other, self.__class__):
             return False
 
-        return all([self_dict[key] == other_dict[key] for key in self_dict])
+        return self.__dict__ == other.__dict__
 
 
 class BooleanOption(BaseOption):

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -111,7 +111,6 @@ class BaseOption(object):
             return errors
 
     def __eq__(self, other):
-        print("CALLED IT")
         self_dict = self.__dict__
         other_dict = other.__dict__
 

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -111,10 +111,15 @@ class BaseOption(object):
             return errors
 
     def __eq__(self, other):
+        """
+        Determines equality by ensuring equality of all attributes, some of
+        which may be Options objects themselves.
+        """
         self_dict = self.__dict__
         other_dict = other.__dict__
 
-        if type(self) != type(other):
+        # Ensures keys in dictionaries are the same below
+        if not isinstance(other, self.__class__):
             return False
 
         return all([self_dict[key] == other_dict[key] for key in self_dict])

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -110,6 +110,16 @@ class BaseOption(object):
         elif errors: 
             return errors
 
+    def __eq__(self, other):
+        print("CALLED IT")
+        self_dict = self.__dict__
+        other_dict = other.__dict__
+
+        if type(self) != type(other):
+            return False
+
+        return all([self_dict[key] == other_dict[key] for key in self_dict])
+
 
 class BooleanOption(BaseOption):
 

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -592,6 +592,8 @@ class DataLabelerOptions(BaseInspectorOptions):
         :vartype data_labeler_dirpath: str
         :ivar max_sample_size: Int to decide sample size
         :vartype max_sample_size: int
+        :ivar data_labeler_object: DataLabeler object used in profiler
+        :vartype max_sample_size: BaseDataLabeler
         """
         BaseInspectorOptions.__init__(self)
         self.data_labeler_dirpath = None

--- a/dataprofiler/tests/profilers/profiler_options/test_base_inspector_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_base_inspector_options.py
@@ -45,3 +45,6 @@ class TestBaseInspectorOptions(TestBooleanOption):
         with self.assertRaisesRegex(AttributeError, expected_error):
             options.is_prop_enabled("Hello World")
 
+    def test_eq(self):
+        super().test_eq()
+

--- a/dataprofiler/tests/profilers/profiler_options/test_base_option.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_base_option.py
@@ -51,3 +51,9 @@ class TestBaseOption(AbstractTestOptions, unittest.TestCase):
 
         with self.assertRaises(NotImplementedError):
             options.validate()
+
+    def test_eq(self):
+        options = self.get_options()
+        self.assertTrue(options == options)
+        options2 = self.get_options()
+        self.assertTrue(options == options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_base_option.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_base_option.py
@@ -54,6 +54,6 @@ class TestBaseOption(AbstractTestOptions, unittest.TestCase):
 
     def test_eq(self):
         options = self.get_options()
-        self.assertTrue(options == options)
+        self.assertEqual(options, options)
         options2 = self.get_options()
-        self.assertTrue(options == options2)
+        self.assertEqual(options, options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_boolean_option.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_boolean_option.py
@@ -82,3 +82,13 @@ class TestBooleanOption(TestBaseOption):
                            .format(optpth, key) for key in self.keys]
         self.assertSetEqual(set(expected_error), 
                             set(option.validate(raise_error=False)))
+
+    def test_eq(self):
+        options = self.get_options()
+        self.assertTrue(options == options)
+        options2 = self.get_options()
+        self.assertTrue(options == options2)
+        options.is_enabled = False
+        self.assertFalse(options == options2)
+        options2.is_enabled = False
+        self.assertTrue(options == options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_boolean_option.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_boolean_option.py
@@ -84,10 +84,10 @@ class TestBooleanOption(TestBaseOption):
                             set(option.validate(raise_error=False)))
 
     def test_eq(self):
+        super().test_eq()
+
         options = self.get_options()
-        self.assertTrue(options == options)
         options2 = self.get_options()
-        self.assertTrue(options == options2)
         options.is_enabled = False
         self.assertFalse(options == options2)
         options2.is_enabled = False

--- a/dataprofiler/tests/profilers/profiler_options/test_boolean_option.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_boolean_option.py
@@ -89,6 +89,6 @@ class TestBooleanOption(TestBaseOption):
         options = self.get_options()
         options2 = self.get_options()
         options.is_enabled = False
-        self.assertFalse(options == options2)
+        self.assertNotEqual(options, options2)
         options2.is_enabled = False
-        self.assertTrue(options == options2)
+        self.assertEqual(options, options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_categorical_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_categorical_options.py
@@ -24,3 +24,6 @@ class TestCategoricalOptions(TestBaseInspectorOptions):
 
     def test_is_prop_enabled(self):
         super().test_is_prop_enabled()
+
+    def test_eq(self):
+        super().test_eq()

--- a/dataprofiler/tests/profilers/profiler_options/test_datalabeler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_datalabeler_options.py
@@ -154,10 +154,17 @@ class TestDataLabelerOptions(TestBaseInspectorOptions):
         options = self.get_options()
         options2 = self.get_options()
         options.data_labeler_dirpath = "hello"
+        self.assertNotEqual(options, options2)
+        options2.data_labeler_dirpath = "hello there"
+        self.assertNotEqual(options, options2)
+        options2.data_labeler_dirpath = "hello"
+        self.assertEqual(options, options2)
+
         options.data_labeler_object = BaseDataLabeler()
         options.data_labeler_object._model = 7
         self.assertNotEqual(options, options2)
-        options2.data_labeler_dirpath = "hello"
         options2.data_labeler_object = BaseDataLabeler()
+        options2.data_labeler_object._model = 8
+        self.assertNotEqual(options, options2)
         options2.data_labeler_object._model = 7
         self.assertEqual(options, options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_datalabeler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_datalabeler_options.py
@@ -160,6 +160,9 @@ class TestDataLabelerOptions(TestBaseInspectorOptions):
         options2.data_labeler_dirpath = "hello"
         self.assertEqual(options, options2)
 
+        # Labeler equality is determined by processor and model equaity
+        # the model is just set to different ints to ensure it is being
+        # looked at by the options __eq__
         options.data_labeler_object = BaseDataLabeler()
         options.data_labeler_object._model = 7
         self.assertNotEqual(options, options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_datalabeler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_datalabeler_options.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from dataprofiler.profilers.profiler_options import DataLabelerOptions
 from dataprofiler.tests.profilers.profiler_options.test_base_inspector_options \
      import TestBaseInspectorOptions
@@ -143,3 +145,19 @@ class TestDataLabelerOptions(TestBaseInspectorOptions):
 
     def test_is_prop_enabled(self):
         super().test_is_prop_enabled()
+
+    @mock.patch('dataprofiler.labelers.base_data_labeler.BaseDataLabeler.'
+                '_load_data_labeler')
+    def test_eq(self, *mocks):
+        super().test_eq()
+
+        options = self.get_options()
+        options2 = self.get_options()
+        options.data_labeler_dirpath = "hello"
+        options.data_labeler_object = BaseDataLabeler()
+        options.data_labeler_object._model = 7
+        self.assertFalse(options == options2)
+        options2.data_labeler_dirpath = "hello"
+        options2.data_labeler_object = BaseDataLabeler()
+        options2.data_labeler_object._model = 7
+        self.assertTrue(options == options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_datalabeler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_datalabeler_options.py
@@ -156,8 +156,8 @@ class TestDataLabelerOptions(TestBaseInspectorOptions):
         options.data_labeler_dirpath = "hello"
         options.data_labeler_object = BaseDataLabeler()
         options.data_labeler_object._model = 7
-        self.assertFalse(options == options2)
+        self.assertNotEqual(options, options2)
         options2.data_labeler_dirpath = "hello"
         options2.data_labeler_object = BaseDataLabeler()
         options2.data_labeler_object._model = 7
-        self.assertTrue(options == options2)
+        self.assertEqual(options, options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_datalabeler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_datalabeler_options.py
@@ -160,7 +160,7 @@ class TestDataLabelerOptions(TestBaseInspectorOptions):
         options2.data_labeler_dirpath = "hello"
         self.assertEqual(options, options2)
 
-        # Labeler equality is determined by processor and model equaity
+        # Labeler equality is determined by processor and model equality
         # the model is just set to different ints to ensure it is being
         # looked at by the options __eq__
         options.data_labeler_object = BaseDataLabeler()

--- a/dataprofiler/tests/profilers/profiler_options/test_datetime_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_datetime_options.py
@@ -24,3 +24,6 @@ class TestDateTimeOptions(TestBaseInspectorOptions):
 
     def test_is_prop_enabled(self):
         super().test_is_prop_enabled()
+
+    def test_eq(self):
+        super().test_eq()

--- a/dataprofiler/tests/profilers/profiler_options/test_float_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_float_options.py
@@ -32,6 +32,6 @@ class TestFloatOptions(TestNumericalOptions):
         options = self.get_options()
         options2 = self.get_options()
         options.precision.is_enabled = False
-        self.assertFalse(options == options2)
+        self.assertNotEqual(options, options2)
         options2.precision.is_enabled = False
-        self.assertTrue(options == options2)
+        self.assertEqual(options, options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_float_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_float_options.py
@@ -25,3 +25,13 @@ class TestFloatOptions(TestNumericalOptions):
     
     def test_is_numeric_stats_enabled(self):
         super().test_is_numeric_stats_enabled()
+
+    def test_eq(self):
+        super().test_eq()
+
+        options = self.get_options()
+        options2 = self.get_options()
+        options.precision.is_enabled = False
+        self.assertFalse(options == options2)
+        options2.precision.is_enabled = False
+        self.assertTrue(options == options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_histogram_option.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_histogram_option.py
@@ -121,6 +121,6 @@ class TestHistogramOption(TestBooleanOption):
         options = self.get_options()
         options2 = self.get_options()
         options.bin_count_or_method = "sturges"
-        self.assertFalse(options == options2)
+        self.assertNotEqual(options, options2)
         options2.bin_count_or_method = "sturges"
-        self.assertTrue(options == options2)
+        self.assertEqual(options, options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_histogram_option.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_histogram_option.py
@@ -114,3 +114,13 @@ class TestHistogramOption(TestBooleanOption):
             r"\['auto', 'fd', 'doane', 'scott', 'rice', 'sturges', 'sqrt'].")
         with self.assertRaisesRegex(ValueError, expected_error):
             option.validate()
+
+    def test_eq(self):
+        options = self.get_options()
+        self.assertTrue(options == options)
+        options2 = self.get_options()
+        self.assertTrue(options == options2)
+        options.bin_count_or_method = "sturges"
+        self.assertFalse(options == options2)
+        options2.bin_count_or_method = "sturges"
+        self.assertTrue(options == options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_histogram_option.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_histogram_option.py
@@ -116,10 +116,10 @@ class TestHistogramOption(TestBooleanOption):
             option.validate()
 
     def test_eq(self):
+        super().test_eq()
+
         options = self.get_options()
-        self.assertTrue(options == options)
         options2 = self.get_options()
-        self.assertTrue(options == options2)
         options.bin_count_or_method = "sturges"
         self.assertFalse(options == options2)
         options2.bin_count_or_method = "sturges"

--- a/dataprofiler/tests/profilers/profiler_options/test_histogram_option.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_histogram_option.py
@@ -122,5 +122,7 @@ class TestHistogramOption(TestBooleanOption):
         options2 = self.get_options()
         options.bin_count_or_method = "sturges"
         self.assertNotEqual(options, options2)
+        options2.bin_count_or_method = "doane"
+        self.assertNotEqual(options, options2)
         options2.bin_count_or_method = "sturges"
         self.assertEqual(options, options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_int_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_int_options.py
@@ -24,3 +24,6 @@ class TestIntOptions(TestNumericalOptions):
     
     def test_is_numeric_stats_enabled(self):
         super().test_is_numeric_stats_enabled()
+
+    def test_eq(self):
+        super().test_eq()

--- a/dataprofiler/tests/profilers/profiler_options/test_numerical_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_numerical_options.py
@@ -110,10 +110,10 @@ class TestNumericalOptions(TestBaseInspectorOptions):
             self.assertFalse(options.is_numeric_stats_enabled)
 
     def test_eq(self):
+        super().test_eq()
+
         options = self.get_options()
-        self.assertTrue(options == options)
         options2 = self.get_options()
-        self.assertTrue(options == options2)
         options.min.is_enabled = False
         options.variance.is_enabled = False
         self.assertFalse(options == options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_numerical_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_numerical_options.py
@@ -115,9 +115,6 @@ class TestNumericalOptions(TestBaseInspectorOptions):
         options = self.get_options()
         options2 = self.get_options()
         options.min.is_enabled = False
-        options.variance.is_enabled = False
         self.assertNotEqual(options, options2)
         options2.min.is_enabled = False
-        options2.variance.is_enabled = False
         self.assertEqual(options, options2)
-

--- a/dataprofiler/tests/profilers/profiler_options/test_numerical_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_numerical_options.py
@@ -1,5 +1,4 @@
-from dataprofiler.profilers.profiler_options \
-     import BooleanOption, NumericalOptions
+from dataprofiler.profilers.profiler_options import NumericalOptions
 from dataprofiler.tests.profilers.profiler_options.test_base_inspector_options \
      import TestBaseInspectorOptions
 
@@ -109,4 +108,16 @@ class TestNumericalOptions(TestBaseInspectorOptions):
         options.is_numeric_stats_enabled = False
         for key in numeric_keys:            
             self.assertFalse(options.is_numeric_stats_enabled)
+
+    def test_eq(self):
+        options = self.get_options()
+        self.assertTrue(options == options)
+        options2 = self.get_options()
+        self.assertTrue(options == options2)
+        options.min.is_enabled = False
+        options.variance.is_enabled = False
+        self.assertFalse(options == options2)
+        options2.min.is_enabled = False
+        options2.variance.is_enabled = False
+        self.assertTrue(options == options2)
 

--- a/dataprofiler/tests/profilers/profiler_options/test_numerical_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_numerical_options.py
@@ -116,8 +116,8 @@ class TestNumericalOptions(TestBaseInspectorOptions):
         options2 = self.get_options()
         options.min.is_enabled = False
         options.variance.is_enabled = False
-        self.assertFalse(options == options2)
+        self.assertNotEqual(options, options2)
         options2.min.is_enabled = False
         options2.variance.is_enabled = False
-        self.assertTrue(options == options2)
+        self.assertEqual(options, options2)
 

--- a/dataprofiler/tests/profilers/profiler_options/test_order_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_order_options.py
@@ -24,3 +24,6 @@ class TestOrderOptions(TestBaseInspectorOptions):
 
     def test_is_prop_enabled(self):
         super().test_is_prop_enabled()
+
+    def test_eq(self):
+        super().test_eq()

--- a/dataprofiler/tests/profilers/profiler_options/test_precision_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_precision_options.py
@@ -109,5 +109,7 @@ class TestPrecisionOptions(TestBooleanOption):
         options2 = self.get_options()
         options.sample_ratio = 0.3
         self.assertNotEqual(options, options2)
+        options2.sample_ratio = 0.5
+        self.assertNotEqual(options, options2)
         options2.sample_ratio = 0.3
         self.assertEqual(options, options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_precision_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_precision_options.py
@@ -108,6 +108,6 @@ class TestPrecisionOptions(TestBooleanOption):
         options = self.get_options()
         options2 = self.get_options()
         options.sample_ratio = 0.3
-        self.assertFalse(options == options2)
+        self.assertNotEqual(options, options2)
         options2.sample_ratio = 0.3
-        self.assertTrue(options == options2)
+        self.assertEqual(options, options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_precision_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_precision_options.py
@@ -101,3 +101,13 @@ class TestPrecisionOptions(TestBooleanOption):
         )
         with self.assertRaisesRegex(ValueError, expected_error):
             option.validate()
+
+    def test_eq(self):
+        options = self.get_options()
+        self.assertTrue(options == options)
+        options2 = self.get_options()
+        self.assertTrue(options == options2)
+        options.sample_ratio = 0.3
+        self.assertFalse(options == options2)
+        options2.sample_ratio = 0.3
+        self.assertTrue(options == options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_precision_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_precision_options.py
@@ -103,10 +103,10 @@ class TestPrecisionOptions(TestBooleanOption):
             option.validate()
 
     def test_eq(self):
+        super().test_eq()
+
         options = self.get_options()
-        self.assertTrue(options == options)
         options2 = self.get_options()
-        self.assertTrue(options == options2)
         options.sample_ratio = 0.3
         self.assertFalse(options == options2)
         options2.sample_ratio = 0.3

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -392,10 +392,10 @@ class TestProfilerOptions(unittest.TestCase):
         options2 = ProfilerOptions()
         options.unstructured_options.data_labeler.is_enabled = False
         options.structured_options.float.precision.sample_ratio = 0.1
-        self.assertFalse(options == options2)
+        self.assertNotEqual(options, options2)
         options2.unstructured_options.data_labeler.is_enabled = False
         options2.structured_options.float.precision.sample_ratio = 0.1
-        self.assertTrue(options == options2)
+        self.assertEqual(options, options2)
 
 
 @mock.patch('dataprofiler.profilers.data_labeler_column_profile.'

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -391,11 +391,16 @@ class TestProfilerOptions(unittest.TestCase):
         options = ProfilerOptions()
         options2 = ProfilerOptions()
         options.unstructured_options.data_labeler.is_enabled = False
-        options.structured_options.float.precision.sample_ratio = 0.1
         self.assertNotEqual(options, options2)
         options2.unstructured_options.data_labeler.is_enabled = False
-        options2.structured_options.float.precision.sample_ratio = 0.1
         self.assertEqual(options, options2)
+
+        options.structured_options.float.precision.sample_ratio = 0.1
+        self.assertNotEqual(options, options2)
+        options2.structured_options.float.precision.sample_ratio = 0.15
+        self.assertNotEqual(options, options2)
+        options.structured_options.float.precision.sample_ratio = 0.1
+        self.assertNotEqual(options, options2)
 
 
 @mock.patch('dataprofiler.profilers.data_labeler_column_profile.'

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -387,6 +387,16 @@ class TestProfilerOptions(unittest.TestCase):
         self.assertFalse(options.structured_options.text.vocab.is_enabled)
         self.assertTrue(options.unstructured_options.text.vocab.is_enabled)
 
+    def test_eq(self, *mocks):
+        options = ProfilerOptions()
+        options2 = ProfilerOptions()
+        options.unstructured_options.data_labeler.is_enabled = False
+        options.structured_options.float.precision.sample_ratio = 0.1
+        self.assertFalse(options == options2)
+        options2.unstructured_options.data_labeler.is_enabled = False
+        options2.structured_options.float.precision.sample_ratio = 0.1
+        self.assertTrue(options == options2)
+
 
 @mock.patch('dataprofiler.profilers.data_labeler_column_profile.'
             'DataLabelerColumn.update', return_value=None)

--- a/dataprofiler/tests/profilers/profiler_options/test_structured_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_structured_options.py
@@ -193,9 +193,14 @@ class TestStructuredOptions(TestBaseOption):
         options = self.get_options()
         options2 = self.get_options()
         options.multiprocess.is_enabled = False
-        options.float.precision.sample_ratio = 0.1
         self.assertNotEqual(options, options2)
         options2.multiprocess.is_enabled = False
+        self.assertEqual(options, options2)
+
+        options.float.precision.sample_ratio = 0.1
+        self.assertNotEqual(options, options2)
+        options2.float.precision.sample_ratio = 0.15
+        self.assertNotEqual(options, options2)
         options2.float.precision.sample_ratio = 0.1
         self.assertEqual(options, options2)
 

--- a/dataprofiler/tests/profilers/profiler_options/test_structured_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_structured_options.py
@@ -194,8 +194,8 @@ class TestStructuredOptions(TestBaseOption):
         options2 = self.get_options()
         options.multiprocess.is_enabled = False
         options.float.precision.sample_ratio = 0.1
-        self.assertFalse(options == options2)
+        self.assertNotEqual(options, options2)
         options2.multiprocess.is_enabled = False
         options2.float.precision.sample_ratio = 0.1
-        self.assertTrue(options == options2)
+        self.assertEqual(options, options2)
 

--- a/dataprofiler/tests/profilers/profiler_options/test_structured_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_structured_options.py
@@ -187,3 +187,15 @@ class TestStructuredOptions(TestBaseOption):
             self.assertSetEqual(set([key]), set(options.enabled_profiles))
             options.set({'{}.is_enabled'.format(key): False})
 
+    def test_eq(self):
+        super().test_eq()
+
+        options = self.get_options()
+        options2 = self.get_options()
+        options.multiprocess.is_enabled = False
+        options.float.precision.sample_ratio = 0.1
+        self.assertFalse(options == options2)
+        options2.multiprocess.is_enabled = False
+        options2.float.precision.sample_ratio = 0.1
+        self.assertTrue(options == options2)
+

--- a/dataprofiler/tests/profilers/profiler_options/test_text_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_text_options.py
@@ -25,3 +25,13 @@ class TestTextOptions(TestNumericalOptions):
     
     def test_is_numeric_stats_enabled(self):
         super().test_is_numeric_stats_enabled()
+
+    def test_eq(self):
+        super().test_eq()
+
+        options = self.get_options()
+        options2 = self.get_options()
+        options.vocab.is_enabled = False
+        self.assertFalse(options == options2)
+        options2.vocab.is_enabled = False
+        self.assertTrue(options == options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_text_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_text_options.py
@@ -32,6 +32,6 @@ class TestTextOptions(TestNumericalOptions):
         options = self.get_options()
         options2 = self.get_options()
         options.vocab.is_enabled = False
-        self.assertFalse(options == options2)
+        self.assertNotEqual(options, options2)
         options2.vocab.is_enabled = False
-        self.assertTrue(options == options2)
+        self.assertEqual(options, options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_unstructured_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_unstructured_options.py
@@ -127,3 +127,15 @@ class TestUnstructuredOptions(TestBaseOption):
         # Disable directly
         option.data_labeler.is_enabled = False
         self.assertEqual([], option.enabled_profiles)
+
+    def test_eq(self):
+        super().test_eq()
+
+        options = self.get_options()
+        options2 = self.get_options()
+        options.data_labeler.is_enabled = False
+        options.text.stop_words = ["woah", "stop", "right", "there"]
+        self.assertFalse(options == options2)
+        options2.data_labeler.is_enabled = False
+        options2.text.stop_words = ["woah", "stop", "right", "there"]
+        self.assertTrue(options == options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_unstructured_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_unstructured_options.py
@@ -134,8 +134,13 @@ class TestUnstructuredOptions(TestBaseOption):
         options = self.get_options()
         options2 = self.get_options()
         options.data_labeler.is_enabled = False
-        options.text.stop_words = ["woah", "stop", "right", "there"]
         self.assertNotEqual(options, options2)
         options2.data_labeler.is_enabled = False
+        self.assertEqual(options, options2)
+
+        options.text.stop_words = ["woah", "stop", "right", "there"]
+        self.assertNotEqual(options, options2)
+        options2.text.stop_words = ["those", "don't", "match"]
+        self.assertNotEqual(options, options2)
         options2.text.stop_words = ["woah", "stop", "right", "there"]
         self.assertEqual(options, options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_unstructured_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_unstructured_options.py
@@ -135,7 +135,7 @@ class TestUnstructuredOptions(TestBaseOption):
         options2 = self.get_options()
         options.data_labeler.is_enabled = False
         options.text.stop_words = ["woah", "stop", "right", "there"]
-        self.assertFalse(options == options2)
+        self.assertNotEqual(options, options2)
         options2.data_labeler.is_enabled = False
         options2.text.stop_words = ["woah", "stop", "right", "there"]
-        self.assertTrue(options == options2)
+        self.assertEqual(options, options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_unstructured_text_profile_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_unstructured_text_profile_options.py
@@ -177,7 +177,7 @@ class TestTextProfilerOptions(TestBaseInspectorOptions):
         with self.assertRaisesRegex(ValueError, expected_error):
             option.validate()
 
-    def test_eq(self, *mocks):
+    def test_eq(self):
         super().test_eq()
 
         options = self.get_options()

--- a/dataprofiler/tests/profilers/profiler_options/test_unstructured_text_profile_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_unstructured_text_profile_options.py
@@ -184,7 +184,7 @@ class TestTextProfilerOptions(TestBaseInspectorOptions):
         options2 = self.get_options()
         options.is_case_sensitive = False
         options.words.is_enabled = False
-        self.assertFalse(options == options2)
+        self.assertNotEqual(options, options2)
         options2.is_case_sensitive = False
         options2.words.is_enabled = False
-        self.assertTrue(options == options2)
+        self.assertEqual(options, options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_unstructured_text_profile_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_unstructured_text_profile_options.py
@@ -176,3 +176,15 @@ class TestTextProfilerOptions(TestBaseInspectorOptions):
             "or list of strings.")
         with self.assertRaisesRegex(ValueError, expected_error):
             option.validate()
+
+    def test_eq(self, *mocks):
+        super().test_eq()
+
+        options = self.get_options()
+        options2 = self.get_options()
+        options.is_case_sensitive = False
+        options.words.is_enabled = False
+        self.assertFalse(options == options2)
+        options2.is_case_sensitive = False
+        options2.words.is_enabled = False
+        self.assertTrue(options == options2)

--- a/dataprofiler/tests/profilers/profiler_options/test_unstructured_text_profile_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_unstructured_text_profile_options.py
@@ -183,8 +183,11 @@ class TestTextProfilerOptions(TestBaseInspectorOptions):
         options = self.get_options()
         options2 = self.get_options()
         options.is_case_sensitive = False
-        options.words.is_enabled = False
         self.assertNotEqual(options, options2)
         options2.is_case_sensitive = False
+        self.assertEqual(options, options2)
+
+        options.words.is_enabled = False
+        self.assertNotEqual(options, options2)
         options2.words.is_enabled = False
         self.assertEqual(options, options2)


### PR DESCRIPTION
`__eq__` function in `BaseOption` that checks equality between all attributes. All attributes are either Python primitive types, other options, or DataLabeler objects, so hence all have `__eq__` functions already, although an enhancement was made to the labeler `__eq__` in this PR to better handle Nones, before it would error.