### PR TITLE
Add option for turning on/off bias correction

### DIFF
--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -144,8 +144,8 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         """
         Property reporting statistics on the significant figures of each
         element in the data.
-        :return
-        :rtype dict
+        :return: Precision statistics
+        :rtype: dict
         """
         # First add the stats that don't need to be re-calculated
         precision = dict(

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -141,6 +141,12 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
 
     @property
     def precision(self):
+        """
+        Property reporting statistics on the significant figures of each
+        element in the data.
+        :return
+        :rtype dict
+        """
         # First add the stats that don't need to be re-calculated
         precision = dict(
             min=self._precision['min'],

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -31,15 +31,13 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         NumericStatsMixin.__init__(self, options)
         BaseColumnPrimitiveTypeProfiler.__init__(self, name)
 
-        self.precision = {
+        self._precision = {
             'min': None,
             'max': None,
-            'mean': None,
-            'var': None,
-            'std': None,
             'sum': None,
+            'mean': None,
+            'biased_var': None,
             'sample_size': None,
-            'margin_of_error': None,
             'confidence_level': 0.999
         }
         self._biased_precision_var = np.nan
@@ -80,45 +78,31 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
 
         if "precision" in merged_profile.__calculations:
 
-            if self.precision['min'] is None:
-                merged_profile.precision = copy.deepcopy(other.precision)
+            if self._precision['min'] is None:
+                merged_profile._precision = copy.deepcopy(other._precision)
             elif other.precision['min'] is None:
-                merged_profile.precision = copy.deepcopy(self.precision)                
+                merged_profile._precision = copy.deepcopy(self._precision)
             else:
-                merged_profile.precision['min'] = min(
-                    self.precision['min'], other.precision['min'])
-                merged_profile.precision['max'] = max(
-                    self.precision['max'], other.precision['max'])
-                merged_profile.precision['sum'] = \
-                    self.precision['sum'] + other.precision['sum']
-                merged_profile.precision['sample_size'] = \
-                    self.precision['sample_size'] + other.precision['sample_size']
+                merged_profile._precision['min'] = min(
+                    self._precision['min'], other._precision['min'])
+                merged_profile._precision['max'] = max(
+                    self._precision['max'], other._precision['max'])
+                merged_profile._precision['sum'] = \
+                    self._precision['sum'] + other._precision['sum']
+                merged_profile._precision['sample_size'] = \
+                    self._precision['sample_size'] + other._precision['sample_size']
 
-                merged_profile._biased_precision_var = self._merge_biased_variance(
-                    self.precision['sample_size'],
-                    self._biased_precision_var, self.precision['mean'],
-                    other.precision['sample_size'],
-                    other._biased_precision_var,
-                    other.precision['mean'])
+                merged_profile._precision['mean'] = \
+                    merged_profile._precision['sum'] \
+                    / merged_profile._precision['sample_size']
 
-                merged_profile.precision['mean'] = \
-                    merged_profile.precision['sum'] \
-                    / merged_profile.precision['sample_size']
-
-                merged_profile.precision['var'] = self._correct_bias_variance(
-                    self.precision['sample_size'],
-                    self._biased_precision_var
-                )
-            
-                merged_profile.precision['std'] = math.sqrt(
-                    merged_profile.precision['var'])
-
-                # Margin of error, 99.9% confidence level
-                merged_profile.precision['margin_of_error'] = \
-                    merged_profile.__z_value_precision * (
-                        merged_profile.precision['std']
-                        / math.sqrt(merged_profile.precision['sample_size'])
-                )
+                merged_profile._precision['biased_var'] = self._merge_biased_variance(
+                    self._precision['sample_size'],
+                    self._precision['biased_var'],
+                    self._precision['mean'],
+                    other._precision['sample_size'],
+                    other._precision['biased_var'],
+                    other._precision['mean'])
 
         return merged_profile
 
@@ -154,6 +138,38 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         )
         
         return profile
+
+    @property
+    def precision(self):
+        # First add the stats that don't need to be re-calculated
+        precision = dict(
+            min=self._precision['min'],
+            max=self._precision['max'],
+            mean=self._precision['mean'],
+            sum=self._precision['sum'],
+            sample_size=self._precision['sample_size'],
+            confidence_level=0.999
+        )
+        var = self._correct_bias_variance(
+            self._precision['sample_size'],
+            self._precision['biased_var']
+        )
+
+        std = np.sqrt(var)
+        margin_of_error = None if self._precision['sample_size'] is None \
+                            else self.__z_value_precision * std / \
+                                  np.sqrt(self._precision['sample_size'])
+        precision['var'] = var
+        precision['std'] = std
+        precision['margin_of_error'] = margin_of_error
+        # Set the significant figures
+        if self._precision['max'] is not None:
+            sigfigs = int(self._precision['max'])
+            for key in ['mean', 'var', 'std', 'margin_of_error']:
+                precision[key] = \
+                    float('{:.{p}g}'.format(precision[key], p=sigfigs))
+
+        return precision
 
     @property
     def data_type_ratio(self):
@@ -202,9 +218,9 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         subset_precision = {
             'min': len_per_float.min(),
             'max': len_per_float.max(),
-            'mean': precision_sum / sample_size,
             'biased_var': float(np.var(len_per_float)),
             'sum': precision_sum,
+            'mean': precision_sum / sample_size,
             'sample_size': sample_size
         }
         
@@ -251,43 +267,25 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         subset_precision = self._get_float_precision(df_series, sample_ratio)
         if subset_precision is None:
             return
-        elif self.precision['min'] is None:
-            self._biased_precision_var = subset_precision.pop('biased_var')
-            self.precision.update(subset_precision)
+        elif self._precision['min'] is None:
+            self._precision.update(subset_precision)
         else:
             # Update the calculations as data is valid
-            self.precision['min'] = min(
-                self.precision['min'], subset_precision['min'])
-            self.precision['max'] = max(
-                self.precision['max'], subset_precision['max'])            
-            self.precision['sum'] += subset_precision['sum']
+            self._precision['min'] = min(
+                self._precision['min'], subset_precision['min'])
+            self._precision['max'] = max(
+                self._precision['max'], subset_precision['max'])
+            self._precision['sum'] += subset_precision['sum']
+            self._precision['sample_size'] += subset_precision['sample_size']
 
-            self._biased_precision_var = self._merge_biased_variance(
-                self.precision['sample_size'], self._biased_precision_var,
-                self.precision['mean'],
+            self._precision['biased_var'] = self._merge_biased_variance(
+                self._precision['sample_size'], self._precision['biased_var'],
+                self._precision['mean'],
                 subset_precision['sample_size'], subset_precision['biased_var'],
                 subset_precision['mean'])
 
-            self.precision['sample_size'] += subset_precision['sample_size']            
-            self.precision['mean'] = self.precision['sum'] \
-                / self.precision['sample_size']
-
-        # Calculated outside
-        self.precision['var'] = self._correct_bias_variance(
-            self.precision['sample_size'],
-            self._biased_precision_var)
-
-        self.precision['std'] = math.sqrt(self.precision['var'])
-
-        # Margin of error, 99.9% confidence level
-        self.precision['margin_of_error'] = self.__z_value_precision *(
-            self.precision['std'] / math.sqrt(self.precision['sample_size']))
-
-        # Set the significant figures
-        sigfigs = int(self.precision['max'])
-        for key in ['mean', 'var', 'std', 'margin_of_error']:
-            self.precision[key] = \
-                float('{:.{p}g}'.format(self.precision[key], p=sigfigs))
+            self._precision['mean'] = self._precision['sum'] \
+                                     / self._precision['sample_size']
 
     def _update_helper(self, df_series_clean, profile):
         """

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -187,6 +187,12 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
             other1._NumericStatsMixin__calculations,
             other2._NumericStatsMixin__calculations)
 
+        # Check and potentially override bias correction computation
+        if other1.bias_correction == False or other2.bias_correction == False:
+            self.bias_correction = False
+        else:
+            self.bias_correction = True
+
         # Merge variance, histogram, min, max, and sum
         if "variance" in self.__calculations.keys():
             self._biased_variance = self._merge_biased_variance(

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -62,9 +62,9 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         ]
         self.histogram_selection = None
         self.user_set_histogram_bin = None
-        self.bias = False  # By default, we correct for bias
+        self.bias_correction = True  # By default, we correct for bias
         if options:
-            self.bias = options.bias.is_enabled
+            self.bias_correction = options.bias_correction.is_enabled
             bin_count_or_method = \
                 options.histogram_and_quantiles.bin_count_or_method
             if isinstance(bin_count_or_method, str):
@@ -240,7 +240,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
 
     @property
     def variance(self):
-        return self._biased_variance if self.bias \
+        return self._biased_variance if not self.bias_correction \
             else self._correct_bias_variance(
                     self.match_count,
                     self._biased_variance)
@@ -253,14 +253,14 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
 
     @property
     def skewness(self):
-        return self._biased_skewness if self.bias \
+        return self._biased_skewness if not self.bias_correction \
             else self._correct_bias_skewness(
                     self.match_count,
                     self._biased_skewness)
 
     @property
     def kurtosis(self):
-        return self._biased_kurtosis if self.bias \
+        return self._biased_kurtosis if not self.bias_correction \
             else self._correct_bias_kurtosis(
                     self.match_count,
                     self._biased_kurtosis)

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -52,7 +52,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         self.min = None
         self.max = None
         self.sum = 0
-        self.variance = 0
+        self._biased_variance = 0
         self._biased_skewness = 0
         self._biased_kurtosis = 0
         self.max_histogram_bin = 100000
@@ -62,7 +62,9 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         ]
         self.histogram_selection = None
         self.user_set_histogram_bin = None
+        self.bias = False  # By default, we correct for bias
         if options:
+            self.bias = options.bias.is_enabled
             bin_count_or_method = \
                 options.histogram_and_quantiles.bin_count_or_method
             if isinstance(bin_count_or_method, str):
@@ -183,9 +185,9 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
 
         # Merge variance, histogram, min, max, and sum
         if "variance" in self.__calculations.keys():
-            self.variance = self._merge_variance(
-                other1.match_count, other1.variance, other1.mean,
-                other2.match_count, other2.variance, other2.mean)
+            self._biased_variance = self._merge_biased_variance(
+                other1.match_count, other1._biased_variance, other1.mean,
+                other2.match_count, other2._biased_variance, other2.mean)
         if "histogram_and_quantiles" in self.__calculations.keys():
             if other1._has_histogram and other2._has_histogram:
                 self._add_helper_merge_profile_histograms(other1, other2)
@@ -212,27 +214,36 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         if "sum" in self.__calculations.keys():
             self.sum = other1.sum + other2.sum
         if "skewness" in self.__calculations.keys():
-            self._biased_skewness = self._merge_biased_skewness(other1.match_count,
-                                                                other1._biased_skewness,
-                                                                other1.variance, other1.mean,
-                                                                other2.match_count,
-                                                                other2._biased_skewness,
-                                                                other2.variance, other2.mean)
+            self._biased_skewness = self._merge_biased_skewness(
+                other1.match_count,
+                other1._biased_skewness,
+                other1._biased_variance, other1.mean,
+                other2.match_count,
+                other2._biased_skewness,
+                other2._biased_variance, other2.mean)
         if "kurtosis" in self.__calculations.keys():
-            self._biased_kurtosis = self._merge_biased_kurtosis(other1.match_count,
-                                                                other1._biased_kurtosis,
-                                                                other1._biased_skewness,
-                                                                other1.variance,
-                                                                other1.mean, other2.match_count,
-                                                                other2._biased_kurtosis,
-                                                                other2._biased_skewness,
-                                                                other2.variance, other2.mean)
+            self._biased_kurtosis = self._merge_biased_kurtosis(
+                other1.match_count,
+                other1._biased_kurtosis,
+                other1._biased_skewness,
+                other1._biased_variance,
+                other1.mean, other2.match_count,
+                other2._biased_kurtosis,
+                other2._biased_skewness,
+                other2._biased_variance, other2.mean)
 
     @property
     def mean(self):
         if self.match_count == 0:
             return 0
         return float(self.sum) / self.match_count
+
+    @property
+    def variance(self):
+        return self._biased_variance if self.bias \
+            else self._correct_bias_variance(
+                    self.match_count,
+                    self._biased_variance)
 
     @property
     def stddev(self):
@@ -242,75 +253,85 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
 
     @property
     def skewness(self):
-        return self._correct_bias_skewness(
-                self.match_count,
-                self._biased_skewness)
+        return self._biased_skewness if self.bias \
+            else self._correct_bias_skewness(
+                    self.match_count,
+                    self._biased_skewness)
 
     @property
     def kurtosis(self):
-        return self._correct_bias_kurtosis(
-            self.match_count,
-            self._biased_kurtosis)
+        return self._biased_kurtosis if self.bias \
+            else self._correct_bias_kurtosis(
+                    self.match_count,
+                    self._biased_kurtosis)
 
     def _update_variance(self, batch_mean, batch_var, batch_count):
         """
-        Calculate the combined variance of the current values and new dataset.
+        Calculate the combined biased variance of the current values and new dataset.
 
         :param batch_mean: mean of new chunk
-        :param batch_var: variance of new chunk
+        :param batch_var: biased variance of new chunk
         :param batch_count: number of samples in new chunk
-        :return: combined variance
+        :return: combined biased variance
         :rtype: float
         """
-        return self._merge_variance(self.match_count, self.variance, self.mean,
+        return self._merge_biased_variance(self.match_count, self._biased_variance, self.mean,
                                     batch_count, batch_var, batch_mean)
 
     @staticmethod
-    def _merge_variance(match_count1, variance1, mean1,
-                        match_count2, variance2, mean2):
+    def _merge_biased_variance(match_count1, biased_variance1, mean1,
+                               match_count2, biased_variance2, mean2):
         """
-        Calculate the combined variance of the current values and new dataset.
+        Calculate the combined biased variance of the current values and new dataset.
 
         :param match_count1: number of samples in new chunk 1
         :param mean1: mean of chunk 1
-        :param variance1: variance of chunk 1
+        :param biased_variance1: variance of chunk 1 without bias correction
         :param match_count2: number of samples in new chunk 2
         :param mean2: mean of chunk 2
-        :param variance2: variance of chunk 2
+        :param biased_variance2: variance of chunk 2 without bias correction
         :return: combined variance
         :rtype: float
         """
-        if np.isnan(variance1):
-            variance1 = 0
-        if np.isnan(variance2):
-            variance2 = 0
+        if np.isnan(biased_variance1):
+            biased_variance1 = 0
+        if np.isnan(biased_variance2):
+            biased_variance2 = 0
         if match_count1 < 1:
-            return variance2
+            return biased_variance2
         elif match_count2 < 1:
-            return variance1
+            return biased_variance1
 
         curr_count = match_count1
         delta = mean2 - mean1
-        m_curr = variance1 * (curr_count - 1)
-        m_batch = variance2 * (match_count2 - 1)
+        m_curr = biased_variance1 * curr_count
+        m_batch = biased_variance2 * match_count2
         M2 = m_curr + m_batch + delta ** 2 * curr_count * match_count2 / \
             (curr_count + match_count2)
-        new_variance = M2 / (curr_count + match_count2 - 1)
+        new_variance = M2 / (curr_count + match_count2)
         return new_variance
 
     @staticmethod
-    def _merge_biased_skewness(match_count1, biased_skewness1, variance1, mean1,
-                               match_count2, biased_skewness2, variance2, mean2):
+    def _correct_bias_variance(match_count, biased_variance):
+        if match_count < 2:
+            return np.nan
+
+        variance = match_count / (match_count - 1) * biased_variance
+        return variance
+
+    @staticmethod
+    def _merge_biased_skewness(match_count1, biased_skewness1, biased_variance1, mean1,
+                               match_count2, biased_skewness2, biased_variance2, mean2):
         """
         Calculate the combined skewness of two data chunks
 
         :param match_count1: # of samples in 1st chunk
         :param biased_skewness1: skewness of 1st chunk without bias correction
-        :param variance1: variance of 1st chunk
+        :param biased_variance1: variance of 1st chunk without bias correction
         :param mean1: mean of 1st chunk
         :param match_count2: # of samples in 2nd chunk
         :param biased_skewness2: skewness of 2nd chunk without bias correction
-        :param variance2: variance of 2nd chunk
+        :param biased_variance2: variance of 2nd chunk without bias correction
         :param mean2: mean of 2nd chunk
         :return: combined skewness
         :rtype: float
@@ -326,8 +347,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
 
         delta = mean2 - mean1
         N = match_count1 + match_count2
-        M2_1 = (match_count1 - 1) * variance1
-        M2_2 = (match_count2 - 1) * variance2
+        M2_1 = match_count1 * biased_variance1
+        M2_2 = match_count2 * biased_variance2
         M2 = M2_1 + M2_2 + delta**2 * match_count1 * match_count2 / N
         if not M2:
             return 0.0
@@ -364,20 +385,20 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
 
     @staticmethod
     def _merge_biased_kurtosis(match_count1, biased_kurtosis1, biased_skewness1,
-                               variance1, mean1, match_count2, biased_kurtosis2,
-                               biased_skewness2, variance2, mean2):
+                               biased_variance1, mean1, match_count2, biased_kurtosis2,
+                               biased_skewness2, biased_variance2, mean2):
         """
         Calculate the combined kurtosis of two sets of data
 
         :param match_count1: # of samples in 1st chunk
         :param biased_kurtosis1: kurtosis of 1st chunk without bias correction
         :param biased_skewness1: skewness of 1st chunk without bias correction
-        :param variance1: variance of 1st chunk
+        :param biased_variance1: variance of 1st chunk without bias correction
         :param mean1: mean of 1st chunk
         :param match_count2: # of samples in 2nd chunk
         :param biased_kurtosis2: kurtosis of 2nd chunk without bias correction
         :param biased_skewness2: skewness of 2nd chunk without bias correction
-        :param variance2: variance of 2nd chunk
+        :param biased_variance2: variance of 2nd chunk without bias correction
         :param mean2: mean of 2nd chunk
         :return: combined skewness
         :rtype: float
@@ -393,8 +414,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
 
         delta = mean2 - mean1
         N = match_count1 + match_count2
-        M2_1 = (match_count1 - 1) * variance1
-        M2_2 = (match_count2 - 1) * variance2
+        M2_1 = match_count1 * biased_variance1
+        M2_2 = match_count2 * biased_variance2
         M2 = M2_1 + M2_2 + delta ** 2 * match_count1 * match_count2 / N
         if not M2:
             return 0
@@ -837,7 +858,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
             return
 
         prev_dependent_properties = {"mean": self.mean,
-                                     "variance": self.variance,
+                                     "biased_variance": self._biased_variance,
                                      "biased_skewness": self._biased_skewness,
                                      "biased_kurtosis": self._biased_kurtosis}
         subset_properties = copy.deepcopy(profile)
@@ -871,18 +892,19 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
     @BaseColumnProfiler._timeit(name="variance")
     def _get_variance(self, df_series, prev_dependent_properties,
                       subset_properties):
-        variance = df_series.var()
-        subset_properties["variance"] = variance
+        batch_biased_variance = np.var(df_series) # Obtains biased variance
+        subset_properties["biased_variance"] = batch_biased_variance
         sum_value = subset_properties["sum"]
         batch_count = subset_properties["match_count"]
         batch_mean = 0. if not batch_count else \
             float(sum_value) / batch_count
         subset_properties["mean"] = batch_mean
-        self.variance = self._merge_variance(self.match_count, self.variance,
-                                             prev_dependent_properties["mean"],
-                                             batch_count,
-                                             variance,
-                                             batch_mean)
+        self._biased_variance = self._merge_biased_variance(
+             self.match_count, self._biased_variance,
+             prev_dependent_properties["mean"],
+             batch_count,
+             batch_biased_variance,
+             batch_mean)
 
     @BaseColumnProfiler._timeit(name = "skewness")
     def _get_skewness(self, df_series, prev_dependent_properties,
@@ -903,15 +925,15 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         batch_biased_skewness = scipy.stats.skew(df_series)
         subset_properties["biased_skewness"] = batch_biased_skewness
         batch_count = subset_properties["match_count"]
-        batch_var = subset_properties["variance"]
+        batch_biased_var = subset_properties["biased_variance"]
         batch_mean = subset_properties["mean"]
 
         self._biased_skewness = self._merge_biased_skewness(
             self.match_count, self._biased_skewness,
-            prev_dependent_properties["variance"],
+            prev_dependent_properties["biased_variance"],
             prev_dependent_properties["mean"],
             batch_count, batch_biased_skewness,
-            batch_var, batch_mean)
+            batch_biased_var, batch_mean)
 
     @BaseColumnProfiler._timeit(name = "kurtosis")
     def _get_kurtosis(self, df_series, prev_dependent_properties,
@@ -932,18 +954,18 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         batch_biased_kurtosis = scipy.stats.kurtosis(df_series)
         subset_properties["biased_kurtosis"] = batch_biased_kurtosis
         batch_count = subset_properties["match_count"]
-        batch_var = subset_properties["variance"]
+        batch_biased_var = subset_properties["biased_variance"]
         batch_biased_skewness = subset_properties["biased_skewness"]
         batch_mean = subset_properties["mean"]
 
         self._biased_kurtosis = self._merge_biased_kurtosis(
             self.match_count, self._biased_kurtosis,
             prev_dependent_properties["biased_skewness"],
-            prev_dependent_properties["variance"],
+            prev_dependent_properties["biased_variance"],
             prev_dependent_properties["mean"],
             batch_count, batch_biased_kurtosis,
             batch_biased_skewness,
-            batch_var, batch_mean)
+            batch_biased_var, batch_mean)
 
     @BaseColumnProfiler._timeit(name="histogram_and_quantiles")
     def _get_histogram_and_quantiles(self, df_series,

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -314,7 +314,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
     @staticmethod
     def _correct_bias_variance(match_count, biased_variance):
         if match_count < 2:
-            return np.nan
+            return 0.0
 
         variance = match_count / (match_count - 1) * biased_variance
         return variance

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -188,10 +188,9 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
             other2._NumericStatsMixin__calculations)
 
         # Check and potentially override bias correction computation
-        if other1.bias_correction == False or other2.bias_correction == False:
+        self.bias_correction = True
+        if not other1.bias_correction or not other2.bias_correction:
             self.bias_correction = False
-        else:
-            self.bias_correction = True
 
         # Merge variance, histogram, min, max, and sum
         if "variance" in self.__calculations.keys():

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -313,7 +313,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
 
     @staticmethod
     def _correct_bias_variance(match_count, biased_variance):
-        if match_count < 2:
+        if match_count is None or biased_variance is None or match_count < 2:
             return 0.0
 
         variance = match_count / (match_count - 1) * biased_variance

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -260,6 +260,8 @@ class NumericalOptions(BaseInspectorOptions):
         :ivar histogram_and_quantiles: boolean option to enable/disable
             histogram_and_quantiles
         :vartype histogram_and_quantiles: BooleanOption
+        :ivar bias : boolean option to enable/disable existence of bias
+        :vartype bias: BooleanOption
         :ivar is_numeric_stats_enabled: boolean to enable/disable all numeric
             stats
         :vartype is_numeric_stats_enabled: bool
@@ -271,6 +273,9 @@ class NumericalOptions(BaseInspectorOptions):
         self.skewness = BooleanOption(is_enabled=True)
         self.kurtosis = BooleanOption(is_enabled=True)
         self.histogram_and_quantiles = HistogramOption()
+        # By default, we do NOT want bias, hence bias is false. This
+        # convention is made to maintain consistency with scipy.stats
+        self.bias = BooleanOption(is_enabled=False)
         BaseInspectorOptions.__init__(self)
 
     @property
@@ -285,7 +290,7 @@ class NumericalOptions(BaseInspectorOptions):
         """
         if self.min.is_enabled or self.max.is_enabled or self.sum.is_enabled \
                 or self.variance.is_enabled or self.skewness.is_enabled \
-                or self.kurtosis.is_enabled \
+                or self.kurtosis.is_enabled or self.bias.is_enabled \
                 or self.histogram_and_quantiles.is_enabled:
             return True
         return False
@@ -306,6 +311,7 @@ class NumericalOptions(BaseInspectorOptions):
         self.variance.is_enabled = value
         self.skewness.is_enabled = value
         self.kurtosis.is_enabled = value
+        self.bias.is_enabled = value
         self.histogram_and_quantiles.is_enabled = value
 
     @property
@@ -392,6 +398,8 @@ class IntOptions(NumericalOptions):
         :ivar histogram_and_quantiles: boolean option to enable/disable
             histogram_and_quantiles
         :vartype histogram_and_quantiles: BooleanOption
+        :ivar bias : boolean option to enable/disable existence of bias
+        :vartype bias: BooleanOption
         :ivar is_numeric_stats_enabled: boolean to enable/disable all numeric
             stats
         :vartype is_numeric_stats_enabled: bool
@@ -473,6 +481,8 @@ class FloatOptions(NumericalOptions):
         :ivar histogram_and_quantiles: boolean option to enable/disable
             histogram_and_quantiles
         :vartype histogram_and_quantiles: BooleanOption
+        :ivar bias : boolean option to enable/disable existence of bias
+        :vartype bias: BooleanOption
         :ivar is_numeric_stats_enabled: boolean to enable/disable all numeric
             stats
         :vartype is_numeric_stats_enabled: bool
@@ -519,6 +529,8 @@ class TextOptions(NumericalOptions):
         :vartype skewness: BooleanOption
         :ivar kurtosis: boolean option to enable/disable kurtosis
         :vartype kurtosis: BooleanOption
+        :ivar bias : boolean option to enable/disable existence of bias
+        :vartype bias: BooleanOption
         :ivar histogram_and_quantiles: boolean option to enable/disable
             histogram_and_quantiles
         :vartype histogram_and_quantiles: BooleanOption

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -260,7 +260,7 @@ class NumericalOptions(BaseInspectorOptions):
         :ivar histogram_and_quantiles: boolean option to enable/disable
             histogram_and_quantiles
         :vartype histogram_and_quantiles: BooleanOption
-        :ivar bias : boolean option to enable/disable existence of bias
+        :ivar bias_correction : boolean option to enable/disable existence of bias
         :vartype bias: BooleanOption
         :ivar is_numeric_stats_enabled: boolean to enable/disable all numeric
             stats
@@ -273,9 +273,8 @@ class NumericalOptions(BaseInspectorOptions):
         self.skewness = BooleanOption(is_enabled=True)
         self.kurtosis = BooleanOption(is_enabled=True)
         self.histogram_and_quantiles = HistogramOption()
-        # By default, we do NOT want bias, hence bias is false. This
-        # convention is made to maintain consistency with scipy.stats
-        self.bias = BooleanOption(is_enabled=False)
+        # By default, we correct for bias
+        self.bias_correction = BooleanOption(is_enabled=True)
         BaseInspectorOptions.__init__(self)
 
     @property
@@ -290,7 +289,7 @@ class NumericalOptions(BaseInspectorOptions):
         """
         if self.min.is_enabled or self.max.is_enabled or self.sum.is_enabled \
                 or self.variance.is_enabled or self.skewness.is_enabled \
-                or self.kurtosis.is_enabled or self.bias.is_enabled \
+                or self.kurtosis.is_enabled or self.bias_correction.is_enabled \
                 or self.histogram_and_quantiles.is_enabled:
             return True
         return False
@@ -311,7 +310,7 @@ class NumericalOptions(BaseInspectorOptions):
         self.variance.is_enabled = value
         self.skewness.is_enabled = value
         self.kurtosis.is_enabled = value
-        self.bias.is_enabled = value
+        self.bias_correction.is_enabled = value
         self.histogram_and_quantiles.is_enabled = value
 
     @property
@@ -338,7 +337,7 @@ class NumericalOptions(BaseInspectorOptions):
 
         errors = super()._validate_helper(variable_path=variable_path)
         for item in ["histogram_and_quantiles", "min", "max", "sum",
-                     "variance", "skewness", "kurtosis"]:
+                     "variance", "skewness", "kurtosis", "bias_correction"]:
             if not isinstance(self.properties[item], BooleanOption):
                 errors.append("{}.{} must be a BooleanOption."
                               .format(variable_path, item))
@@ -398,7 +397,7 @@ class IntOptions(NumericalOptions):
         :ivar histogram_and_quantiles: boolean option to enable/disable
             histogram_and_quantiles
         :vartype histogram_and_quantiles: BooleanOption
-        :ivar bias : boolean option to enable/disable existence of bias
+        :ivar bias_correction : boolean option to enable/disable existence of bias
         :vartype bias: BooleanOption
         :ivar is_numeric_stats_enabled: boolean to enable/disable all numeric
             stats
@@ -481,7 +480,7 @@ class FloatOptions(NumericalOptions):
         :ivar histogram_and_quantiles: boolean option to enable/disable
             histogram_and_quantiles
         :vartype histogram_and_quantiles: BooleanOption
-        :ivar bias : boolean option to enable/disable existence of bias
+        :ivar bias_correction : boolean option to enable/disable existence of bias
         :vartype bias: BooleanOption
         :ivar is_numeric_stats_enabled: boolean to enable/disable all numeric
             stats
@@ -529,7 +528,7 @@ class TextOptions(NumericalOptions):
         :vartype skewness: BooleanOption
         :ivar kurtosis: boolean option to enable/disable kurtosis
         :vartype kurtosis: BooleanOption
-        :ivar bias : boolean option to enable/disable existence of bias
+        :ivar bias_correction : boolean option to enable/disable existence of bias
         :vartype bias: BooleanOption
         :ivar histogram_and_quantiles: boolean option to enable/disable
             histogram_and_quantiles

--- a/dataprofiler/tests/profilers/profiler_options/test_numerical_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_numerical_options.py
@@ -7,7 +7,7 @@ class TestNumericalOptions(TestBaseInspectorOptions):
     
     option_class = NumericalOptions
     keys = ["min", "max", "sum", "variance", "skewness",
-            "kurtosis", "histogram_and_quantiles"]
+            "kurtosis", "bias_correction", "histogram_and_quantiles"]
 
     def test_init(self):
         options = self.get_options()
@@ -153,6 +153,7 @@ class TestNumericalOptions(TestBaseInspectorOptions):
         options = self.get_options()
         numeric_keys = ["min", "max", "sum", "variance",
                         "skewness", "kurtosis",
+                        "bias_correction",
                         "histogram_and_quantiles"] 
 
         # Disable All Numeric Stats

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -80,8 +80,8 @@ class TestProfilerOptions(unittest.TestCase):
                 self.assertIsNone(profile_column["statistics"]["max"])
                 self.assertEqual(0, profile_column["statistics"]["variance"])
                 self.assertIsNone(profile_column["statistics"]["quantiles"][0])
-                self.assertEqual(profile_column["statistics"]["skewness"], 0)
-                self.assertEqual(profile_column["statistics"]["kurtosis"], 0)
+                self.assertEqual(0, profile_column["statistics"]["skewness"])
+                self.assertEqual(0, profile_column["statistics"]["kurtosis"])
 
         # Assert that the stats are enabled
         options.set({"*.is_numeric_stats_enabled": True})

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -64,10 +64,8 @@ class TestProfilerOptions(unittest.TestCase):
                 self.assertIsNone(profile_column["statistics"]["max"])
                 self.assertEqual(0, profile_column["statistics"]["variance"])
                 self.assertIsNone(profile_column["statistics"]["quantiles"][0])
-                self.assertTrue(
-                    profile_column["statistics"]["skewness"] is np.nan)
-                self.assertTrue(
-                    profile_column["statistics"]["kurtosis"] is np.nan)
+                self.assertEqual(profile_column["statistics"]["skewness"], 0)
+                self.assertEqual(profile_column["statistics"]["kurtosis"], 0)
 
         # Assert that the stats are enabled
         options.set({"is_numeric_stats_enabled": True})
@@ -87,6 +85,8 @@ class TestProfilerOptions(unittest.TestCase):
                 self.assertNotEqual(0, profile_column["statistics"]["variance"])
                 self.assertIsNotNone(
                     profile_column["statistics"]["quantiles"][0])
+                self.assertTrue(profile_column["statistics"]["skewness"] is np.nan)
+                self.assertTrue(profile_column["statistics"]["kurtosis"] is np.nan)
 
     def test_disable_labeler_in_profiler_options(self, *mocks):
         options = ProfilerOptions()

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -956,6 +956,7 @@ class TestFloatColumn(unittest.TestCase):
         profile3 = profiler3.profile
         histogram = profile3.pop('histogram')
 
+        self.assertTrue(profiler3.bias_correction)
         self.assertAlmostEqual(profiler3.stddev,
                                expected_profile.pop('stddev'), places=3)
         self.assertAlmostEqual(profiler3.variance,

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -372,12 +372,15 @@ class TestFloatColumn(unittest.TestCase):
         self.assertAlmostEqual(0.3311739, num_profiler.kurtosis)
 
     def test_bias_correction_option(self):
+        # df1 = [-5, -4, ..., 3, 4, 5]
         data = np.linspace(-5, 5, 11).tolist()
         df1 = pd.Series(data)
 
+        # df2 = [-3, -2.5, -2, ..., 1.5, 2]
         data = np.linspace(-3, 2, 11).tolist()
         df2 = pd.Series(data)
 
+        # df3 = [1, 1, ... , 1] (ten '1's)
         data = np.full((10,), 1)
         df3 = pd.Series(data)
 
@@ -385,6 +388,7 @@ class TestFloatColumn(unittest.TestCase):
         options = FloatOptions(); options.bias_correction.is_enabled = False
         num_profiler = FloatColumn(df1.name, options=options)
         num_profiler.update(df1.apply(str))
+        # Test biased values of variance, skewness, kurtosis
         self.assertAlmostEqual(10, num_profiler.variance)
         self.assertAlmostEqual(0, num_profiler.skewness)
         self.assertAlmostEqual(89/50 - 3, num_profiler.kurtosis)

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -26,7 +26,7 @@ class TestFloatColumn(unittest.TestCase):
         self.assertEqual(profiler.max, None)
         self.assertEqual(profiler.sum, 0)
         self.assertEqual(profiler.mean, 0)
-        self.assertTrue(profiler.variance is np.nan)
+        self.assertEqual(profiler.variance, 0)
         self.assertTrue(profiler.skewness is np.nan)
         self.assertTrue(profiler.kurtosis is np.nan)
         self.assertTrue(profiler.stddev is np.nan)
@@ -40,7 +40,7 @@ class TestFloatColumn(unittest.TestCase):
         profiler.update(data)
         self.assertEqual(profiler.match_count, 1.0)
         self.assertEqual(profiler.mean, 1.5)
-        self.assertTrue(profiler.variance is np.nan)
+        self.assertEqual(profiler.variance, 0)
 
         data = pd.Series([2.5]).apply(str)
         profiler.update(data)

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -840,7 +840,6 @@ class TestFloatColumn(unittest.TestCase):
             variance = profile.pop('variance')
             expected_variance = expected_profile.pop('variance')
 
-            self.maxDiff = None
             self.assertDictEqual(expected_profile, profile)
             self.assertDictEqual(expected_profile['precision'], profile['precision'])
             self.assertEqual(expected_histogram['bin_counts'].tolist(),

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -381,8 +381,8 @@ class TestFloatColumn(unittest.TestCase):
         data = np.full((10,), 1)
         df3 = pd.Series(data)
 
-        # Enable bias option to get biased values
-        options = FloatOptions(); options.bias.is_enabled = True
+        # Disable bias correction
+        options = FloatOptions(); options.bias_correction.is_enabled = False
         num_profiler = FloatColumn(df1.name, options=options)
         num_profiler.update(df1.apply(str))
         self.assertAlmostEqual(10, num_profiler.variance)

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -26,7 +26,7 @@ class TestFloatColumn(unittest.TestCase):
         self.assertEqual(profiler.max, None)
         self.assertEqual(profiler.sum, 0)
         self.assertEqual(profiler.mean, 0)
-        self.assertEqual(profiler.variance, 0)
+        self.assertTrue(profiler.variance is np.nan)
         self.assertTrue(profiler.skewness is np.nan)
         self.assertTrue(profiler.kurtosis is np.nan)
         self.assertTrue(profiler.stddev is np.nan)
@@ -40,7 +40,7 @@ class TestFloatColumn(unittest.TestCase):
         profiler.update(data)
         self.assertEqual(profiler.match_count, 1.0)
         self.assertEqual(profiler.mean, 1.5)
-        self.assertEqual(profiler.variance, 0.0)
+        self.assertTrue(profiler.variance is np.nan)
 
         data = pd.Series([2.5]).apply(str)
         profiler.update(data)
@@ -763,7 +763,10 @@ class TestFloatColumn(unittest.TestCase):
             expected_quantiles = expected_profile.pop('quantiles')
             skewness = profile.pop('skewness')
             expected_skewness = expected_profile.pop('skewness')
+            variance = profile.pop('variance')
+            expected_variance = expected_profile.pop('variance')
 
+            self.maxDiff = None
             self.assertDictEqual(expected_profile, profile)
             self.assertDictEqual(expected_profile['precision'], profile['precision'])
             self.assertEqual(expected_histogram['bin_counts'].tolist(),
@@ -775,6 +778,7 @@ class TestFloatColumn(unittest.TestCase):
             self.assertAlmostEqual(expected_quantiles[1], quantiles[499])
             self.assertAlmostEqual(expected_quantiles[2], quantiles[749])
             self.assertAlmostEqual(expected_skewness, skewness)
+            self.assertAlmostEqual(expected_variance, variance)
 
             # Validate time in datetime class has expected time after second update
             profiler.update(df)

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -371,6 +371,38 @@ class TestFloatColumn(unittest.TestCase):
         df = pd.concat([df1, df2, df3])
         self.assertAlmostEqual(0.3311739, num_profiler.kurtosis)
 
+    def test_bias_correction_option(self):
+        data = np.linspace(-5, 5, 11).tolist()
+        df1 = pd.Series(data)
+
+        data = np.linspace(-3, 2, 11).tolist()
+        df2 = pd.Series(data)
+
+        data = np.full((10,), 1)
+        df3 = pd.Series(data)
+
+        # Enable bias option to get biased values
+        options = FloatOptions(); options.bias.is_enabled = True
+        num_profiler = FloatColumn(df1.name, options=options)
+        num_profiler.update(df1.apply(str))
+        self.assertAlmostEqual(10, num_profiler.variance)
+        self.assertAlmostEqual(0, num_profiler.skewness)
+        self.assertAlmostEqual(89/50 - 3, num_profiler.kurtosis)
+
+        df2_ints = df2[df2 == df2.round()]
+        num_profiler.update(df2.apply(str))
+        df = pd.concat([df1, df2_ints])
+        self.assertAlmostEqual(6.3125, num_profiler.variance)
+        self.assertAlmostEqual(0.17733336, num_profiler.skewness)
+        self.assertAlmostEqual(-0.56798353, num_profiler.kurtosis)
+
+        df3_ints = df3[df3 == df3.round()]
+        num_profiler.update(df3.apply(str))
+        df = pd.concat([df1, df2_ints, df3_ints])
+        self.assertAlmostEqual(4.6755371, num_profiler.variance)
+        self.assertAlmostEqual(-0.29622465, num_profiler.skewness)
+        self.assertAlmostEqual(0.099825352, num_profiler.kurtosis)
+
     def test_null_values_for_histogram(self):
         data = pd.Series(['-inf', 'inf'])
         profiler = FloatColumn(data.name)

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -266,8 +266,8 @@ class TestIntColumn(unittest.TestCase):
         data = np.full((10,), 1)
         df3 = pd.Series(data)
 
-        # Enable bias option to get biased values
-        options = IntOptions(); options.bias.is_enabled = True
+        # Disable bias correction
+        options = IntOptions(); options.bias_correction.is_enabled = False
         num_profiler = IntColumn(df1.name, options=options)
         num_profiler.update(df1.apply(str))
         self.assertAlmostEqual(10, num_profiler.variance)

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -25,7 +25,7 @@ class TestIntColumn(unittest.TestCase):
         self.assertEqual(profiler.max, None)
         self.assertEqual(profiler.sum, 0)
         self.assertEqual(profiler.mean, 0)
-        self.assertEqual(profiler.variance, 0)
+        self.assertTrue(profiler.variance is np.nan)
         self.assertTrue(profiler.skewness is np.nan)
         self.assertTrue(profiler.kurtosis is np.nan)
         self.assertTrue(profiler.stddev is np.nan)
@@ -41,7 +41,7 @@ class TestIntColumn(unittest.TestCase):
         self.assertEqual(profiler.match_count, 1)
         self.assertEqual(profiler.sum, 1)
         self.assertEqual(profiler.mean, 1)
-        self.assertEqual(profiler.variance, 0)
+        self.assertTrue(profiler.variance is np.nan)
 
         data = pd.Series([2])
         profiler.update(data)
@@ -203,8 +203,8 @@ class TestIntColumn(unittest.TestCase):
 
         df = pd.concat([df1, df2_ints, df3_ints])
         self.assertEqual(mean(df), num_profiler.mean)
-        self.assertEqual(variance, num_profiler.variance)
-        self.assertEqual(np.sqrt(variance), num_profiler.stddev)
+        self.assertAlmostEqual(variance, num_profiler.variance)
+        self.assertAlmostEqual(np.sqrt(variance), num_profiler.stddev)
 
     def test_profiled_skewness(self):
         data = np.linspace(-5, 5, 11).tolist()

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -527,6 +527,7 @@ class TestIntColumn(unittest.TestCase):
         profile3 = profiler3.profile
         histogram = profile3.pop('histogram')
 
+        self.assertTrue(profiler3.bias_correction)
         self.assertAlmostEqual(profiler3.stddev,
                                expected_profile.pop('stddev'),places=3)
         self.assertAlmostEqual(profiler3.variance,

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -25,7 +25,7 @@ class TestIntColumn(unittest.TestCase):
         self.assertEqual(profiler.max, None)
         self.assertEqual(profiler.sum, 0)
         self.assertEqual(profiler.mean, 0)
-        self.assertTrue(profiler.variance is np.nan)
+        self.assertEqual(profiler.variance, 0)
         self.assertTrue(profiler.skewness is np.nan)
         self.assertTrue(profiler.kurtosis is np.nan)
         self.assertTrue(profiler.stddev is np.nan)
@@ -41,7 +41,7 @@ class TestIntColumn(unittest.TestCase):
         self.assertEqual(profiler.match_count, 1)
         self.assertEqual(profiler.sum, 1)
         self.assertEqual(profiler.mean, 1)
-        self.assertTrue(profiler.variance is np.nan)
+        self.assertEqual(profiler.variance, 0)
 
         data = pd.Series([2])
         profiler.update(data)

--- a/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
+++ b/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
@@ -135,7 +135,7 @@ class TestNumericStatsMixin(unittest.TestCase):
             mean1, var1, count1)
         num_profiler.match_count = count1
         num_profiler.sum = 0
-        self.assertTrue(num_profiler.variance is np.nan)
+        self.assertEqual(num_profiler.variance, 0)
 
         # data with 1 element
         data2 = [5.0]
@@ -146,7 +146,7 @@ class TestNumericStatsMixin(unittest.TestCase):
             mean2, var2, count2)
         num_profiler.match_count += count2
         num_profiler.sum += 5.0
-        self.assertTrue(num_profiler.variance is np.nan)
+        self.assertEqual(num_profiler.variance, 0)
 
         # data with multiple elements
         data3 = [-5.0, 5.0, 11.0, -11.0]

--- a/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
+++ b/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
@@ -95,11 +95,11 @@ class TestNumericStatsMixin(unittest.TestCase):
         var1 = ((-3.0 - mean1) ** 2 + (2.0 - mean1)
                 ** 2 + (11.0 - mean1) ** 2) / 2
         count1 = len(data1)
-        num_profiler.variance = num_profiler._update_variance(
-            mean1, var1, count1)
-        self.assertEqual(var1, num_profiler.variance)
+        num_profiler._biased_variance = num_profiler._update_variance(
+            mean1, var1 * 2 / 3, count1)
         num_profiler.match_count = count1
         num_profiler.sum = sum(data1)
+        self.assertAlmostEqual(var1, num_profiler.variance)
 
         # test streaming update variance with new data
         data2 = [-5.0, 5.0, 11.0]
@@ -107,8 +107,10 @@ class TestNumericStatsMixin(unittest.TestCase):
         var2 = ((-5.0 - mean2) ** 2 + (5.0 - mean2)
                 ** 2 + (11.0 - mean2) ** 2) / 2
         count2 = len(data2)
-        num_profiler.variance = num_profiler._update_variance(
-            mean2, var2, count2)
+        num_profiler._biased_variance = num_profiler._update_variance(
+            mean2, var2 * 2 / 3, count2)
+        num_profiler.match_count += count2
+        num_profiler.sum += sum(data2)
         var_from_profile_updated = num_profiler.variance
 
         data_all = [-5.0, 5.0, 11.0, -3.0, 2.0, 11.0]
@@ -117,7 +119,7 @@ class TestNumericStatsMixin(unittest.TestCase):
                    (11.0 - mean_all) ** 2 + (-3.0 - mean_all) ** 2 + \
                    (2.0 - mean_all) ** 2 + (11.0 - mean_all) ** 2) / 5
 
-        self.assertEqual(var_all, var_from_profile_updated)
+        self.assertAlmostEqual(var_all, var_from_profile_updated)
 
     def test_update_variance_with_varying_data_length(self):
         """
@@ -126,21 +128,25 @@ class TestNumericStatsMixin(unittest.TestCase):
         """
         # empty data
         data1 = []
-        mean1, var1, count1 = 0, 0, 0
+        mean1, var1, count1 = 0, np.nan, 0
 
         num_profiler = TestColumn()
-        num_profiler.variance = num_profiler._update_variance(
+        num_profiler._biased_variance = num_profiler._update_variance(
             mean1, var1, count1)
-        self.assertEqual(var1, num_profiler.variance)
+        num_profiler.match_count = count1
+        num_profiler.sum = 0
+        self.assertTrue(num_profiler.variance is np.nan)
 
         # data with 1 element
         data2 = [5.0]
         mean2, var2, count2 = 5.0, 0, 1
 
         num_profiler = TestColumn()
-        num_profiler.variance = num_profiler._update_variance(
+        num_profiler._biased_variance = num_profiler._update_variance(
             mean2, var2, count2)
-        self.assertEqual(var2, num_profiler.variance)
+        num_profiler.match_count += count2
+        num_profiler.sum += 5.0
+        self.assertTrue(num_profiler.variance is np.nan)
 
         # data with multiple elements
         data3 = [-5.0, 5.0, 11.0, -11.0]
@@ -149,8 +155,10 @@ class TestNumericStatsMixin(unittest.TestCase):
                 (11.0 - mean3) ** 2 + (-11.0 - mean3) ** 2) / 3
 
         num_profiler = TestColumn()
-        num_profiler.variance = num_profiler._update_variance(
-            mean3, var3, count3)
+        num_profiler._biased_variance = num_profiler._update_variance(
+            mean3, var3 * 3 / 4, count3)
+        num_profiler.match_count += count3
+        num_profiler.sum += sum(data3)
         self.assertEqual(var3, num_profiler.variance)
 
     def test_update_variance_with_empty_data(self):
@@ -165,17 +173,19 @@ class TestNumericStatsMixin(unittest.TestCase):
         var1 = ((-3.0 - mean1) ** 2 + (2.0 - mean1)
                 ** 2 + (11.0 - mean1) ** 2) / 2
         count1 = len(data1)
-        num_profiler.variance = num_profiler._update_variance(
-            mean1, var1, count1)
-        self.assertEqual(var1, num_profiler.variance)
+        num_profiler._biased_variance = num_profiler._update_variance(
+            mean1, var1 * 2 / 3, count1)
         num_profiler.match_count = count1
         num_profiler.sum = sum(data1)
+        self.assertEqual(var1, num_profiler.variance)
 
         # test adding data which would not have anything
         # data + empty
         mean2, var2, count2 = 0, 0, 0
-        num_profiler.variance = num_profiler._update_variance(
+        num_profiler._biased_variance = num_profiler._update_variance(
             mean2, var2, count2)
+        num_profiler.match_count = count1
+        num_profiler.sum = sum(data1)
         var_from_profile_updated = num_profiler.variance
 
         # simulate not having data
@@ -193,8 +203,8 @@ class TestNumericStatsMixin(unittest.TestCase):
             'bin_edges': np.array([2., 5.25, 8.5, 11.75, 15.])
         }
 
-        other1.min, other1.max, other1.variance, other1.sum = 0, 0, 0, 0
-        other2.min, other2.max, other2.variance, other2.sum = 1, 1, 1, 1
+        other1.min, other1.max, other1._biased_variance, other1.sum = 0, 0, 0, 0
+        other2.min, other2.max, other2._biased_variance, other2.sum = 1, 1, 1, 1
 
         # set auto as only histogram to merge
         other1.histogram_selection = "auto"
@@ -224,7 +234,7 @@ class TestNumericStatsMixin(unittest.TestCase):
 
         # Dummy data to make min call
         prev_dependent_properties = {"mean": 0,
-                                     "variance": 0,
+                                     "biased_variance": 0,
                                      "biased_skewness": 0}
         data = np.array([0, 0, 0, 0, 0])
         df_series = pd.Series(data)


### PR DESCRIPTION
By default, the computations for variance/skewness/kurtosis are corrected for bias. However, this update allows the user to set "bias" to true or false in options to provide either biased or unbiased statistics, respectively. By default, bias is False (i.e. there will NOT be bias included in these calculations). 