### PR TITLE
Update default value for variance/skew/kurtosis

### DIFF
--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -40,7 +40,6 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             'sample_size': None,
             'confidence_level': 0.999
         }
-        self._biased_precision_var = np.nan
 
         # https://www.calculator.net/confidence-interval-calculator.html
         self.__z_value_precision = 3.291

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -53,9 +53,9 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         self.min = None
         self.max = None
         self.sum = 0
-        self._biased_variance = 0
-        self._biased_skewness = 0
-        self._biased_kurtosis = 0
+        self._biased_variance = np.nan
+        self._biased_skewness = np.nan
+        self._biased_kurtosis = np.nan
         self.max_histogram_bin = 100000
         self.min_histogram_bin = 1000
         self.histogram_bin_method_names = [
@@ -329,7 +329,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
     @staticmethod
     def _correct_bias_variance(match_count, biased_variance):
         if match_count is None or biased_variance is None or match_count < 2:
-            return 0.0
+            return np.nan
 
         variance = match_count / (match_count - 1) * biased_variance
         return variance

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -81,10 +81,10 @@ class TestProfilerOptions(unittest.TestCase):
                     profile_column["statistics"]["histogram"]["bin_edges"])
                 self.assertIsNone(profile_column["statistics"]["min"])
                 self.assertIsNone(profile_column["statistics"]["max"])
-                self.assertEqual(0, profile_column["statistics"]["variance"])
+                self.assertTrue(np.isnan(profile_column["statistics"]["variance"]))
                 self.assertIsNone(profile_column["statistics"]["quantiles"][0])
-                self.assertEqual(0, profile_column["statistics"]["skewness"])
-                self.assertEqual(0, profile_column["statistics"]["kurtosis"])
+                self.assertTrue(np.isnan(profile_column["statistics"]["skewness"]))
+                self.assertTrue(np.isnan(profile_column["statistics"]["kurtosis"]))
 
         # Assert that the stats are enabled
         options.set({"*.is_numeric_stats_enabled": True})
@@ -101,7 +101,8 @@ class TestProfilerOptions(unittest.TestCase):
                     profile_column["statistics"]["histogram"]["bin_edges"])
                 self.assertIsNotNone(profile_column["statistics"]["min"])
                 self.assertIsNotNone(profile_column["statistics"]["max"])
-                self.assertNotEqual(0, profile_column["statistics"]["variance"])
+                print(profile_column["statistics"]["variance"])
+                self.assertEqual(0.5, profile_column["statistics"]["variance"])
                 self.assertIsNotNone(
                     profile_column["statistics"]["quantiles"][0])
                 self.assertTrue(profile_column["statistics"]["skewness"] is np.nan)
@@ -198,7 +199,7 @@ class TestProfilerOptions(unittest.TestCase):
                     profile_column["statistics"]["histogram"]["bin_edges"])
                 self.assertIsNone(profile_column["statistics"]["min"])
                 self.assertIsNone(profile_column["statistics"]["max"])
-                self.assertEqual(0, profile_column["statistics"]["variance"])
+                self.assertTrue(np.isnan(profile_column["statistics"]["variance"]))
                 self.assertIsNone(profile_column["statistics"]["quantiles"][0])
                 self.assertTrue(profile_column["statistics"]["skewness"] is np.nan)
                 self.assertTrue(profile_column["statistics"]["kurtosis"] is np.nan)

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -101,7 +101,6 @@ class TestProfilerOptions(unittest.TestCase):
                     profile_column["statistics"]["histogram"]["bin_edges"])
                 self.assertIsNotNone(profile_column["statistics"]["min"])
                 self.assertIsNotNone(profile_column["statistics"]["max"])
-                print(profile_column["statistics"]["variance"])
                 self.assertEqual(0.5, profile_column["statistics"]["variance"])
                 self.assertIsNotNone(
                     profile_column["statistics"]["quantiles"][0])

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -26,7 +26,7 @@ class TestFloatColumn(unittest.TestCase):
         self.assertEqual(profiler.max, None)
         self.assertEqual(profiler.sum, 0)
         self.assertEqual(profiler.mean, 0)
