### PR TITLE
Add skewness and kurtosis statistics to numerical stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,6 @@ The format for a structured profile is below:
 		'mean': float,
 		'var': float,
 		'std': float,
-		'skewness': float,
-		'kurtosis': float,
 		'sample_size': int,
 		'margin_of_error': float,
 		'confidence_level': float		

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -37,6 +37,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             'mean': None,
             'var': None,
             'std': None,
+            # TODO: skew, kurt here
             'sum': None,
             'sample_size': None,
             'margin_of_error': None,
@@ -127,6 +128,8 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             mean=self.np_type_to_type(self.mean),
             variance=self.np_type_to_type(self.variance),
             stddev=self.np_type_to_type(self.stddev),
+            skewness=self.np_type_to_type(self.skewness),
+            # TODO: Kurtosis here
             histogram=self._get_best_histogram_for_profile(),
             quantiles=self.quantiles,
             times=self.times,
@@ -136,6 +139,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
                 mean=self.np_type_to_type(self.precision['mean']),
                 var=self.np_type_to_type(self.precision['var']),
                 std=self.np_type_to_type(self.precision['std']),
+                # TODO: Add skewness, kurtosis here
                 sample_size=self.np_type_to_type(self.precision['sample_size']),
                 margin_of_error=self.np_type_to_type(self.precision['margin_of_error']),
                 confidence_level=self.np_type_to_type(self.precision['confidence_level'])

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -129,7 +129,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             variance=self.np_type_to_type(self.variance),
             stddev=self.np_type_to_type(self.stddev),
             skewness=self.np_type_to_type(self.skewness),
-            # TODO: Kurtosis here
+            kurtosis=self.np_type_to_type(self.kurtosis),
             histogram=self._get_best_histogram_for_profile(),
             quantiles=self.quantiles,
             times=self.times,

--- a/dataprofiler/profilers/int_column_profile.py
+++ b/dataprofiler/profilers/int_column_profile.py
@@ -67,7 +67,7 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             variance=self.np_type_to_type(self.variance),
             stddev=self.np_type_to_type(self.stddev),
             skewness=self.np_type_to_type(self.skewness),
-            # TODO: Kurtosis here
+            kurtosis=self.np_type_to_type(self.kurtosis),
             histogram=self._get_best_histogram_for_profile(),
             quantiles=self.quantiles,
             times=self.times

--- a/dataprofiler/profilers/int_column_profile.py
+++ b/dataprofiler/profilers/int_column_profile.py
@@ -66,6 +66,8 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             mean=self.np_type_to_type(self.mean),
             variance=self.np_type_to_type(self.variance),
             stddev=self.np_type_to_type(self.stddev),
+            skewness=self.np_type_to_type(self.skewness),
+            # TODO: Kurtosis here
             histogram=self._get_best_histogram_for_profile(),
             quantiles=self.quantiles,
             times=self.times

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -355,7 +355,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         :return: unbiased estimator of skewness
         :rtype: NaN if sample size is too small, float otherwise
         """
-        if biased_skewness is None or np.isnan(biased_skewness) or match_count < 3:
+        if np.isnan(biased_skewness) or match_count < 3:
             return np.nan
 
         skewness = np.sqrt(match_count * (match_count - 1)) \
@@ -427,7 +427,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         :return: unbiased estimator of kurtosis
         :rtype: NaN if sample size is too small, float otherwise
         """
