### PR TITLE
Fixes propagation error in options when setting generic values

### DIFF
--- a/dataprofiler/data_readers/json_data.py
+++ b/dataprofiler/data_readers/json_data.py
@@ -257,7 +257,6 @@ class JSONData(SpreadSheetDataMixin, BaseData):
                 )
             return data
 
-
     def _get_data_as_records(self, data):
         """
         Extracts the data as a record format.

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -76,9 +76,11 @@ class BaseOption(object):
                             {option: options[option]},
                             variable_path=option_variable_path)
             else:
+                error_path = (variable_path if variable_path
+                              else self.__class__.__name__)
                 raise AttributeError(
                     "type object '{}' has no attribute '{}'".format(
-                        variable_path, option))
+                        error_path, option))
 
     def set(self, options):
         """

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -42,6 +42,13 @@ class BaseOption(object):
         for option in options:
             option_list = option.split(".", 1)
             option_name = option_list[0]
+
+            is_check_all = False
+            if option_name == '*':
+                option_list = option_list[1].split(".", 1)
+                option_name = option_list[0]
+                is_check_all = True
+
             option_variable_path = variable_path + '.' + option_name \
                 if variable_path else option_name
             if option_name in self.properties:
@@ -58,13 +65,20 @@ class BaseOption(object):
                             option_variable_path, option_list[1]))
                 else:
                     setattr(self, option_name, options[option])