-        self.assertEqual(profiler.variance, 0)
+        self.assertTrue(profiler.variance is np.nan)
         self.assertTrue(profiler.skewness is np.nan)
         self.assertTrue(profiler.kurtosis is np.nan)
         self.assertTrue(profiler.stddev is np.nan)
@@ -40,7 +40,7 @@ class TestFloatColumn(unittest.TestCase):
         profiler.update(data)
         self.assertEqual(profiler.match_count, 1.0)
         self.assertEqual(profiler.mean, 1.5)
-        self.assertEqual(profiler.variance, 0)
+        self.assertTrue(profiler.variance is np.nan)
 
         data = pd.Series([2.5]).apply(str)
         profiler.update(data)
@@ -340,12 +340,9 @@ class TestFloatColumn(unittest.TestCase):
         self.assertEqual(0, num_profiler.skewness)
 
         num_profiler.update(df2.apply(str))
-        df = pd.concat([df1, df2])
-        print(num_profiler.skewness)
         self.assertAlmostEqual(np.sqrt(22 * 21) / 20 * 133 / 750, num_profiler.skewness)
 
         num_profiler.update(df3.apply(str))
-        df = pd.concat([df1, df2, df3])
         self.assertAlmostEqual(-0.3109967, num_profiler.skewness)
 
     def test_profiled_kurtosis(self):
@@ -364,11 +361,9 @@ class TestFloatColumn(unittest.TestCase):
         self.assertAlmostEqual(-6 / 5, num_profiler.kurtosis)
 
         num_profiler.update(df2.apply(str))
-        df = pd.concat([df1, df2])
         self.assertAlmostEqual(-0.390358, num_profiler.kurtosis)
 
         num_profiler.update(df3.apply(str))
-        df = pd.concat([df1, df2, df3])
         self.assertAlmostEqual(0.3311739, num_profiler.kurtosis)
 
     def test_bias_correction_option(self):

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -25,7 +25,7 @@ class TestIntColumn(unittest.TestCase):
         self.assertEqual(profiler.max, None)
         self.assertEqual(profiler.sum, 0)
         self.assertEqual(profiler.mean, 0)
-        self.assertEqual(profiler.variance, 0)
+        self.assertTrue(profiler.variance is np.nan)
         self.assertTrue(profiler.skewness is np.nan)
         self.assertTrue(profiler.kurtosis is np.nan)
         self.assertTrue(profiler.stddev is np.nan)
@@ -41,7 +41,7 @@ class TestIntColumn(unittest.TestCase):
         self.assertEqual(profiler.match_count, 1)
         self.assertEqual(profiler.sum, 1)
         self.assertEqual(profiler.mean, 1)
-        self.assertEqual(profiler.variance, 0)
+        self.assertTrue(profiler.variance is np.nan)
 
         data = pd.Series([2])
         profiler.update(data)

--- a/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
+++ b/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
@@ -134,7 +134,7 @@ class TestNumericStatsMixin(unittest.TestCase):
             mean1, var1, count1)
         num_profiler.match_count = count1
         num_profiler.sum = 0
-        self.assertEqual(num_profiler.variance, 0)
+        self.assertTrue(num_profiler.variance is np.nan)
 
         # data with 1 element
         data2 = [5.0]
@@ -145,7 +145,7 @@ class TestNumericStatsMixin(unittest.TestCase):
             mean2, var2, count2)
         num_profiler.match_count += count2
         num_profiler.sum += 5.0
-        self.assertEqual(num_profiler.variance, 0)
+        self.assertTrue(num_profiler.variance is np.nan)
 
         # data with multiple elements
         data3 = [-5.0, 5.0, 11.0, -11.0]


### PR DESCRIPTION
Previously, variance/skewness/kurtosis have a default value of zero, even if their value is incomputable based on the sample size. This changes the default value to NaN when these statistics cannot be computed on the data.