-        if biased_kurtosis is None or np.isnan(biased_kurtosis) or match_count < 4:
+        if np.isnan(biased_kurtosis) or match_count < 4:
             return np.nan
 
         kurtosis = (match_count - 1) / ((match_count - 2) *
@@ -887,6 +887,19 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
     @BaseColumnProfiler._timeit(name = "skewness")
     def _get_skewness(self, df_series, prev_dependent_properties,
                       subset_properties):
+        """
+        Computes and updates the skewness of the current dataset given
+        new chunk
+
+        :param df_series: incoming data
+        :type df_series: pandas series
+        :param prev_dependent_properties: pre-update values needed
+            for computation
+        :type prev_dependent_properties: dict
+        :param subset_properties: incoming data statistics
+        :type subset_properties: dict
+        :return None
+        """
         batch_biased_skewness = skew(df_series)
         subset_properties["biased_skewness"] = batch_biased_skewness
         batch_count = subset_properties["match_count"]
@@ -903,6 +916,19 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
     @BaseColumnProfiler._timeit(name = "kurtosis")
     def _get_kurtosis(self, df_series, prev_dependent_properties,
                       subset_properties):
+        """
+        Computes and updates the kurtosis of the current dataset given
+        new chunk
+
+        :param df_series: incoming data
+        :type df_series: pandas series
+        :param prev_dependent_properties: pre-update values needed
+            for computation
+        :type prev_dependent_properties: dict
+        :param subset_properties: incoming data statistics
+        :type subset_properties: dict
+        :return None
+        """
         batch_biased_kurtosis = kurtosis(df_series)
         subset_properties["biased_kurtosis"] = batch_biased_kurtosis
         batch_count = subset_properties["match_count"]

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -302,7 +302,18 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
     def _merge_biased_skewness(match_count1, biased_skewness1, variance1, mean1,
                                match_count2, biased_skewness2, variance2, mean2):
         """
-        # TODO: Documentation
+        Calculate the combined skewness of two data chunks
+
+        :param match_count1: # of samples in 1st chunk
+        :param biased_skewness1: skewness of 1st chunk without bias correction
+        :param variance1: variance of 1st chunk
+        :param mean1: mean of 1st chunk
+        :param match_count2: # of samples in 2nd chunk
+        :param biased_skewness2: skewness of 2nd chunk without bias correction
+        :param variance2: variance of 2nd chunk
+        :param mean2: mean of 2nd chunk
+        :return: combined skewness
+        :rtype: float
         """
         if np.isnan(biased_skewness1):
             biased_skewness1 = 0
@@ -336,7 +347,14 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
 
     @staticmethod
     def _correct_bias_skewness(match_count, biased_skewness):
-        """ TODO: Documentation """
+        """
+        Apply bias correction to skewness
+
+        :param match_count: number of samples
+        :param biased_skewness: skewness without bias correction
+        :return: unbiased estimator of skewness
+        :rtype: NaN if sample size is too small, float otherwise
+        """
         if biased_skewness is None or np.isnan(biased_skewness) or match_count < 3:
             return np.nan
 
@@ -345,8 +363,25 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         return skewness
 
     @staticmethod
-    def _merge_biased_kurtosis(match_count1, biased_kurtosis1, biased_skewness1, variance1, mean1,
-                        match_count2, biased_kurtosis2, biased_skewness2, variance2, mean2):
+    def _merge_biased_kurtosis(match_count1, biased_kurtosis1, biased_skewness1,
+                               variance1, mean1, match_count2, biased_kurtosis2,
+                               biased_skewness2, variance2, mean2):
+        """
+        Calculate the combined kurtosis of two sets of data
+
+        :param match_count1: # of samples in 1st chunk
+        :param biased_kurtosis1: kurtosis of 1st chunk without bias correction
+        :param biased_skewness1: skewness of 1st chunk without bias correction
+        :param variance1: variance of 1st chunk
+        :param mean1: mean of 1st chunk
+        :param match_count2: # of samples in 2nd chunk
+        :param biased_kurtosis2: kurtosis of 2nd chunk without bias correction
+        :param biased_skewness2: skewness of 2nd chunk without bias correction
+        :param variance2: variance of 2nd chunk
+        :param mean2: mean of 2nd chunk
+        :return: combined skewness
+        :rtype: float
+        """
         if np.isnan(biased_kurtosis1):
             biased_kurtosis1 = 0
         if np.isnan(biased_kurtosis2):
@@ -384,6 +419,14 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
 
     @staticmethod
     def _correct_bias_kurtosis(match_count, biased_kurtosis):
+        """
+        Apply bias correction to kurtosis
+
+        :param match_count: number of samples
+        :param biased_kurtosis: skewness without bias correction
+        :return: unbiased estimator of kurtosis
+        :rtype: NaN if sample size is too small, float otherwise
+        """
         if biased_kurtosis is None or np.isnan(biased_kurtosis) or match_count < 4:
             return np.nan
 
@@ -850,11 +893,12 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         batch_var = subset_properties["variance"]
         batch_mean = subset_properties["mean"]
 
-        self._biased_skewness = self._merge_biased_skewness(self.match_count, self._biased_skewness,
-                                                            prev_dependent_properties["variance"],
-                                                            prev_dependent_properties["mean"],
-                                                            batch_count, batch_biased_skewness,
-                                                            batch_var, batch_mean)
+        self._biased_skewness = self._merge_biased_skewness(
+            self.match_count, self._biased_skewness,
+            prev_dependent_properties["variance"],
+            prev_dependent_properties["mean"],
+            batch_count, batch_biased_skewness,
+            batch_var, batch_mean)
 
     @BaseColumnProfiler._timeit(name = "kurtosis")
     def _get_kurtosis(self, df_series, prev_dependent_properties,
@@ -866,13 +910,14 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         batch_biased_skewness = subset_properties["biased_skewness"]
         batch_mean = subset_properties["mean"]
 
-        self._biased_kurtosis = self._merge_biased_kurtosis(self.match_count, self._biased_kurtosis,
-                                             prev_dependent_properties["biased_skewness"],
-                                             prev_dependent_properties["variance"],
-                                             prev_dependent_properties["mean"],
-                                             batch_count, batch_biased_kurtosis,
-                                             batch_biased_skewness,
-                                             batch_var, batch_mean)
+        self._biased_kurtosis = self._merge_biased_kurtosis(
+            self.match_count, self._biased_kurtosis,
+            prev_dependent_properties["biased_skewness"],
+            prev_dependent_properties["variance"],
+            prev_dependent_properties["mean"],
+            batch_count, batch_biased_kurtosis,
+            batch_biased_skewness,
+            batch_var, batch_mean)
 
     @BaseColumnProfiler._timeit(name="histogram_and_quantiles")
     def _get_histogram_and_quantiles(self, df_series,

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -7,7 +7,6 @@ respective parameters.
 from __future__ import print_function
 from __future__ import division
 
-from scipy.stats import skew, kurtosis
 from future.utils import with_metaclass
 import copy
 import abc
@@ -15,6 +14,7 @@ import warnings
 import sys
 
 import numpy as np
+import scipy.stats
 
 from . import histogram_utils
 from .base_column_profilers import BaseColumnProfiler
@@ -900,7 +900,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         :type subset_properties: dict
         :return None
         """
-        batch_biased_skewness = skew(df_series)
+        batch_biased_skewness = scipy.stats.skew(df_series)
         subset_properties["biased_skewness"] = batch_biased_skewness
         batch_count = subset_properties["match_count"]
         batch_var = subset_properties["variance"]
@@ -929,7 +929,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         :type subset_properties: dict
         :return None
         """
-        batch_biased_kurtosis = kurtosis(df_series)
+        batch_biased_kurtosis = scipy.stats.kurtosis(df_series)
         subset_properties["biased_kurtosis"] = batch_biased_kurtosis
         batch_count = subset_properties["match_count"]
         batch_var = subset_properties["variance"]

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -282,7 +282,8 @@ class NumericalOptions(BaseInspectorOptions):
         """
         if self.min.is_enabled or self.max.is_enabled or self.sum.is_enabled \
                 or self.variance.is_enabled or self.skewness.is_enabled \
-                or self.histogram_and_quantiles.is_enabled: \
+                or self.kurtosis.is_enabled \
+                or self.histogram_and_quantiles.is_enabled:
             return True
         return False
 
@@ -352,7 +353,7 @@ class NumericalOptions(BaseInspectorOptions):
         if (sum_disabled or var_disabled or skew_disabled) \
             and not kurt_disabled:
             errors.append("{}: The numeric stats must toggle on sum,"
-                          "variance, and skewness if kurtosis is "
+                          " variance, and skewness if kurtosis is "
                           "toggled on.".format(variable_path))
 
         # warn user if all stats are disabled

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -253,13 +253,16 @@ class NumericalOptions(BaseInspectorOptions):
         :vartype sum: BooleanOption
         :ivar variance: boolean option to enable/disable variance
         :vartype variance: BooleanOption
+        :ivar skewness: boolean option to enable/disable skewness
+        :vartype skewness: BooleanOption
+        :ivar kurtosis: boolean option to enable/disable kurtosis
+        :vartype kurtosis: BooleanOption
         :ivar histogram_and_quantiles: boolean option to enable/disable
             histogram_and_quantiles
         :vartype histogram_and_quantiles: BooleanOption
         :ivar is_numeric_stats_enabled: boolean to enable/disable all numeric
             stats
         :vartype is_numeric_stats_enabled: bool
-        TODO: Add comments for skew/kurt here
         """
         self.min = BooleanOption(is_enabled=True)
         self.max = BooleanOption(is_enabled=True)
@@ -291,7 +294,7 @@ class NumericalOptions(BaseInspectorOptions):
     def is_numeric_stats_enabled(self, value):
         """
         This property will enable or disable all numeric stats properties:
-        min, max, sum, variance, histogram_and_quantiles
+        min, max, sum, variance, skewness, kurtosis, histogram_and_quantiles
 
         :param value: boolean to enable/disable all numeric stats properties
         :type value: bool
@@ -382,6 +385,10 @@ class IntOptions(NumericalOptions):
         :vartype sum: BooleanOption
         :ivar variance: boolean option to enable/disable variance
         :vartype variance: BooleanOption
+        :ivar skewness: boolean option to enable/disable skewness
+        :vartype skewness: BooleanOption
+        :ivar kurtosis: boolean option to enable/disable kurtosis
+        :vartype kurtosis: BooleanOption
         :ivar histogram_and_quantiles: boolean option to enable/disable
             histogram_and_quantiles
         :vartype histogram_and_quantiles: BooleanOption
@@ -459,6 +466,10 @@ class FloatOptions(NumericalOptions):
         :vartype sum: BooleanOption
         :ivar variance: boolean option to enable/disable variance
         :vartype variance: BooleanOption
+        :ivar skewness: boolean option to enable/disable skewness
+        :vartype skewness: BooleanOption
+        :ivar kurtosis: boolean option to enable/disable kurtosis
+        :vartype kurtosis: BooleanOption
         :ivar histogram_and_quantiles: boolean option to enable/disable
             histogram_and_quantiles
         :vartype histogram_and_quantiles: BooleanOption
@@ -504,6 +515,10 @@ class TextOptions(NumericalOptions):
         :vartype sum: BooleanOption
         :ivar variance: boolean option to enable/disable variance
         :vartype variance: BooleanOption
+        :ivar skewness: boolean option to enable/disable skewness
+        :vartype skewness: BooleanOption
+        :ivar kurtosis: boolean option to enable/disable kurtosis
+        :vartype kurtosis: BooleanOption
         :ivar histogram_and_quantiles: boolean option to enable/disable
             histogram_and_quantiles
         :vartype histogram_and_quantiles: BooleanOption

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -336,24 +336,25 @@ class NumericalOptions(BaseInspectorOptions):
                 errors += self.properties[item]._validate_helper(
                     variable_path=variable_path + '.' + item)
 
-        # Sum is not toggled
-        if not self.properties["sum"].is_enabled:
-            if self.properties["variance"].is_enabled:
-                errors.append("{}: The numeric stats must toggle on the sum "
-                              "if the variance is toggled on."
-                              .format(variable_path))
-            # Variance is also not toggled
-            else:
-                if self.properties["skewness"].is_enabled:
-                    errors.append("{}: The numeric stats must toggle on the "
-                                  "sum and variance if skewness is toggled on."
-                                  .format(variable_path))
-                # Skewness is also not toggled
-                else:
-                    if self.properties["kurtosis"].is_enabled:
-                        errors.append("{}: The numeric stats must toggle on sum,"
-                                      "variance, and skewness if kurtosis is "
-                                      "toggled on.".format(variable_path))
+        # Error checks for dependent calculations
+        sum_disabled = not self.properties["sum"].is_enabled
+        var_disabled = not self.properties["variance"].is_enabled
+        skew_disabled = not self.properties["skewness"].is_enabled
+        kurt_disabled = not self.properties["kurtosis"].is_enabled
+        if sum_disabled and not var_disabled:
+            errors.append("{}: The numeric stats must toggle on the sum "
+                          "if the variance is toggled on."
+                          .format(variable_path))
+        if (sum_disabled or var_disabled) and not skew_disabled:
+            errors.append("{}: The numeric stats must toggle on the "
+                          "sum and variance if skewness is toggled on."
+                          .format(variable_path))
+        if (sum_disabled or var_disabled or skew_disabled) \
+            and not kurt_disabled:
+            errors.append("{}: The numeric stats must toggle on sum,"
+                          "variance, and skewness if kurtosis is "
+                          "toggled on.".format(variable_path))
+
         # warn user if all stats are disabled
         if not errors:
             if not self.is_numeric_stats_enabled:

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -259,11 +259,13 @@ class NumericalOptions(BaseInspectorOptions):
         :ivar is_numeric_stats_enabled: boolean to enable/disable all numeric
             stats
         :vartype is_numeric_stats_enabled: bool
+        TODO: Add comments for skew/kurt here
         """
         self.min = BooleanOption(is_enabled=True)
         self.max = BooleanOption(is_enabled=True)
         self.sum = BooleanOption(is_enabled=True)
         self.variance = BooleanOption(is_enabled=True)
+        self.skewness = BooleanOption(is_enabled=True)
         self.histogram_and_quantiles = HistogramOption()
         BaseInspectorOptions.__init__(self)
 
@@ -278,8 +280,8 @@ class NumericalOptions(BaseInspectorOptions):
         :rtype bool:
         """
         if self.min.is_enabled or self.max.is_enabled or self.sum.is_enabled \
-                or self.variance.is_enabled \
-                or self.histogram_and_quantiles.is_enabled:
+                or self.variance.is_enabled or self.skewness.is_enabled \
+                or self.histogram_and_quantiles.is_enabled: \
             return True
         return False
 
@@ -297,6 +299,7 @@ class NumericalOptions(BaseInspectorOptions):
         self.max.is_enabled = value
         self.sum.is_enabled = value
         self.variance.is_enabled = value
+        self.skewness.is_enabled = value
         self.histogram_and_quantiles.is_enabled = value
 
     @property
@@ -323,7 +326,7 @@ class NumericalOptions(BaseInspectorOptions):
 
         errors = super()._validate_helper(variable_path=variable_path)
         for item in ["histogram_and_quantiles", "min", "max", "sum",
-                     "variance"]:
+                     "variance", "skewness"]:
             if not isinstance(self.properties[item], BooleanOption):
                 errors.append("{}.{} must be a BooleanOption."
                               .format(variable_path, item))
@@ -336,7 +339,7 @@ class NumericalOptions(BaseInspectorOptions):
             errors.append("{}: The numeric stats must toggle on the sum "
                           "if the variance is toggled on."
                           .format(variable_path))
-
+        # TODO: Add error check for skewness if variance/sum isn't turned on
         # warn user if all stats are disabled
         if not errors:
             if not self.is_numeric_stats_enabled:

--- a/dataprofiler/profilers/text_column_profile.py
+++ b/dataprofiler/profilers/text_column_profile.py
@@ -72,7 +72,7 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             variance=self.variance,
             stddev=self.stddev,
             skewness=self.skewness,
-            # TODO: kurtosis here
+            kurtosis=self.kurtosis,
             histogram=self._get_best_histogram_for_profile(),
             quantiles=self.quantiles,
             vocab=self.vocab,

--- a/dataprofiler/profilers/text_column_profile.py
+++ b/dataprofiler/profilers/text_column_profile.py
@@ -71,6 +71,8 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             mean=self.mean,
             variance=self.variance,
             stddev=self.stddev,
+            skewness=self.skewness,
+            # TODO: kurtosis here
             histogram=self._get_best_histogram_for_profile(),
             quantiles=self.quantiles,
             vocab=self.vocab,

--- a/dataprofiler/tests/profilers/profiler_options/test_numerical_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_numerical_options.py
@@ -6,7 +6,8 @@ from dataprofiler.tests.profilers.profiler_options.test_base_inspector_options \
 class TestNumericalOptions(TestBaseInspectorOptions):
     
     option_class = NumericalOptions
-    keys = ["min", "max", "sum", "variance", "histogram_and_quantiles"]
+    keys = ["min", "max", "sum", "variance", "skewness",
+            "kurtosis", "histogram_and_quantiles"]
 
     def test_init(self):
         options = self.get_options()
@@ -51,11 +52,41 @@ class TestNumericalOptions(TestBaseInspectorOptions):
             options.set({skey: True})
 
         # Disable Sum and Enable Variance
-        options.set({"sum.is_enabled": False, "variance.is_enabled": True})
-        expected_error = "{}: The numeric stats must toggle on the sum if " \
+        options.set({"sum.is_enabled": False,
+                     "variance.is_enabled": True,
+                     "skewness.is_enabled": False,
+                     "kurtosis.is_enabled": False})
+        var_error = "{}: The numeric stats must toggle on the sum if " \
                          "the variance is toggled on.".format(optpth)
-        self.assertEqual([expected_error], options._validate_helper()) 
-    
+        self.assertEqual([var_error], options._validate_helper())
+
+        # Disable Sum and Variance, Enable Skewness
+        options.set({"sum.is_enabled": False,
+                     "variance.is_enabled": False,
+                     "skewness.is_enabled": True,
+                     "kurtosis.is_enabled": False})
+        skew_error = "{}: The numeric stats must toggle on the " \
+                         "sum and variance if skewness is toggled on." \
+            .format(optpth)
+        self.assertEqual([skew_error], options._validate_helper())
+
+        # Disable Sum, Variance, and Skewness, Enable Kurtosis
+        options.set({"sum.is_enabled": False,
+                     "variance.is_enabled": False,
+                     "skewness.is_enabled": False,
+                     "kurtosis.is_enabled": True})
+        kurt_error = "{}: The numeric stats must toggle on sum," \
+                         " variance, and skewness if kurtosis is " \
+                         "toggled on.".format(optpth)
+        self.assertEqual([kurt_error], options._validate_helper())
+
+        # Test multiple errors
+        options.set({"sum.is_enabled": False,
+                     "variance.is_enabled": True,
+                     "skewness.is_enabled": True,
+                     "kurtosis.is_enabled": True})
+        self.assertEqual([var_error, skew_error, kurt_error], options._validate_helper())
+
     def test_validate(self):
         super().test_validate()
         options = self.get_options()
@@ -75,16 +106,53 @@ class TestNumericalOptions(TestBaseInspectorOptions):
             options.set({skey: True})
 
         # Disable Sum and Enable Variance
-        options.set({"sum.is_enabled": False, "variance.is_enabled": True})
-        expected_error = "{}: The numeric stats must toggle on the sum if " \
+        options.set({"sum.is_enabled": False,
+                     "variance.is_enabled": True,
+                     "skewness.is_enabled": False,
+                     "kurtosis.is_enabled": False})
+        var_error = "{}: The numeric stats must toggle on the sum if " \
                          "the variance is toggled on.".format(optpth)
-        with self.assertRaisesRegex(ValueError, expected_error):
-            options.validate(raise_error=True)    
-        self.assertEqual([expected_error], options.validate(raise_error=False))
-    
+        with self.assertRaisesRegex(ValueError, var_error):
+            options.validate(raise_error=True)
+        self.assertEqual([var_error], options.validate(raise_error=False))
+
+        # Disable Sum and Variance, Enable Skewness
+        options.set({"sum.is_enabled": False,
+                     "variance.is_enabled": False,
+                     "skewness.is_enabled": True,
+                     "kurtosis.is_enabled": False})
+        skew_error = "{}: The numeric stats must toggle on the " \
+                         "sum and variance if skewness is toggled on." \
+            .format(optpth)
+        with self.assertRaisesRegex(ValueError, skew_error):
+            options.validate(raise_error=True)
+        self.assertEqual([skew_error], options.validate(raise_error=False))
+
+        # Disable Sum, Variance, and Skewness, Enable Kurtosis
+        options.set({"sum.is_enabled": False,
+                     "variance.is_enabled": False,
+                     "skewness.is_enabled": False,
+                     "kurtosis.is_enabled": True})
+        kurt_error = "{}: The numeric stats must toggle on sum," \
+                         " variance, and skewness if kurtosis is " \
+                         "toggled on.".format(optpth)
+        with self.assertRaisesRegex(ValueError, kurt_error):
+            options.validate(raise_error=True)
+        self.assertEqual([kurt_error], options.validate(raise_error=False))
+
+        # Test multiple errors
+        options.set({"sum.is_enabled": False,
+                     "variance.is_enabled": True,
+                     "skewness.is_enabled": True,
+                     "kurtosis.is_enabled": True})
+        with self.assertRaisesRegex(ValueError, kurt_error):
+            options.validate(raise_error=True)
+        self.assertEqual([var_error, skew_error, kurt_error], options.validate(raise_error=False))
+
     def test_is_numeric_stats_enabled(self):
         options = self.get_options()
-        numeric_keys = ["min", "max", "sum", "variance", 
+        numeric_keys = ["min", "max", "sum", "variance",
+                        "skewness", "kurtosis",
                         "histogram_and_quantiles"] 
 
         # Disable All Numeric Stats

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from unittest import mock
 
+import numpy as np
 import pandas as pd
 
 from dataprofiler import Data, ProfilerOptions, Profiler
@@ -138,7 +139,9 @@ class TestProfilerOptions(unittest.TestCase):
             "min.is_enabled": False,
             "max.is_enabled": False,
             "sum.is_enabled": False,
-            "variance.is_enabled": False
+            "variance.is_enabled": False,
+            "skewness.is_enabled": False,
+            "kurtosis.is_enabled": False
         }
         options.set(statistical_options)
 
@@ -169,6 +172,8 @@ class TestProfilerOptions(unittest.TestCase):
                 self.assertIsNone(profile_column["statistics"]["max"])
                 self.assertEqual(0, profile_column["statistics"]["variance"])
                 self.assertIsNone(profile_column["statistics"]["quantiles"][0])
+                self.assertTrue(profile_column["statistics"]["skewness"] is np.nan)
+                self.assertTrue(profile_column["statistics"]["kurtosis"] is np.nan)
 
     def test_validate(self, *mocks):
         options = ProfilerOptions()
@@ -194,7 +199,9 @@ class TestProfilerOptions(unittest.TestCase):
             "min.is_enabled": False,
             "max.is_enabled": False,
             "sum.is_enabled": False,
-            "variance.is_enabled": True
+            "variance.is_enabled": True,
+            "skewness.is_enabled": False,
+            "kurtosis.is_enabled": False
         }
         # Asserts error since sum must be toggled on if variance is
         expected_error = (

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -337,16 +337,16 @@ class TestFloatColumn(unittest.TestCase):
         num_profiler = FloatColumn(df1.name)
         num_profiler.update(df1.apply(str))
 
-        self.assertEqual(df1.skew(), num_profiler.skewness)
+        self.assertEqual(0, num_profiler.skewness)
 
         num_profiler.update(df2.apply(str))
         df = pd.concat([df1, df2])
         print(num_profiler.skewness)
-        self.assertAlmostEqual(df.skew(), num_profiler.skewness)
+        self.assertAlmostEqual(np.sqrt(22 * 21) / 20 * 133 / 750, num_profiler.skewness)
 
         num_profiler.update(df3.apply(str))
         df = pd.concat([df1, df2, df3])
-        self.assertAlmostEqual(df.skew(), num_profiler.skewness)
+        self.assertAlmostEqual(-0.3109967, num_profiler.skewness)
 
     def test_profiled_kurtosis(self):
         data = np.linspace(-5, 5, 11).tolist()
@@ -361,15 +361,15 @@ class TestFloatColumn(unittest.TestCase):
         num_profiler = FloatColumn(df1.name)
         num_profiler.update(df1.apply(str))
 
-        self.assertAlmostEqual(df1.kurtosis(), num_profiler.kurtosis)
+        self.assertAlmostEqual(-6 / 5, num_profiler.kurtosis)
 
         num_profiler.update(df2.apply(str))
         df = pd.concat([df1, df2])
-        self.assertAlmostEqual(df.kurtosis(), num_profiler.kurtosis)
+        self.assertAlmostEqual(-0.390358, num_profiler.kurtosis)
 
         num_profiler.update(df3.apply(str))
         df = pd.concat([df1, df2, df3])
-        self.assertAlmostEqual(df.kurtosis(), num_profiler.kurtosis)
+        self.assertAlmostEqual(0.3311739, num_profiler.kurtosis)
 
     def test_null_values_for_histogram(self):
         data = pd.Series(['-inf', 'inf'])

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -124,8 +124,6 @@ class TestFloatColumn(unittest.TestCase):
         self.assertEqual(10, float_profiler.precision['sample_size'])
         self.assertEqual(0, float_profiler.precision['var'])
         self.assertEqual(0, float_profiler.precision['std'])
-        self.assertEqual(0, float_profiler.precision['skewness'])
-        self.assertAlmostEqual(-4.3392857, float_profiler.precision['kurtosis'])
 
         # random precision
         df_random = pd.Series(['+ 9', '-.3', '-1e-3', '3.2343', '0',
@@ -138,8 +136,6 @@ class TestFloatColumn(unittest.TestCase):
         self.assertEqual(9, float_profiler.precision['sample_size'])
         self.assertEqual(2.7778, float_profiler.precision['var'])
         self.assertEqual(1.6667, float_profiler.precision['std'])
-        self.assertAlmostEqual(0.1242857, float_profiler.precision['skewness'])
-        self.assertAlmostEqual(-1.1365714, float_profiler.precision['kurtosis'])
 
         # Ensure order doesn't change anything
         df_random_order = pd.Series(['1230', '0.33', '4.3', '302.1', '-4.322',
@@ -147,15 +143,9 @@ class TestFloatColumn(unittest.TestCase):
         float_profiler_order = FloatColumn("Name")
         float_profiler_order.update(df_random)
 
-        skew = float_profiler.precision.pop('skewness')
-        order_skew = float_profiler_order.precision.pop('skewness')
-        kurt = float_profiler.precision.pop('kurtosis')
-        order_kurt = float_profiler_order.precision.pop('kurtosis')
         self.assertDictEqual(
             float_profiler.precision, float_profiler_order.precision
         )
-        self.assertAlmostEqual(skew, order_skew)
-        self.assertAlmostEqual(kurt, order_kurt)
 
         # check to make sure all formats of precision are correctly predicted
         samples = [
@@ -753,8 +743,6 @@ class TestFloatColumn(unittest.TestCase):
                 'mean': 2.0,
                 'var': 1.0,
                 'std': 1.0,
-                'skewness': 0.0,
-                'kurtosis': np.nan,
                 'sample_size': 3,
                 'margin_of_error': 1.9,
                 'confidence_level': 0.999

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -25,6 +25,8 @@ class TestIntColumn(unittest.TestCase):
         self.assertEqual(profiler.max, None)
         self.assertEqual(profiler.mean, 0)
         self.assertEqual(profiler.variance, 0)
+        self.assertTrue(profiler.skewness is np.nan)
+        self.assertTrue(profiler.kurtosis is np.nan)
         self.assertTrue(profiler.stddev is np.nan)
         self.assertIsNone(profiler.histogram_selection)
         self.assertDictEqual({k: profiler.quantiles.get(k, 'fail')
@@ -201,6 +203,56 @@ class TestIntColumn(unittest.TestCase):
         self.assertEqual(variance, num_profiler.variance)
         self.assertEqual(np.sqrt(variance), num_profiler.stddev)
 
+    def test_profiled_skewness(self):
+        data = np.linspace(-5, 5, 11).tolist()
+        df1 = pd.Series(data)
+
+        data = np.linspace(-3, 2, 11).tolist()
+        df2 = pd.Series(data)
+
+        data = np.full((10,), 1)
+        df3 = pd.Series(data)
+
+        num_profiler = IntColumn(df1.name)
+        num_profiler.update(df1.apply(str))
+
+        self.assertAlmostEqual(df1.skew(), num_profiler.skewness)
+
+        df2_ints = df2[df2 == df2.round()]
+        num_profiler.update(df2.apply(str))
+        df = pd.concat([df1, df2_ints])
+        self.assertAlmostEqual(df.skew(), num_profiler.skewness)
+
+        df3_ints = df3[df3 == df3.round()]
+        num_profiler.update(df3.apply(str))
+        df = pd.concat([df1, df2_ints, df3_ints])
+        self.assertAlmostEqual(df.skew(), num_profiler.skewness)
+
+    def test_profiled_kurtosis(self):
+        data = np.linspace(-5, 5, 11).tolist()
+        df1 = pd.Series(data)
+
+        data = np.linspace(-3, 2, 11).tolist()
+        df2 = pd.Series(data)
+
+        data = np.full((10,), 1)
+        df3 = pd.Series(data)
+
+        num_profiler = IntColumn(df1.name)
+        num_profiler.update(df1.apply(str))
+
+        self.assertAlmostEqual(df1.kurtosis(), num_profiler.kurtosis)
+
+        df2_ints = df2[df2 == df2.round()]
+        num_profiler.update(df2.apply(str))
+        df = pd.concat([df1, df2_ints])
+        self.assertAlmostEqual(df.kurtosis(), num_profiler.kurtosis)
+
+        df3_ints = df3[df3 == df3.round()]
+        num_profiler.update(df3.apply(str))
+        df = pd.concat([df1, df2_ints, df3_ints])
+        self.assertAlmostEqual(df.kurtosis(), num_profiler.kurtosis)
+
     def test_profiled_histogram(self):
         """
         Checks the histogram of profiled numerical columns.
@@ -271,6 +323,8 @@ class TestIntColumn(unittest.TestCase):
             max=6.0,
             mean=4.0,
             variance=8.0,
+            skewness=np.nan,
+            kurtosis=np.nan,
             stddev=np.sqrt(8.0),
             histogram={
                 'bin_counts': np.array([1, 0, 1]),
@@ -283,7 +337,8 @@ class TestIntColumn(unittest.TestCase):
             },
             times=defaultdict(
                 float, {'histogram_and_quantiles': 1.0, 'max': 1.0, 'min': 1.0,
-                        'sum': 1.0, 'variance': 1.0})
+                        'sum': 1.0, 'variance': 1.0, 'skewness': 1.0,
+                        'kurtosis': 1.0})
             
         )
         time_array = [float(i) for i in range(100, 0, -1)]