-
-        for option_name in self.properties:
-            option = getattr(self, option_name)
-            if isinstance(option, BaseOption):
-                option_variable_path = variable_path + '.' + option_name \
-                    if variable_path else option_name
-                option._set_helper(options, variable_path=option_variable_path)
+            elif len(option_list) > 1 or is_check_all:
+                for class_option_name in self.properties:
+                    class_option = getattr(self, class_option_name)
+                    if isinstance(class_option, BaseOption):
+                        option_variable_path = (
+                            variable_path + '.' + class_option_name
+                            if variable_path else class_option_name)
+                        class_option._set_helper(
+                            {option: options[option]},
+                            variable_path=option_variable_path)
+            else:
+                raise AttributeError(
+                    "type object '{}' has no attribute '{}'".format(
+                        variable_path, option))
 
     def set(self, options):
         """

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -994,7 +994,8 @@ class ProfilerOptions(BaseOption):
                            "text.is_enabled", "text.vocab"}
 
         # Specification needed for overlap_options above
-        option_specifications = {"structured_options", "unstructured_options"}
+        option_specifications = {
+            "*", "structured_options", "unstructured_options"}
 
         # Function to see if any overlap options present in option being set
         def overlap_opt_set(opt):

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -8,6 +8,7 @@ import psutil
 import numpy as np
 import multiprocessing as mp
 
+
 def dict_merge(dct, merge_dct):
     # Recursive dictionary merge
     # Copyright (C) 2016 Paul Durivage <pauldurivage+github@gmail.com>
@@ -67,7 +68,7 @@ def _combine_unique_sets(a, b):
     elif not b:
         combined_list = set(a)
     else:
-        combined_list = set().union(a,b)
+        combined_list = set().union(a, b)
     return list(combined_list)
 
     

--- a/dataprofiler/tests/profilers/profiler_options/test_boolean_option.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_boolean_option.py
@@ -59,8 +59,6 @@ class TestBooleanOption(TestBaseOption):
         # Option is_enabled is not a boolean
         option = self.get_options(is_enabled="Hello World")
         expected_error = ["{}.is_enabled must be a Boolean.".format(optpth)]
-        expected_error += ["{}.{}.is_enabled must be a Boolean." 
-                           .format(optpth, key) for key in self.keys]
         self.assertSetEqual(set(expected_error), 
                             set(option._validate_helper()))
     
@@ -78,8 +76,6 @@ class TestBooleanOption(TestBaseOption):
             option.validate(raise_error=True)
 
         expected_error = [expected_error]
-        expected_error += ["{}.{}.is_enabled must be a Boolean." 
-                           .format(optpth, key) for key in self.keys]
         self.assertSetEqual(set(expected_error), 
                             set(option.validate(raise_error=False)))
 

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -50,7 +50,8 @@ class TestProfilerOptions(unittest.TestCase):
         options = ProfilerOptions()
 
         # check if no '*.' it raises an error bc attribute not found
-        expected_error = "type object '' has no attribute 'is_enabled'"
+        expected_error = ("type object 'ProfilerOptions' has no attribute "
+                          "'is_enabled'")
         with self.assertRaisesRegex(AttributeError, expected_error):
             options.set({"is_enabled": False})
 

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -174,7 +174,7 @@ class TestProfilerOptions(unittest.TestCase):
         float_options = options.structured_options.float.properties
         int_options = options.structured_options.int.properties
         for option in ["histogram_and_quantiles", "min", "max", "sum",
-                       "variance","skewness", "kurtosis",
+                       "variance", "skewness", "kurtosis",
                        "num_zeros", "num_negatives"]:
             self.assertFalse(text_options[option].is_enabled)
             self.assertFalse(float_options[option].is_enabled)

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -45,10 +45,25 @@ class TestProfilerOptions(unittest.TestCase):
         # Stored in Profiler as StructuredOptions
         self.assertEqual(profile2.options, options.structured_options)
 
+    def test_set_failures(self, *mocks):
+
+        options = ProfilerOptions()
+
+        # check if no '*.' it raises an error bc attribute not found
+        expected_error = "type object '' has no attribute 'is_enabled'"
+        with self.assertRaisesRegex(AttributeError, expected_error):
+            options.set({"is_enabled": False})
+
+        # check if attribute doesn't exist, it raises an error
+        expected_error = ("type object 'structured_options' has no attribute "
+                          "'test'")
+        with self.assertRaisesRegex(AttributeError, expected_error):
+            options.set({"structured_options.test": False})
+
     def test_numerical_stats_option(self, *mocks):
         # Assert that the stats are disabled
         options = ProfilerOptions()
-        options.set({"is_numeric_stats_enabled": False})
+        options.set({"*.is_numeric_stats_enabled": False})
         profile = Profiler(self.data, options=options)
 
         for column_name in profile.profile.keys():
@@ -70,7 +85,7 @@ class TestProfilerOptions(unittest.TestCase):
                     profile_column["statistics"]["kurtosis"] is np.nan)
 
         # Assert that the stats are enabled
-        options.set({"is_numeric_stats_enabled": True})
+        options.set({"*.is_numeric_stats_enabled": True})
         profile = Profiler(self.data, options=options)
 
         for column_name in profile.profile.keys():
@@ -158,7 +173,7 @@ class TestProfilerOptions(unittest.TestCase):
         float_options = options.structured_options.float.properties
         int_options = options.structured_options.int.properties
         for option in ["histogram_and_quantiles", "min", "max", "sum",
-                          "variance","skewness", "kurtosis",
+                       "variance","skewness", "kurtosis",
                        "num_zeros", "num_negatives"]:
             self.assertFalse(text_options[option].is_enabled)
             self.assertFalse(float_options[option].is_enabled)
@@ -228,7 +243,7 @@ class TestProfilerOptions(unittest.TestCase):
 
         # test warns if is_numeric_stats_enabled = False
         numerical_options = {
-            "is_numeric_stats_enabled": False,
+            "*.is_numeric_stats_enabled": False,
         }
         options.set(numerical_options)
         with self.assertWarnsRegex(UserWarning,
@@ -241,10 +256,11 @@ class TestProfilerOptions(unittest.TestCase):
         options = ProfilerOptions()
 
         # Ensure set works appropriately
-        options.set({"data_labeler.is_enabled": False,
-                     "min.is_enabled": False,
-                     "structured_options.data_labeler_dirpath": "test",
-                     "max_sample_size": 15})
+        options.set({
+            "data_labeler.is_enabled": False,
+            "min.is_enabled": False,
+            "structured_options.data_labeler.data_labeler_dirpath": "test",
+            "data_labeler.max_sample_size": 15})
 
         text_options = options.structured_options.text.properties
         float_options = options.structured_options.float.properties
@@ -276,7 +292,7 @@ class TestProfilerOptions(unittest.TestCase):
         float_options = FloatOptions()
         float_options.set({"precision.is_enabled": False,
                            "min.is_enabled": False,
-                           "is_enabled": False})
+                           "*.is_enabled": False})
 
         self.assertFalse(float_options.precision.is_enabled)
         self.assertFalse(float_options.min.is_enabled)
@@ -292,8 +308,7 @@ class TestProfilerOptions(unittest.TestCase):
                 ValueError, "ProfilerOptions.structured_options.text.max."
                             "is_enabled must be a Boolean."):
             profile_options = ProfilerOptions()
-            profile_options.structured_options.text.max.is_enabled \
-                = "String"
+            profile_options.structured_options.text.max.is_enabled = "String"
             profile_options.validate()
 
     def test_invalid_options_type(self, *mocks):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,5 @@ pyarrow>=1.0.1
 chardet>=3.0.4
 fastavro>=1.0.0.post1
 python-snappy>=0.5.4
-h5py>=2.10.0
 charset-normalizer>=1.3.6
 psutil>=4.0.0


### PR DESCRIPTION
Previously, `is_enabled` would propagate to all `is_enabled` values which may not be intuitive when calling `options.set(dict(is_enabled=True))`.

Now, if the user wants it to propagate to all properties or a specific set they must either use a wildcard or specify the set of options e.g.
```python
options.set({"*.is_enabled": True})
# or
options.set({"int.is_enabled": True})
```

Also resolves issues with tests which used set and erroneously propagated checks.