@@ -313,6 +368,7 @@ class TestIntColumn(unittest.TestCase):
 
             expected = defaultdict(
                 float, {'min': 1.0, 'max': 1.0, 'sum': 1.0, 'variance': 1.0,
+                        'skewness': 1.0, 'kurtosis': 1.0,
                         'histogram_and_quantiles': 1.0})
             self.assertEqual(expected, profile['times'])
 
@@ -321,6 +377,7 @@ class TestIntColumn(unittest.TestCase):
             profiler.update(df)
             expected = defaultdict(
                 float, {'min': 2.0, 'max': 2.0, 'sum': 2.0, 'variance': 2.0,
+                        'skewness': 2.0, 'kurtosis': 2.0,
                         'histogram_and_quantiles': 2.0})
             self.assertEqual(expected, profiler.profile['times'])
 
@@ -342,13 +399,15 @@ class TestIntColumn(unittest.TestCase):
             # Validate the time in the datetime class has the expected time.
             profile = profiler.profile
 
-            expected = defaultdict(float, {'max': 1.0, 'sum': 1.0, 'variance': 1.0, \
+            expected = defaultdict(float, {'max': 1.0, 'sum': 1.0, 'variance': 1.0,
+                                           'skewness': 1.0, 'kurtosis': 1.0,
                                            'histogram_and_quantiles': 1.0})
             self.assertCountEqual(expected, profile['times'])
 
             # Validate time in datetime class has expected time after second update
             profiler.update(df)
-            expected = defaultdict(float, {'max': 2.0, 'sum': 2.0, 'variance': 2.0, \
+            expected = defaultdict(float, {'max': 2.0, 'sum': 2.0, 'variance': 2.0,
+                                           'skewness': 2.0, 'kurtosis': 2.0,
                                            'histogram_and_quantiles': 2.0})
             self.assertCountEqual(expected, profiler.profile['times'])
 
@@ -368,6 +427,8 @@ class TestIntColumn(unittest.TestCase):
             max=15.0,
             mean=8.25,
             variance=30.916666666666668,
+            skewness=918 * np.sqrt(3 / 371) / 371,
+            kurtosis=-16068/19663,
             stddev=np.sqrt(30.916),
             histogram={
                 'bin_counts': np.array([1, 1, 1, 1]),
@@ -385,6 +446,10 @@ class TestIntColumn(unittest.TestCase):
                                expected_profile.pop('stddev'),places=3)
         self.assertAlmostEqual(profiler3.variance,
                                expected_profile.pop('variance'), places=3)
+        self.assertAlmostEqual(profiler3.skewness,
+                               expected_profile.pop('skewness'),places=3)
+        self.assertAlmostEqual(profiler3.kurtosis,
+                               expected_profile.pop('kurtosis'), places=3)
         self.assertEqual(profiler3.mean,expected_profile.pop('mean'))
         self.assertEqual(profiler3.histogram_selection, 'doane')
         self.assertEqual(profiler3.min,expected_profile.pop('min'))
@@ -421,6 +486,8 @@ class TestIntColumn(unittest.TestCase):
         profiler = profiler1 + profiler2
         self.assertEqual(profiler.min, None)
         self.assertEqual(profiler.max, None)
+        self.assertTrue(np.isnan(profiler.skewness))
+        self.assertTrue(np.isnan(profiler.kurtosis))
         self.assertIsNone(profiler.histogram_selection)
 
         df3 = pd.Series([2, 3]).apply(str)
@@ -430,6 +497,8 @@ class TestIntColumn(unittest.TestCase):
         profiler = profiler1 + profiler3
         self.assertEqual(profiler.min, 2)
         self.assertEqual(profiler.max, 3)
+        self.assertTrue(np.isnan(profiler.skewness))
+        self.assertTrue(np.isnan(profiler.kurtosis))
 
         df4 = pd.Series([4, 5]).apply(str)
         profiler4 = IntColumn("Int")
@@ -438,6 +507,8 @@ class TestIntColumn(unittest.TestCase):
         profiler = profiler3 + profiler4
         self.assertEqual(profiler.min, 2)
         self.assertEqual(profiler.max, 5)
+        self.assertEqual(profiler.skewness, 0)
+        self.assertAlmostEqual(profiler.kurtosis, -1.2)
 
     def test_custom_bin_count_merge(self):
 
@@ -593,4 +664,3 @@ class TestIntColumn(unittest.TestCase):
         profile_2.update(data_2)
 
         profile_1 + profile_2
-

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -219,17 +219,17 @@ class TestIntColumn(unittest.TestCase):
         num_profiler = IntColumn(df1.name)
         num_profiler.update(df1.apply(str))
 
-        self.assertAlmostEqual(df1.skew(), num_profiler.skewness)
+        self.assertEqual(0, num_profiler.skewness)
 
         df2_ints = df2[df2 == df2.round()]
         num_profiler.update(df2.apply(str))
         df = pd.concat([df1, df2_ints])
-        self.assertAlmostEqual(df.skew(), num_profiler.skewness)
+        self.assertAlmostEqual(11 * np.sqrt(102 / 91) / 91, num_profiler.skewness)
 
         df3_ints = df3[df3 == df3.round()]
         num_profiler.update(df3.apply(str))
         df = pd.concat([df1, df2_ints, df3_ints])
-        self.assertAlmostEqual(df.skew(), num_profiler.skewness)
+        self.assertAlmostEqual(-6789 * np.sqrt(39 / 463) / 4630, num_profiler.skewness)
 
     def test_profiled_kurtosis(self):
         data = np.linspace(-5, 5, 11).tolist()
@@ -244,17 +244,17 @@ class TestIntColumn(unittest.TestCase):
         num_profiler = IntColumn(df1.name)
         num_profiler.update(df1.apply(str))
 
-        self.assertAlmostEqual(df1.kurtosis(), num_profiler.kurtosis)
+        self.assertAlmostEqual(-6 / 5, num_profiler.kurtosis)
 
         df2_ints = df2[df2 == df2.round()]
         num_profiler.update(df2.apply(str))
         df = pd.concat([df1, df2_ints])
-        self.assertAlmostEqual(df.kurtosis(), num_profiler.kurtosis)
+        self.assertAlmostEqual(-29886 / 41405, num_profiler.kurtosis)
 
         df3_ints = df3[df3 == df3.round()]
         num_profiler.update(df3.apply(str))
         df = pd.concat([df1, df2_ints, df3_ints])
-        self.assertAlmostEqual(df.kurtosis(), num_profiler.kurtosis)
+        self.assertAlmostEqual(16015779 / 42873800, num_profiler.kurtosis)
 
     def test_profiled_histogram(self):
         """

--- a/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
+++ b/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
@@ -223,7 +223,9 @@ class TestNumericStatsMixin(unittest.TestCase):
         num_profiler = TestColumn()
 
         # Dummy data to make min call
-        prev_dependent_properties = {"mean": 0}
+        prev_dependent_properties = {"mean": 0,
+                                     "variance": 0,
+                                     "biased_skewness": 0}
         data = np.array([0, 0, 0, 0, 0])
         df_series = pd.Series(data)
         subset_properties = {"min": 0, "match_count": 0}
@@ -261,6 +263,22 @@ class TestNumericStatsMixin(unittest.TestCase):
             # Validate _get_variance is timed.
             expected['variance'] = 1.0
             num_profiler._get_variance(
+                df_series,
+                prev_dependent_properties,
+                subset_properties)
+            self.assertEqual(expected, num_profiler.times)
+
+            # Validate _get_skewness is timed
+            expected['skewness'] = 1.0
+            num_profiler._get_skewness(
+                df_series,
+                prev_dependent_properties,
+                subset_properties)
+            self.assertEqual(expected, num_profiler.times)
+
+            # Validate _get_kurtosis is timed
+            expected['kurtosis'] = 1.0
+            num_profiler._get_kurtosis(
                 df_series,
                 prev_dependent_properties,
                 subset_properties)
@@ -371,4 +389,3 @@ class TestNumericStatsMixin(unittest.TestCase):
         best_histogram = num_profiler._get_best_histogram_for_profile()
 
         assert best_histogram == "hist_1"
-

--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -1,5 +1,4 @@
 scikit-learn>=0.23.2
-scipy>=1.4.1
 keras>=2.4.3
 tensorflow-gpu>=2.3.0; sys.platform == 'linux'
 tensorflow>=2.3.0; sys.platform == 'darwin'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ h5py>=2.10.0
 wheel>=0.33.1
 future>=0.18.2
 numpy>=1.18.5
+scipy>=1.4.1
 pandas>=1.1.2
 python-dateutil>=2.7.5
 pytz>=2020.1


### PR DESCRIPTION
Added the bias-corrected skewness and kurtosis values as defined [here (skewness)](https://en.wikipedia.org/wiki/Skewness#Sample_skewness) and [here (kurtosis)](https://en.wikipedia.org/wiki/Kurtosis#Standard_unbiased_estimator)] for numerical statistics. Also added it for float precision statistics, but let me know if this isn't needed/useful.  