### PR TITLE
Refactor StructuredProfiler._profile and report['data_stats'] to be a lists instead of dictionaries to allow duplicate column names

### DIFF
--- a/dataprofiler/profilers/helpers/report_helpers.py
+++ b/dataprofiler/profilers/helpers/report_helpers.py
@@ -118,13 +118,13 @@ def _prepare_report(report, output_format=None, omit_keys=None):
         if isinstance(value, set):
             value = sorted(list(value))
 
-        # For data_stats, need to specially recurse through a list
-        # As well as account for omit_keys containing indices instead of
-        # keys
-        if key == "data_stats":
+        # For data_stats (in structured case), need to recurse through a list
+        # As well as account for omit_keys containing indices instead of keys
+        if key == "data_stats" and isinstance(value, list):
             fmt_report["data_stats"] = []
             # split off any remaining keys for the recursion
             # i.e. [test0, test1.test2] -> omit_keys => [test1.test2]
+            # This will filter out all the data_stats omit keys
             data_stat_omit_keys = []
             for omit_key in omit_keys:
                 omit_key_split = omit_key.split('.', 1)
@@ -137,8 +137,11 @@ def _prepare_report(report, output_format=None, omit_keys=None):
                         if prior_key_layer == '*' or prior_key_layer == key:
                             data_stat_omit_keys.append(next_key_layer)
 
+            # Recurse throw indices in data_stats and call report_helper for
+            # each entry
             for i in range(len(value)):
                 i_index_omit_keys = []
+                # Filter off data_stats omit keys depending on index
                 for nl_key in data_stat_omit_keys:
                     key_split = nl_key.split(".", 1)
 

--- a/dataprofiler/profilers/helpers/report_helpers.py
+++ b/dataprofiler/profilers/helpers/report_helpers.py
@@ -122,6 +122,7 @@ def _prepare_report(report, output_format=None, omit_keys=None):
         # As well as account for omit_keys containing indices instead of
         # keys
         if key == "data_stats":
+            fmt_report["data_stats"] = []
             # split off any remaining keys for the recursion
             # i.e. [test0, test1.test2] -> omit_keys => [test1.test2]
             data_stat_omit_keys = []
@@ -151,9 +152,8 @@ def _prepare_report(report, output_format=None, omit_keys=None):
                                 i_index_omit_keys.append(next_key_layer)
 
                 # Recursively prepare each column in data_stats list
-                fmt_report["data_stats"][i] = _prepare_report(value[i],
-                                                              output_format,
-                                                              i_index_omit_keys)
+                fmt_report["data_stats"].append(
+                    _prepare_report(value[i], output_format, i_index_omit_keys))
 
         # Do not recurse or modify profile_schema
         elif key == "profile_schema":

--- a/dataprofiler/profilers/helpers/report_helpers.py
+++ b/dataprofiler/profilers/helpers/report_helpers.py
@@ -96,6 +96,11 @@ def _prepare_report(report, output_format=None, omit_keys=None):
         
         value = report[key]
 
+        # Do not recurse or modify profile_schema
+        if key == "profile_schema":
+            fmt_report[key] = value
+            continue
+
         # Convert set to list, for report generation
         if isinstance(value, set):
             value = sorted(list(value))

--- a/dataprofiler/profilers/helpers/report_helpers.py
+++ b/dataprofiler/profilers/helpers/report_helpers.py
@@ -87,6 +87,24 @@ def _prepare_report(report, output_format=None, omit_keys=None):
             "data_stats.*.statistics.histogram"
         ])
         output_format = "pretty"
+
+    # Modify omit_keys to account for data_stats being a list and not a dict
+    # With column names for keys
+    new_omit_keys = []
+    for omit_key in omit_keys:
+        key_list = omit_key.split(".")
+        if len(key_list) > 1 and key_list[0] == "data_stats" \
+                and key_list[1] != "*":
+            idxs = report["global_stats"]["profile_schema"][key_list[1]]
+            for i in idxs:
+                swapped_list = key_list
+                swapped_list[1] = str(i)
+                swapped_str = ".".join(swapped_list)
+                new_omit_keys.append(swapped_str)
+        else:
+            new_omit_keys.append(omit_key)
+
+    omit_keys = new_omit_keys
     
     for key in report:
         
@@ -96,16 +114,52 @@ def _prepare_report(report, output_format=None, omit_keys=None):
         
         value = report[key]
 
-        # Do not recurse or modify profile_schema
-        if key == "profile_schema":
-            fmt_report[key] = value
-            continue
-
         # Convert set to list, for report generation
         if isinstance(value, set):
             value = sorted(list(value))
 
-        if isinstance(value, dict):
+        # For data_stats, need to specially recurse through a list
+        # As well as account for omit_keys containing indices instead of
+        # keys
+        if key == "data_stats":
+            # split off any remaining keys for the recursion
+            # i.e. [test0, test1.test2] -> omit_keys => [test1.test2]
+            data_stat_omit_keys = []
+            for omit_key in omit_keys:
+                omit_key_split = omit_key.split('.', 1)
+
+                # Must have more keys left for recursion
+                if len(omit_key_split) > 1:
+                    next_key_layer = omit_key_split[-1]
+                    prior_key_layer = omit_key_split[0]
+                    if len(next_key_layer) > 0:
+                        if prior_key_layer == '*' or prior_key_layer == key:
+                            data_stat_omit_keys.append(next_key_layer)
+
+            for i in range(len(value)):
+                i_index_omit_keys = []
+                for nl_key in data_stat_omit_keys:
+                    key_split = nl_key.split(".", 1)
+
+                    # Must have more keys left for recursion
+                    if len(key_split) > 1:
+                        next_key_layer = key_split[-1]
+                        index = key_split[0]
+                        if len(next_key_layer) > 0:
+                            if (index.isdigit() and int(index) == i) \
+                                    or index == "*":
+                                i_index_omit_keys.append(next_key_layer)
+
+                # Recursively prepare each column in data_stats list
+                fmt_report["data_stats"][i] = _prepare_report(value[i],
+                                                              output_format,
+                                                              i_index_omit_keys)
+
+        # Do not recurse or modify profile_schema
+        elif key == "profile_schema":
+            fmt_report[key] = value
+
+        elif isinstance(value, dict):
 
             # split off any remaining keys for the recursion
             # i.e. [test0, test1.test2] -> omit_keys => [test1.test2]

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1258,19 +1258,20 @@ class StructuredProfiler(BaseProfiler):
         :rtype: Dict[int, int]
         """
 
-        len_schema_1 = len(schema1)
-        len_schema_2 = len(schema2)
+        len_schema1 = len(schema1)
+        len_schema2 = len(schema2)
 
-        if strict and len_schema_1 != len_schema_2:
+        # If both non-empty, must be same length
+        if 0 < len_schema1 != len_schema2 > 0:
             raise ValueError("Attempted to merge profiles with different "
                              "numbers of columns")
 
         # In the case of __add__ with one of the schemas not initialized
-        if strict and (len_schema_1 == 0 or len_schema_2 == 0):
+        if strict and (len_schema1 == 0 or len_schema2 == 0):
             raise ValueError("Cannot merge empty profiles.")
 
         # In the case of _update_from_chunk with uninitialized schema
-        if not strict and len_schema_2 == 0:
+        if not strict and len_schema2 == 0:
             return {col_ind: col_ind for col_ind_list in schema1.values()
                     for col_ind in col_ind_list}
 

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1162,7 +1162,6 @@ class StructuredProfiler(BaseProfiler):
         self.hashed_row_dict = dict()
         self._profile = []
         self._col_name_to_idx = defaultdict(list)
-        self._duplicate_cols_present = False
 
         if data is not None:
             self.update_profile(data)
@@ -1614,12 +1613,6 @@ class StructuredProfiler(BaseProfiler):
 
         self._update_row_statistics(data, samples_for_row_stats)
 
-        # Update personal attributes about state of profile
-        if not initialized:
-            num_cols = [len(self._col_name_to_idx[col])
-                        for col in self._col_name_to_idx]
-            self._duplicate_cols_present = any(num > 1 for num in num_cols)
-
     def save(self, filepath=None):
         """
         Save profiler to disk
@@ -1641,7 +1634,6 @@ class StructuredProfiler(BaseProfiler):
                 "options": self.options,
                 "_profile": self.profile,
                 "_col_name_to_idx": self._col_name_to_idx,
-                "_duplicate_cols_present": self._duplicate_cols_present
                } 
 
         self._save_helper(filepath, data_dict)

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1243,6 +1243,9 @@ class StructuredProfiler(BaseProfiler):
         for col in self._col_name_to_idx:
             col_idxs = self._col_name_to_idx[col]
             if prof_idx in col_idxs:
+                # Case where col isn't duplicated, no need to look through ids
+                if len(col_idxs) == 1:
+                    return data[col]
                 # If there are duplicate columns under the same name, need
                 # to figure place in list of indexes, as this corresponds
                 # to place in list of series returned by data[col]

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1174,9 +1174,9 @@ class StructuredProfiler(BaseProfiler):
         """
 
         # Pass with strict = True to enforce both needing to be non-empty
-        self_to_other_idx = self._get_and_validate_schema(self._col_name_to_idx,
-                                                          other._col_name_to_idx,
-                                                          True)
+        self_to_other_idx = self._get_and_validate_schema_mapping(self._col_name_to_idx,
+                                                                  other._col_name_to_idx,
+                                                                  True)
         if not all([isinstance(other._profile[self_to_other_idx[idx]],
                                type(self._profile[idx]))
                     for idx in range(len(self._profile))]):  # options check
@@ -1203,8 +1203,8 @@ class StructuredProfiler(BaseProfiler):
         merged_profile.hashed_row_dict.update(self.hashed_row_dict)
         merged_profile.hashed_row_dict.update(other.hashed_row_dict)
 
-        self_to_other_idx = self._get_and_validate_schema(self._col_name_to_idx,
-                                                          other._col_name_to_idx)
+        self_to_other_idx = self._get_and_validate_schema_mapping(self._col_name_to_idx,
+                                                                  other._col_name_to_idx)
 
         # merge profiles
         for idx in range(len(self._profile)):
@@ -1257,7 +1257,7 @@ class StructuredProfiler(BaseProfiler):
                 return col_name
 
     @staticmethod
-    def _get_and_validate_schema(schema1, schema2, strict=False):
+    def _get_and_validate_schema_mapping(schema1, schema2, strict=False):
         """
         Validate compatibility between schema1 and schema2 and return a dict
         mapping indices in schema1 to their corresponding indices in schema2.
@@ -1467,8 +1467,8 @@ class StructuredProfiler(BaseProfiler):
             mapping_given[col].append(col_idx)
 
         # Validate schema compatibility and index mapping from data to _profile
-        col_idx_to_prof_idx = self._get_and_validate_schema(mapping_given,
-                                                            self._col_name_to_idx)
+        col_idx_to_prof_idx = self._get_and_validate_schema_mapping(mapping_given,
+                                                                    self._col_name_to_idx)
 
         try:
             from tqdm import tqdm

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1431,7 +1431,7 @@ class StructuredProfiler(BaseProfiler):
         if not duplicate_cols_present:
             # Given duplicate columns despite duplicate columns not being
             # present in nonempty _profile
-            if len(self._profile) > 0 and duplicate_cols_given:
+            if initialized and duplicate_cols_given:
                 raise ValueError("Attempted to update data with duplicate "
                                  "column names that weren't present before "
                                  "update. Schema must be identical when "
@@ -1457,6 +1457,7 @@ class StructuredProfiler(BaseProfiler):
                     new_cols = True
         else:
             # Ensure same schema if initialized with duplicate columns
+            # No adding columns to _profile after initialization in this case
             mapping_given = dict()
             for i in range(len(data.columns)):
                 col = data.columns[i]

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1588,7 +1588,7 @@ class StructuredProfiler(BaseProfiler):
                 notification_str += " (with " + str(pool_size) + " processes)"
         print(notification_str)
         
-        for col_idx in tqdm(range(len(self._profile))):
+        for col_idx in tqdm(clean_sampled_dict.keys()):
             self._profile[col_idx].update_column_profilers(
                 clean_sampled_dict[col_idx], pool)
 

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1240,13 +1240,6 @@ class StructuredProfiler(BaseProfiler):
         """
         return min([col._last_batch_size for col in self._profile], default=0)
 
-    @property
-    def is_initialized(self):
-        """
-        Determines if profiler has been initialized with data
-        """
-        return self.total_samples > 0
-
     @staticmethod
     def _get_and_validate_schema_mapping(schema1, schema2, strict=False):
         """
@@ -1444,8 +1437,6 @@ class StructuredProfiler(BaseProfiler):
         elif isinstance(data, list):
             data = pd.DataFrame(data)
 
-        initialized = self.is_initialized
-
         # Calculate schema of incoming data
         mapping_given = defaultdict(list)
         for col_idx in range(len(data.columns)):
@@ -1485,7 +1476,7 @@ class StructuredProfiler(BaseProfiler):
         # Create StructuredColProfilers upon initialization
         # Record correlation between columns in data and index in _profile
         new_cols = False
-        if not initialized:
+        if len(self._profile) == 0:
             for col_idx in range(data.shape[1]):
                 col_name = data.columns[col_idx]
                 # Pandas cols are int by default, but need to fuzzy match strs

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1250,6 +1250,13 @@ class StructuredProfiler(BaseProfiler):
                     if col_idxs[i] == prof_idx:
                         return data[col][i]
 
+    def profile_by_name(self, name):
+        """
+        Return first profile that comes up for a given name
+        """
+        if name in self._col_name_to_idx:
+            return self._profile[self._col_name_to_idx[name][0]]
+        return None
 
     def report(self, report_options=None):
         if not report_options:

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1439,10 +1439,13 @@ class StructuredProfiler(BaseProfiler):
 
             # Either initializing _profile for the first time or updating
             # _profile that doesn't contain duplicate column names
-            if not initialized:
-                for col in data.columns:
-                    # Append StructuredColProfiler to list of profiles and
-                    # record index where it was appended to in list
+            for col in data.columns:
+                # If initializing for the first time, must fill mapping
+                # If initialized, with no duplicate columns, only add to mapping
+                # if not already there, since this means we are updating
+                if not initialized or col not in self._col_name_to_idx:
+                    # Append StructuredColProfiler to list of profiles
+                    # and record index where it was appended to in list
                     self._col_name_to_idx.setdefault(col, []).append(
                         len(self._profile))
                     self._profile.append(StructuredColProfiler(

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1250,14 +1250,6 @@ class StructuredProfiler(BaseProfiler):
                     if col_idxs[i] == prof_idx:
                         return data[col][i]
 
-    def profile_by_name(self, name):
-        """
-        Return first profile that comes up for a given name
-        """
-        if name in self._col_name_to_idx:
-            return self._profile[self._col_name_to_idx[name][0]]
-        return None
-
     def report(self, report_options=None):
         if not report_options:
             report_options = {

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1636,7 +1636,9 @@ class StructuredProfiler(BaseProfiler):
                 "_min_true_samples": self._min_true_samples,
                 "options": self.options,
                 "_profile": self.profile,
-                "_col_name_to_idx": self._col_name_to_idx
+                "_col_name_to_idx": self._col_name_to_idx,
+                "_initialized": self._initialized,
+                "_duplicate_cols_present": self._duplicate_cols_present
                } 
 
         self._save_helper(filepath, data_dict)

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1279,35 +1279,18 @@ class StructuredProfiler(BaseProfiler):
                 "unique_row_ratio": self._get_unique_row_ratio(),
                 "duplicate_row_count": self._get_duplicate_row_count(),
                 "file_type": self.file_type,
-                "encoding": self.encoding
+                "encoding": self.encoding,
+                "profile_schema": copy.deepcopy(self._col_name_to_idx)
             }),
-            ("data_stats", OrderedDict()),
+            ("data_stats", []),
         ])
-        for col in self._col_name_to_idx:
-            idxs = self._col_name_to_idx[col]
-            # Case where column only appears once in data
-            # Report has 1 entry of data stats for this column
-            if len(idxs) == 1:
-                idx = idxs[0]
-                report["data_stats"][col] = self._profile[idx].profile
-                quantiles = report["data_stats"][col]["statistics"].get(
-                    'quantiles')
-                if quantiles:
-                    quantiles = calculate_quantiles(num_quantile_groups,
-                                                    quantiles)
-                    report["data_stats"][col]["statistics"]["quantiles"] = \
-                        quantiles
-            # Case where column appears multiple times
-            # Report has a list of entries under this column
-            else:
-                report["data_stats"][col] = [self._profile[idx].profile
-                                             for idx in idxs]
-                for profile in report["data_stats"][col]:
-                    quantiles = profile["statistics"].get('quantiles')
-                    if quantiles:
-                        quantiles = calculate_quantiles(num_quantile_groups,
-                                                        quantiles)
-                        profile["statistics"]["quantiles"] = quantiles
+
+        for i in range(len(self._profile)):
+            report["data_stats"].append(self._profile[i].profile)
+            quantiles = report["data_stats"][i]["statistics"].get('quantiles')
+            if quantiles:
+                quantiles = calculate_quantiles(num_quantile_groups, quantiles)
+                report["data_stats"][i]["statistics"]["quantiles"] = quantiles
 
         return _prepare_report(report, output_format, omit_keys)
 

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1622,7 +1622,8 @@ class StructuredProfiler(BaseProfiler):
                 "_samples_per_update": self._samples_per_update,
                 "_min_true_samples": self._min_true_samples,
                 "options": self.options,
-                "_profile": self.profile
+                "_profile": self.profile,
+                "_col_name_to_idx": self._col_name_to_idx
                } 
 
         self._save_helper(filepath, data_dict)

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1162,7 +1162,6 @@ class StructuredProfiler(BaseProfiler):
         self.hashed_row_dict = dict()
         self._profile = []
         self._col_name_to_idx = dict()
-        self._initialized = False
         self._duplicate_cols_present = False
 
         if data is not None:
@@ -1405,9 +1404,10 @@ class StructuredProfiler(BaseProfiler):
             data = pd.DataFrame(data)
 
         duplicate_cols_given = len(data.columns) != len(data.columns.unique())
+        initialized = self.total_samples > 0
 
         # Error out if schema given does not match schema present in data
-        if self._initialized:
+        if initialized:
             mapping_given = dict()
             for i in range(len(data.columns)):
                 col = data.columns[i]
@@ -1461,7 +1461,7 @@ class StructuredProfiler(BaseProfiler):
         # Create StructuredColProfilers upon initialization
         # Record correlation between columns in data and index in _profile
         new_cols = False
-        if not self._initialized:
+        if not initialized:
             for col_idx in range(data.shape[1]):
                 col_name = data.columns[col_idx]
                 if isinstance(col_name, str):
@@ -1602,11 +1602,10 @@ class StructuredProfiler(BaseProfiler):
         self._update_row_statistics(data, samples_for_row_stats)
 
         # Update personal attributes about state of profile
-        if not self._initialized:
+        if not initialized:
             num_cols = [len(self._col_name_to_idx[col])
                         for col in self._col_name_to_idx]
             self._duplicate_cols_present = any(num > 1 for num in num_cols)
-        self._initialized = True
 
     def save(self, filepath=None):
         """
@@ -1629,7 +1628,6 @@ class StructuredProfiler(BaseProfiler):
                 "options": self.options,
                 "_profile": self.profile,
                 "_col_name_to_idx": self._col_name_to_idx,
-                "_initialized": self._initialized,
                 "_duplicate_cols_present": self._duplicate_cols_present
                } 
 

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1397,6 +1397,23 @@ class StructuredProfiler(BaseProfiler):
         duplicate_cols_present = any([num > 1 for num in num_cols])
         initialized = len(self._profile) > 0
 
+        # Error out if initialized with unique columns but given duplicates
+        if initialized and duplicate_cols_given and not duplicate_cols_present:
+            raise ValueError("Attempted to update data with duplicate "
+                             "column names that weren't present before "
+                             "update. Schema must be identical when "
+                             "profiling data with duplicate column names.")
+
+        # Error out if duplicate columns present and given schema doesn't match
+        if duplicate_cols_present:
+            mapping_given = dict()
+            for i in range(len(data.columns)):
+                col = data.columns[i]
+                mapping_given.setdefault(col, []).append(i)
+            if mapping_given != self._col_name_to_idx:
+                raise ValueError("Schema of data with duplicate column names "
+                                 "not respected when updating profile.")
+
         try:
             from tqdm import tqdm
         except ImportError:
@@ -1424,14 +1441,6 @@ class StructuredProfiler(BaseProfiler):
         # or unique column names)
         new_cols = False
         if not duplicate_cols_present:
-            # Given duplicate columns despite duplicate columns not being
-            # present in nonempty _profile
-            if initialized and duplicate_cols_given:
-                raise ValueError("Attempted to update data with duplicate "
-                                 "column names that weren't present before "
-                                 "update. Schema must be identical when "
-                                 "profiling data with duplicate column names.")
-
             # Either initializing _profile for the first time or updating
             # _profile that doesn't contain duplicate column names
             for col in data.columns:
@@ -1450,16 +1459,6 @@ class StructuredProfiler(BaseProfiler):
                         options=self.options
                     ))
                     new_cols = True
-        else:
-            # Ensure same schema if initialized with duplicate columns
-            # No adding columns to _profile after initialization in this case
-            mapping_given = dict()
-            for i in range(len(data.columns)):
-                col = data.columns[i]
-                mapping_given.setdefault(col, []).append(i)
-            if mapping_given != self._col_name_to_idx:
-                raise ValueError("Schema of data with duplicate column names "
-                                 "not respected when updating profile.")
                 
         # Generate pool and estimate datasize
         pool = None

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1258,12 +1258,19 @@ class StructuredProfiler(BaseProfiler):
         :rtype: Dict[int, int]
         """
 
+        len_schema_1 = len(schema1)
+        len_schema_2 = len(schema2)
+
+        if strict and len_schema_1 != len_schema_2:
+            raise ValueError("Attempted to merge profiles with different "
+                             "numbers of columns")
+
         # In the case of __add__ with one of the schemas not initialized
-        if strict and (len(schema1) == 0 or len(schema2) == 0):
+        if strict and (len_schema_1 == 0 or len_schema_2 == 0):
             raise ValueError("Cannot merge empty profiles.")
 
         # In the case of _update_from_chunk with uninitialized schema
-        if not strict and len(schema2) == 0:
+        if not strict and len_schema_2 == 0:
             return {col_ind: col_ind for col_ind_list in schema1.values()
                     for col_ind in col_ind_list}
 
@@ -1475,15 +1482,14 @@ class StructuredProfiler(BaseProfiler):
 
         # Create StructuredColProfilers upon initialization
         # Record correlation between columns in data and index in _profile
-        new_cols = False
         if len(self._profile) == 0:
+            # Already calculated incoming schema for validation
+            self._col_name_to_idx = mapping_given
             for col_idx in range(data.shape[1]):
                 col_name = data.columns[col_idx]
                 # Pandas cols are int by default, but need to fuzzy match strs
                 if isinstance(col_name, str):
                     col_name = col_name.lower()
-                # Record index in _profile corresponding to current col profile
-                self._col_name_to_idx[col_name].append(len(self._profile))
                 # Add blank StructuredColProfiler to _profile
                 self._profile.append(StructuredColProfiler(
                     sample_size=sample_size,
@@ -1491,7 +1497,6 @@ class StructuredProfiler(BaseProfiler):
                     sample_ids=sample_ids,
                     options=self.options
                 ))
-                new_cols = True
                 
         # Generate pool and estimate datasize
         pool = None
@@ -1504,7 +1509,7 @@ class StructuredProfiler(BaseProfiler):
 
         # Format the data
         notification_str = "Finding the Null values in the columns..."        
-        if pool and new_cols:
+        if pool:
             notification_str += " (with " + str(pool_size) + " processes)"
 
         # Keys are _profile indices

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1479,7 +1479,9 @@ class StructuredProfiler(BaseProfiler):
             # Create a bunch of simultaneous column conversions
             for col in data.columns.unique():
                 df_or_ser = data[col]
+                # Only one column under the name "col"
                 if isinstance(df_or_ser, pd.Series):
+                    # Calculate index in _profile that corresponds to "col""
                     idx = self._col_name_to_idx[col][0]
                     if min_true_samples is None:
                         min_true_samples = self._profile[idx]._min_true_samples
@@ -1491,9 +1493,14 @@ class StructuredProfiler(BaseProfiler):
                     except Exception as e:
                         print(e)
                         single_process_list.add(idx)
+                # Multiple columns under the name "col"
                 else:
+                    # Calculate indices in _profile that correspond to "col"
                     for data_idx in range(len(df_or_ser.columns)):
                         df_or_ser = df_or_ser.iloc[:, data_idx]
+                        # Order in _profile matches order in data
+                        # Pull out entry in _col_name_to_idx that corresponds
+                        # to multiple columns under name "col" (df_or_ser)
                         idx = self._col_name_to_idx[col][data_idx]
                         if min_true_samples is None:
                             min_true_samples = \
@@ -1539,7 +1546,9 @@ class StructuredProfiler(BaseProfiler):
             print(notification_str)
             for col in tqdm(data.columns.unique()):
                 df_or_ser = data[col]
+                # Only 1 column under the name "col"
                 if isinstance(df_or_ser, pd.Series):
+                    # Calculate index in _profile that corresponds to "col"
                     idx = self._col_name_to_idx[col][0]
                     if min_true_samples is None:
                         min_true_samples = self._profile[idx]._min_true_samples
@@ -1550,8 +1559,13 @@ class StructuredProfiler(BaseProfiler):
                             sample_ids=sample_ids
                         )
                     self._profile[idx]._update_base_stats(base_stats)
+                # Multiple columns under the name "col"
                 else:
+                    # Calculate indices in _profile that correspond to "col"
                     for data_idx in range(len(df_or_ser.columns)):
+                        # Order in _profile matches order in data
+                        # Pull out entry in _col_name_to_idx that corresponds
+                        # to multiple columns under name "col" (df_or_ser)
                         df_or_ser = df_or_ser.iloc[:, data_idx]
                         idx = self._col_name_to_idx[col][data_idx]
                         if min_true_samples is None:

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1248,14 +1248,6 @@ class StructuredProfiler(BaseProfiler):
         """
         return self.total_samples > 0
 
-    def _get_col_name_from_idx(self, idx):
-        """
-        Determine which column name corresponds to a _profile index
-        """
-        for col_name in self._col_name_to_idx:
-            if idx in self._col_name_to_idx[col_name]:
-                return col_name
-
     @staticmethod
     def _get_and_validate_schema_mapping(schema1, schema2, strict=False):
         """

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1274,14 +1274,12 @@ class StructuredProfiler(BaseProfiler):
         :rtype: Dict[int, int]
         """
 
-        one_schema_empty = (len(schema1) == 0 and len(schema2) > 0) \
-                           or (len(schema1) > 0 and len(schema2) == 0)
         # In the case of __add__ with one of the schemas not initialized
-        if strict and one_schema_empty:
-            raise ValueError("Cannot merge profiles due to schema mismatch")
+        if strict and (len(schema1) == 0 or len(schema2) == 0):
+            raise ValueError("Cannot merge empty profiles.")
 
         # In the case of _update_from_chunk with uninitialized schema
-        if len(schema2) == 0:
+        if not strict and len(schema2) == 0:
             return {col_ind: col_ind for col_ind_list in schema1.values()
                     for col_ind in col_ind_list}
 

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1218,7 +1218,7 @@ class StructuredProfiler(BaseProfiler):
             # If columns unique, order may be permutated
             if not self._duplicate_cols_present:
                 # Determine which index in other._profile corresponds to idx
-                col_name = self._profile[idx].name.lower()
+                col_name = self._get_col_name_from_idx(idx)
                 other_idx = other._col_name_to_idx[col_name][0]
             merged_profile._profile.append(self._profile[idx] +
                                            other._profile[other_idx])

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1487,10 +1487,6 @@ class StructuredProfiler(BaseProfiler):
             # Already calculated incoming schema for validation
             self._col_name_to_idx = mapping_given
             for col_idx in range(data.shape[1]):
-                col_name = data.columns[col_idx]
-                # Pandas cols are int by default, but need to fuzzy match strs
-                if isinstance(col_name, str):
-                    col_name = col_name.lower()
                 # Add blank StructuredColProfiler to _profile
                 self._profile.append(StructuredColProfiler(
                     sample_size=sample_size,

--- a/dataprofiler/tests/labelers/test_integration_struct_data_labeler.py
+++ b/dataprofiler/tests/labelers/test_integration_struct_data_labeler.py
@@ -291,9 +291,9 @@ class TestStructuredDataLabeler(unittest.TestCase):
 
         columns = []
         predictions = []
-        for col in results['data_stats']:
-            columns.append(col)
-            predictions.append(results['data_stats'][col]['data_label'])
+        for i in range(len(results['data_stats'])):
+            columns.append(i)
+            predictions.append(results['data_stats'][i]['data_label'])
 
     def test_warning_tf_run_dp_multiple_times(self):
         test_root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -319,9 +319,9 @@ class TestStructuredDataLabeler(unittest.TestCase):
 
             columns = []
             predictions = []
-            for col in results['data_stats']:
-                columns.append(col)
-                predictions.append(results['data_stats'][col]['data_label'])
+            for i in range(len(results['data_stats'])):
+                columns.append(i)
+                predictions.append(results['data_stats'][i]['data_label'])
 
     def test_warning_tf_run_dp_merge(self):
         test_root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))

--- a/dataprofiler/tests/labelers/test_integration_struct_data_labeler.py
+++ b/dataprofiler/tests/labelers/test_integration_struct_data_labeler.py
@@ -319,9 +319,9 @@ class TestStructuredDataLabeler(unittest.TestCase):
 
             columns = []
             predictions = []
-            for i in range(len(results['data_stats'])):
-                columns.append(i)
-                predictions.append(results['data_stats'][i]['data_label'])
+            for j in range(len(results['data_stats'])):
+                columns.append(j)
+                predictions.append(results['data_stats'][j]['data_label'])
 
     def test_warning_tf_run_dp_merge(self):
         test_root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -70,8 +70,8 @@ class TestProfilerOptions(unittest.TestCase):
         options.set({"*.is_numeric_stats_enabled": False})
         profile = Profiler(self.data, options=options)
 
-        for column_name in profile.profile.keys():
-            profile_column = profile.profile[column_name].profile
+        for col_profiler in profile.profile:
+            profile_column = col_profiler.profile
             if profile_column["statistics"] \
                     and "histogram" in profile_column["statistics"].keys() \
                     and profile_column["statistics"]["histogram"]:
@@ -92,8 +92,8 @@ class TestProfilerOptions(unittest.TestCase):
         options.set({"*.is_numeric_stats_enabled": True})
         profile = Profiler(self.data, options=options)
 
-        for column_name in profile.profile.keys():
-            profile_column = profile.profile[column_name].profile
+        for col_profiler in profile.profile:
+            profile_column = col_profiler.profile
             if profile_column["statistics"] \
                     and "histogram" in profile_column["statistics"].keys() \
                     and profile_column["statistics"]["histogram"]:
@@ -111,8 +111,8 @@ class TestProfilerOptions(unittest.TestCase):
         options = ProfilerOptions()
         options.structured_options.data_labeler.enable = False
         profile = Profiler(self.data, options=options)
-        for column_name in profile.profile.keys():
-            profile_column = profile.profile[column_name].profile
+        for col_profiler in profile.profile:
+            profile_column = col_profiler.profile
             if profile_column["statistics"] \
                     and "data_label_probability" in \
                     profile_column["statistics"].keys():
@@ -129,8 +129,8 @@ class TestProfilerOptions(unittest.TestCase):
         options.structured_options.category.is_enabled = False
         options.structured_options.data_labeler.is_enabled = False
         profile = Profiler(self.data, options=options)
-        for column_name in profile.profile.keys():
-            profile_column = profile.profile[column_name].profile
+        for col_profiler in profile.profile:
+            profile_column = col_profiler.profile
             self.assertIsNone(profile_column["data_type"])
             self.assertTrue("data_label" not in profile_column.keys())
             self.assertIsNone(profile_column["categorical"])
@@ -187,8 +187,8 @@ class TestProfilerOptions(unittest.TestCase):
         profile = Profiler(self.data, options=options)
 
         # Assert that the stats are non-existent
-        for column_name in profile.profile.keys():
-            profile_column = profile.profile[column_name].profile
+        for col_profiler in profile.profile:
+            profile_column = col_profiler.profile
             if profile_column["statistics"] \
                     and "histogram" in profile_column["statistics"].keys() \
                     and profile_column["statistics"]["histogram"]:

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -611,6 +611,43 @@ class TestStructuredProfiler(unittest.TestCase):
             self.assertEqual(col_sum, profiler._profile[col_idx].
                              profile["statistics"]["sum"])
 
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnPrimitiveTypeProfileCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnStatsProfileCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnDataLabelerCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
+    def test_schema_errors(self, *mocks):
+        # Can't merge profiles with different schemas
+        empty_profile1 = dp.StructuredProfiler(None)
+        empty_profile2 = dp.StructuredProfiler(None)
+        empty_profile1._col_name_to_idx = {"profile": [0], "one": [1]}
+        empty_profile2._col_name_to_idx = {"profile": [0], "two": [2]}
+        msg = 'Profiles do not have the same schema.'
+        with self.assertRaisesRegex(ValueError, msg):
+            empty_profile1._add_error_checks(empty_profile2)
+
+        # Can't change schema when updating
+        dupe_data = pd.DataFrame([[1, 2, 3, 4, 5, 6],
+                                  [10, 20, 30, 40, 50, 60]],
+                                 columns=["a", "b", "a", "b", "c", "d"])
+        unique_data = pd.DataFrame({"e": [1, 1], "f": [2, 2], "g": [3, 3]})
+        dupe_profile = dp.StructuredProfiler(dupe_data)
+        unique_profile = dp.StructuredProfiler(unique_data)
+
+        msg = ("Schema of data with duplicate column names not respected when "
+               "updating profile.")
+        with self.assertRaisesRegex(ValueError, msg):
+            dupe_profile.update_profile(unique_data)
+
+        msg = ("Attempted to update data with duplicate "
+               "column names that weren't present before "
+               "update. Schema must be identical when "
+               "profiling data with duplicate column names.")
+        with self.assertRaisesRegex(ValueError, msg):
+            unique_profile.update_profile(dupe_data)
+
 
 class TestStructuredColProfilerClass(unittest.TestCase):
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -681,45 +681,6 @@ class TestStructuredProfiler(unittest.TestCase):
             self.assertEqual(col_sum, profiler._profile[col_idx].
                              profile["statistics"]["sum"])
 
-    @mock.patch('dataprofiler.profilers.profile_builder.'
-                'ColumnPrimitiveTypeProfileCompiler')
-    @mock.patch('dataprofiler.profilers.profile_builder.'
-                'ColumnStatsProfileCompiler')
-    @mock.patch('dataprofiler.profilers.profile_builder.'
-                'ColumnDataLabelerCompiler')
-    @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
-    def test_schema_errors(self, *mocks):
-        # Can't merge profiles with different schemas
-        empty_profile1 = dp.StructuredProfiler(None)
-        empty_profile2 = dp.StructuredProfiler(None)
-        empty_profile1._col_name_to_idx = {"profile": [0], "one": [1]}
-        empty_profile2._col_name_to_idx = {"profile": [0], "two": [2]}
-        msg = 'Profiles do not have the same schema.'
-        with self.assertRaisesRegex(ValueError, msg):
-            empty_profile1._add_error_checks(empty_profile2)
-
-        # Can't change schema when updating
-        dupe_data = pd.DataFrame([[1, 2, 3, 4, 5, 6],
-                                  [10, 20, 30, 40, 50, 60]],
-                                 columns=["a", "b", "a", "b", "c", "d"])
-        unique_data = pd.DataFrame({"e": [1, 1], "f": [2, 2], "g": [3, 3]})
-        dupe_profile = dp.StructuredProfiler(dupe_data)
-        unique_profile = dp.StructuredProfiler(unique_data)
-
-        msg = ("Schema of data given to StructuredProfiler.update does not "
-               "match schema calculated at initialization.")
-        with self.assertRaisesRegex(ValueError, msg):
-            dupe_profile.update_profile(unique_data)
-
-        perm_data = pd.DataFrame([[1, 2, 3, 4, 5, 6],
-                                  [10, 20, 30, 40, 50, 60]],
-                                 columns=["a", "a", "b", "b", "c", "d"])
-        with self.assertRaisesRegex(ValueError, msg):
-            dupe_profile.update_profile(perm_data)
-
-        with self.assertRaisesRegex(ValueError, msg):
-            unique_profile.update_profile(dupe_data)
-
     def test_unique_col_permutation(self, *mocks):
         data = pd.DataFrame([[1, 2, 3, 4],
                              [5, 6, 7, 8]],

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -245,7 +245,8 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(0.0, self.trained_schema._get_duplicate_row_count())
 
     def test_correct_datatime_schema_test(self):
-        profile = self.trained_schema.profile_by_name("datetime")
+        profile_idx = self.trained_schema._col_name_to_idx["datetime"][0]
+        profile = self.trained_schema.profile[profile_idx]
         col_schema_info = \
             profile.profiles['data_type_profile']._profiles["datetime"]
 
@@ -257,7 +258,8 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(['%m/%d/%y %H:%M'], col_schema_info['date_formats'])
 
     def test_correct_integer_column_detection_src(self):
-        profile = self.trained_schema.profile_by_name("src")
+        profile_idx = self.trained_schema._col_name_to_idx["src"][0]
+        profile = self.trained_schema.profile[profile_idx]
         col_schema_info = profile.profiles['data_type_profile']._profiles["int"]
 
         self.assertEqual(2999, profile.sample_size)
@@ -266,7 +268,8 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(3, profile.null_count)
 
     def test_correct_integer_column_detection_int_col(self):
-        profile = self.trained_schema.profile_by_name("int_col")
+        profile_idx = self.trained_schema._col_name_to_idx["int_col"][0]
+        profile = self.trained_schema.profile[profile_idx]
         col_schema_info = profile.profiles['data_type_profile']._profiles["int"]
         self.assertEqual(2999, profile.sample_size)
         self.assertEqual(col_schema_info.sample_size,
@@ -274,7 +277,8 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(0, profile.null_count)
 
     def test_correct_integer_column_detection_port(self):
-        profile = self.trained_schema.profile_by_name("srcport")
+        profile_idx = self.trained_schema._col_name_to_idx["srcport"][0]
+        profile = self.trained_schema.profile[profile_idx]
         col_schema_info = profile.profiles['data_type_profile']._profiles["int"]
         self.assertEqual(2999, profile.sample_size)
         self.assertEqual(col_schema_info.sample_size,
@@ -282,7 +286,8 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(197, profile.null_count)
 
     def test_correct_integer_column_detection_destport(self):
-        profile = self.trained_schema.profile_by_name("destport")
+        profile_idx = self.trained_schema._col_name_to_idx["destport"][0]
+        profile = self.trained_schema.profile[profile_idx]
         col_schema_info = profile.profiles['data_type_profile']._profiles["int"]
         self.assertEqual(2999, profile.sample_size)
         self.assertEqual(col_schema_info.sample_size,

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -720,6 +720,46 @@ class TestStructuredProfiler(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             unique_profile.update_profile(dupe_data)
 
+    def test_unique_col_permutation(self, *mocks):
+        data = pd.DataFrame([[1, 2, 3, 4],
+                             [5, 6, 7, 8]],
+                            columns=["a", "b", "c", "d"])
+        perm_data = pd.DataFrame([[4, 3, 2, 1],
+                                  [8, 7, 6, 5]],
+                                 columns=["d", "c", "b", "a"])
+
+        # Test via add
+        first_profiler = dp.StructuredProfiler(data)
+        perm_profiler = dp.StructuredProfiler(perm_data)
+        profiler = first_profiler + perm_profiler
+
+        for col_idx in range(len(profiler._profile)):
+            col_min = data.iloc[0, col_idx]
+            col_max = data.iloc[1, col_idx]
+            # Sum is doubled since it was updated with the same vals
+            col_sum = 2 * (col_min + col_max)
+            self.assertEqual(col_min, profiler._profile[col_idx].
+                             profile["statistics"]["min"])
+            self.assertEqual(col_max, profiler._profile[col_idx].
+                             profile["statistics"]["max"])
+            self.assertEqual(col_sum, profiler._profile[col_idx].
+                             profile["statistics"]["sum"])
+
+        # Test via update
+        profiler = dp.StructuredProfiler(data)
+        profiler.update_profile(perm_data)
+
+        for col_idx in range(len(profiler._profile)):
+            col_min = data.iloc[0, col_idx]
+            col_max = data.iloc[1, col_idx]
+            # Sum is doubled since it was updated with the same vals
+            col_sum = 2 * (col_min + col_max)
+            self.assertEqual(col_min, profiler._profile[col_idx].
+                             profile["statistics"]["min"])
+            self.assertEqual(col_max, profiler._profile[col_idx].
+                             profile["statistics"]["max"])
+            self.assertEqual(col_sum, profiler._profile[col_idx].
+                             profile["statistics"]["sum"])
 
 class TestStructuredColProfilerClass(unittest.TestCase):
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -380,10 +380,10 @@ class TestStructuredProfiler(unittest.TestCase):
         trained_schema = dp.StructuredProfiler(self.aws_dataset, samples_per_update=5)
         report = trained_schema.report()
         has_non_null_column = False
-        for key in report['data_stats']:
+        for i in range(len(report['data_stats'])):
             # only test non-null columns
-            if report['data_stats'][key]['data_type'] is not None:
-                self.assertIsNotNone(report['data_stats'][key]['data_label'])
+            if report['data_stats'][i]['data_type'] is not None:
+                self.assertIsNotNone(report['data_stats'][i]['data_label'])
                 has_non_null_column = True
         if not has_non_null_column:
             self.fail(
@@ -447,8 +447,8 @@ class TestStructuredProfiler(unittest.TestCase):
 
         def _clean_report(report):
             data_stats = report["data_stats"]
-            for key in data_stats:
-                stats = data_stats[key]["statistics"]
+            for i in range(len(data_stats)):
+                stats = data_stats[i]["statistics"]
                 if "histogram" in stats:
                     if "bin_counts" in stats["histogram"]:
                         stats["histogram"]["bin_counts"] = \
@@ -491,14 +491,14 @@ class TestStructuredProfiler(unittest.TestCase):
             # Check that reports are equivalent
             save_report = _clean_report(save_profile.report())
             load_report = _clean_report(load_profile.report())
-            self.assertDictEqual(save_report, load_report)
+            self.assertEqual(save_report, load_report)
 
     def test_save_and_load_no_labeler(self):
 
         def _clean_report(report):
             data_stats = report["data_stats"]
-            for key in data_stats:
-                stats = data_stats[key]["statistics"]
+            for i in range(len(data_stats)):
+                stats = data_stats[i]["statistics"]
                 if "histogram" in stats:
                     if "bin_counts" in stats["histogram"]:
                         stats["histogram"]["bin_counts"] = \
@@ -529,7 +529,7 @@ class TestStructuredProfiler(unittest.TestCase):
         # Check that reports are equivalent
         save_report = _clean_report(save_profile.report())
         load_report = _clean_report(load_profile.report())
-        self.assertDictEqual(save_report, load_report)
+        self.assertEqual(save_report, load_report)
 
         # validate both are still usable after
         save_profile.update_profile(pd.DataFrame(['test', 'test2']))
@@ -1677,8 +1677,8 @@ class TestProfilerFactoryClass(unittest.TestCase):
 
         def _clean_report(report):
             data_stats = report["data_stats"]
-            for key in data_stats:
-                stats = data_stats[key]["statistics"]
+            for i in range(len(data_stats)):
+                stats = data_stats[i]["statistics"]
                 if "histogram" in stats:
                     if "bin_counts" in stats["histogram"]:
                         stats["histogram"]["bin_counts"] = \
@@ -1721,7 +1721,7 @@ class TestProfilerFactoryClass(unittest.TestCase):
             # Check that reports are equivalent
             save_report = _clean_report(save_profile.report())
             load_report = _clean_report(load_profile.report())
-            self.assertDictEqual(save_report, load_report)
+            self.assertEqual(save_report, load_report)
 
             # validate both are still usable after
             save_profile.update_profile(data.data.iloc[:2])

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -312,16 +312,16 @@ class TestStructuredProfiler(unittest.TestCase):
             report_options={"num_quantile_groups": None})
         report = self.trained_schema.report()
         self.assertEqual(report_none, report)
-        for key, val in report["data_stats"].items():
-            if key == "int_col":
-                report_quantiles = val["statistics"]["quantiles"]
+        for col in report["data_stats"]:
+            if col["column_name"] == "int_col":
+                report_quantiles = col["statistics"]["quantiles"]
                 break
         self.assertEqual(len(report_quantiles), 3)
         report2 = self.trained_schema.report(
             report_options={"num_quantile_groups": 1000})
-        for key, val in report2["data_stats"].items():
-            if key == "int_col":
-                report2_1000_quant = val["statistics"]["quantiles"]
+        for col in report2["data_stats"]:
+            if col["column_name"] == "int_col":
+                report2_1000_quant = col["statistics"]["quantiles"]
                 break
         self.assertEqual(len(report2_1000_quant), 999)
         self.assertEqual(report_quantiles, {

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -152,8 +152,7 @@ class TestStructuredProfiler(unittest.TestCase):
         profile2._profile.pop(0)
         profile2._col_name_to_idx.pop(0)
         with self.assertRaisesRegex(ValueError,
-                                    "Attempted to merge profiles with "
-                                    "different numbers of columns"):
+                                    "Cannot merge empty profiles."):
             profile1 + profile2
 
         # test mismatched profiles due to options

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -730,8 +730,8 @@ class TestStructuredProfiler(unittest.TestCase):
 
         msg = "Columns do not match, cannot update or merge profiles."
         with self.assertRaisesRegex(ValueError, msg):
-            dp.StructuredProfiler._get_and_validate_schema_mapping(unique_schema_1,
-                                                                   unique_schema_3)
+            dp.StructuredProfiler._get_and_validate_schema_mapping(
+                unique_schema_1,unique_schema_3)
 
         expected_schema = {0: 0, 1: 1, 2: 2}
         actual_schema = dp.StructuredProfiler.\
@@ -752,21 +752,21 @@ class TestStructuredProfiler(unittest.TestCase):
         msg = ("Different number of columns detected for "
                "'a', cannot update or merge profiles.")
         with self.assertRaisesRegex(ValueError, msg):
-            dp.StructuredProfiler._get_and_validate_schema_mapping(dupe_schema_1,
-                                                                   dupe_schema_3)
+            dp.StructuredProfiler._get_and_validate_schema_mapping(
+                dupe_schema_1, dupe_schema_3)
 
         msg = ("Different column indices under "
                "duplicate name 'b', cannot update "
                "or merge unless schema is identical.")
         with self.assertRaisesRegex(ValueError, msg):
-            dp.StructuredProfiler._get_and_validate_schema_mapping(dupe_schema_1,
-                                                                   dupe_schema_2)
+            dp.StructuredProfiler._get_and_validate_schema_mapping(
+                dupe_schema_1, dupe_schema_2)
 
         # In strict case, column number must match
         msg = "Attempted to merge profiles with different numbers of columns"
         with self.assertRaisesRegex(ValueError, msg):
             dp.StructuredProfiler._get_and_validate_schema_mapping(
-                dupe_schema_1, four_col_schema, True)
+                dupe_schema_1, four_col_schema)
 
         expected_schema = {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5}
         actual_schema = dp.StructuredProfiler.\

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -730,17 +730,17 @@ class TestStructuredProfiler(unittest.TestCase):
 
         msg = "Columns do not match, cannot update or merge profiles."
         with self.assertRaisesRegex(ValueError, msg):
-            dp.StructuredProfiler._get_and_validate_schema(unique_schema_1,
-                                                           unique_schema_3)
+            dp.StructuredProfiler._get_and_validate_schema_mapping(unique_schema_1,
+                                                                   unique_schema_3)
 
         expected_schema = {0: 0, 1: 1, 2: 2}
         actual_schema = dp.StructuredProfiler.\
-            _get_and_validate_schema(unique_schema_1, {})
+            _get_and_validate_schema_mapping(unique_schema_1, {})
         self.assertDictEqual(actual_schema, expected_schema)
 
         expected_schema = {0: 2, 1: 0, 2: 1}
         actual_schema = dp.StructuredProfiler.\
-            _get_and_validate_schema(unique_schema_1, unique_schema_2)
+            _get_and_validate_schema_mapping(unique_schema_1, unique_schema_2)
         self.assertDictEqual(actual_schema, expected_schema)
 
         dupe_schema_1 = {"a": [0], "b": [1, 2], "c": [3, 4, 5]}
@@ -750,19 +750,19 @@ class TestStructuredProfiler(unittest.TestCase):
         msg = ("Different number of columns detected for "
                "'a', cannot update or merge profiles.")
         with self.assertRaisesRegex(ValueError, msg):
-            dp.StructuredProfiler._get_and_validate_schema(dupe_schema_1,
-                                                           dupe_schema_3)
+            dp.StructuredProfiler._get_and_validate_schema_mapping(dupe_schema_1,
+                                                                   dupe_schema_3)
 
         msg = ("Different column indices under "
                "duplicate name 'b', cannot update "
                "or merge unless schema is identical.")
         with self.assertRaisesRegex(ValueError, msg):
-            dp.StructuredProfiler._get_and_validate_schema(dupe_schema_1,
-                                                           dupe_schema_2)
+            dp.StructuredProfiler._get_and_validate_schema_mapping(dupe_schema_1,
+                                                                   dupe_schema_2)
 
         expected_schema = {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5}
         actual_schema = dp.StructuredProfiler.\
-            _get_and_validate_schema(dupe_schema_1, dupe_schema_1)
+            _get_and_validate_schema_mapping(dupe_schema_1, dupe_schema_1)
         self.assertDictEqual(actual_schema, expected_schema)
 
 class TestStructuredColProfilerClass(unittest.TestCase):

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -711,6 +711,12 @@ class TestStructuredProfiler(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             dupe_profile.update_profile(unique_data)
 
+        perm_data = pd.DataFrame([[1, 2, 3, 4, 5, 6],
+                                  [10, 20, 30, 40, 50, 60]],
+                                 columns=["a", "a", "b", "b", "c", "d"])
+        with self.assertRaisesRegex(ValueError, msg):
+            dupe_profile.update_profile(perm_data)
+
         msg = ("Attempted to update data with duplicate "
                "column names that weren't present before "
                "update. Schema must be identical when "

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1445,14 +1445,16 @@ class TestStructuredProfilerNullValues(unittest.TestCase):
         profile = dp.StructuredProfiler(data, options=profiler_options)
 
         report = profile.report(report_options={"output_format":"pretty"})
+        count_idx = report["global_stats"]["profile_schema"]["COUNT"][0]
+        numbers_idx = report["global_stats"]["profile_schema"][" NUMBERS"][0]
         
         self.assertEqual(
-            report['data_stats']['COUNT']['statistics']['null_types_index'],
+            report['data_stats'][count_idx]['statistics']['null_types_index'],
             {'': '[2, 3, 4, 5, 7, 8]'}
         )
         
         self.assertEqual(
-            report['data_stats'][' NUMBERS']['statistics']['null_types_index'],
+            report['data_stats'][numbers_idx]['statistics']['null_types_index'],
             {'': '[5, 6, 8]', ' ': '[2, 4]'}
         )
        

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -761,6 +761,48 @@ class TestStructuredProfiler(unittest.TestCase):
             self.assertEqual(col_sum, profiler._profile[col_idx].
                              profile["statistics"]["sum"])
 
+    def test_get_and_validate_schema_mapping(self):
+        unique_schema_1 = {"a": [0], "b": [1], "c": [2]}
+        unique_schema_2 = {"a": [2], "b": [0], "c": [1]}
+        unique_schema_3 = {"a": [0], "b": [1], "d": [2]}
+
+        msg = "Columns do not match, cannot update or merge profiles."
+        with self.assertRaisesRegex(ValueError, msg):
+            dp.StructuredProfiler._get_and_validate_schema(unique_schema_1,
+                                                           unique_schema_3)
+
+        expected_schema = {0: 0, 1: 1, 2: 2}
+        actual_schema = dp.StructuredProfiler.\
+            _get_and_validate_schema(unique_schema_1, {})
+        self.assertDictEqual(actual_schema, expected_schema)
+
+        expected_schema = {0: 2, 1: 0, 2: 1}
+        actual_schema = dp.StructuredProfiler.\
+            _get_and_validate_schema(unique_schema_1, unique_schema_2)
+        self.assertDictEqual(actual_schema, expected_schema)
+
+        dupe_schema_1 = {"a": [0], "b": [1, 2], "c": [3, 4, 5]}
+        dupe_schema_2 = {"a": [0], "b": [1, 3], "c": [2, 4, 5]}
+        dupe_schema_3 = {"a": [0, 1], "b": [2, 3, 4], "c": [5]}
+
+        msg = ("Different number of columns detected for "
+               "'a', cannot update or merge profiles.")
+        with self.assertRaisesRegex(ValueError, msg):
+            dp.StructuredProfiler._get_and_validate_schema(dupe_schema_1,
+                                                           dupe_schema_3)
+
+        msg = ("Different column indices under "
+               "duplicate name 'b', cannot update "
+               "or merge unless schema is identical.")
+        with self.assertRaisesRegex(ValueError, msg):
+            dp.StructuredProfiler._get_and_validate_schema(dupe_schema_1,
+                                                           dupe_schema_2)
+
+        expected_schema = {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5}
+        actual_schema = dp.StructuredProfiler.\
+            _get_and_validate_schema(dupe_schema_1, dupe_schema_1)
+        self.assertDictEqual(actual_schema, expected_schema)
+
 class TestStructuredColProfilerClass(unittest.TestCase):
 
     def setUp(self):

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -493,7 +493,7 @@ class TestStructuredProfiler(unittest.TestCase):
             # Check that reports are equivalent
             save_report = _clean_report(save_profile.report())
             load_report = _clean_report(load_profile.report())
-            self.assertEqual(save_report, load_report)
+            self.assertDictEqual(save_report, load_report)
 
     def test_save_and_load_no_labeler(self):
 
@@ -531,7 +531,7 @@ class TestStructuredProfiler(unittest.TestCase):
         # Check that reports are equivalent
         save_report = _clean_report(save_profile.report())
         load_report = _clean_report(load_profile.report())
-        self.assertEqual(save_report, load_report)
+        self.assertDictEqual(save_report, load_report)
 
         # validate both are still usable after
         save_profile.update_profile(pd.DataFrame(['test', 'test2']))
@@ -1725,7 +1725,7 @@ class TestProfilerFactoryClass(unittest.TestCase):
             # Check that reports are equivalent
             save_report = _clean_report(save_profile.report())
             load_report = _clean_report(load_profile.report())
-            self.assertEqual(save_report, load_report)
+            self.assertDictEqual(save_report, load_report)
 
             # validate both are still usable after
             save_profile.update_profile(data.data.iloc[:2])

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -152,7 +152,8 @@ class TestStructuredProfiler(unittest.TestCase):
         profile2._profile.pop(0)
         profile2._col_name_to_idx.pop(0)
         with self.assertRaisesRegex(ValueError,
-                                    'Profiles do not have the same schema.'):
+                                    'Cannot merge profiles due to schema '
+                                    'mismatch'):
             profile1 + profile2
 
         # test mismatched profiles due to options

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1564,17 +1564,19 @@ class TestStructuredProfilerNullValues(unittest.TestCase):
         profiler_options.set({'data_labeler.is_enabled': False})
         trained_schema = dp.StructuredProfiler(test_dataset, len(test_dataset),
                                                options=profiler_options)
+        ts_profile = trained_schema.profile
+        ts_mapping = trained_schema._col_name_to_idx
 
         self.assertCountEqual(['', 'nan', 'None', 'null'],
-                         trained_schema.profile[trained_schema._col_name_to_idx['1'][0]].null_types)
-        self.assertEqual(5, trained_schema.profile[trained_schema._col_name_to_idx['1'][0]].null_count)
+                              ts_profile[ts_mapping['1'][0]].null_types)
+        self.assertEqual(5, ts_profile[ts_mapping['1'][0]].null_count)
         self.assertEqual({'': {4}, 'nan': {0}, 'None': {2, 3}, 'null': {1}},
-                         trained_schema.profile[trained_schema._col_name_to_idx['1'][0]].null_types_index)
+                         ts_profile[ts_mapping['1'][0]].null_types_index)
         self.assertCountEqual(['', 'nan', 'None', 'null'],
-                         trained_schema.profile[trained_schema._col_name_to_idx[1][0]].null_types)
-        self.assertEqual(5, trained_schema.profile[trained_schema._col_name_to_idx[1][0]].null_count)
+                              ts_profile[ts_mapping[1][0]].null_types)
+        self.assertEqual(5, ts_profile[ts_mapping[1][0]].null_count)
         self.assertEqual({'': {4}, 'nan': {0}, 'None': {1, 3}, 'null': {2}},
-                         trained_schema.profile[trained_schema._col_name_to_idx[1][0]].null_types_index)
+                         ts_profile[ts_mapping[1][0]].null_types_index)
 
     def test_correct_null_row_counts(self):
         file_path = os.path.join(test_root_path, 'data', 'csv/empty_rows.txt')

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -152,8 +152,7 @@ class TestStructuredProfiler(unittest.TestCase):
         profile2._profile.pop(0)
         profile2._col_name_to_idx.pop(0)
         with self.assertRaisesRegex(ValueError,
-                                    'Cannot merge profiles due to schema '
-                                    'mismatch'):
+                                    "Cannot merge empty profiles."):
             profile1 + profile2
 
         # test mismatched profiles due to options

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -604,8 +604,8 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertDictEqual(save_report, load_report)
 
         # validate both are still usable after
-        save_profile.update_profile(pd.DataFrame(['test', 'test2']))
-        load_profile.update_profile(pd.DataFrame(['test', 'test2']))
+        save_profile.update_profile(pd.DataFrame({"a": [4, 5]}))
+        load_profile.update_profile(pd.DataFrame({"a": [4, 5]}))
 
     @mock.patch('dataprofiler.profilers.profile_builder.'
                 'ColumnPrimitiveTypeProfileCompiler')
@@ -706,8 +706,8 @@ class TestStructuredProfiler(unittest.TestCase):
         dupe_profile = dp.StructuredProfiler(dupe_data)
         unique_profile = dp.StructuredProfiler(unique_data)
 
-        msg = ("Schema of data with duplicate column names not respected when "
-               "updating profile.")
+        msg = ("Schema of data given to StructuredProfiler.update does not "
+               "match schema calculated at initialization.")
         with self.assertRaisesRegex(ValueError, msg):
             dupe_profile.update_profile(unique_data)
 
@@ -717,10 +717,6 @@ class TestStructuredProfiler(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             dupe_profile.update_profile(perm_data)
 
-        msg = ("Attempted to update data with duplicate "
-               "column names that weren't present before "
-               "update. Schema must be identical when "
-               "profiling data with duplicate column names.")
         with self.assertRaisesRegex(ValueError, msg):
             unique_profile.update_profile(dupe_data)
 
@@ -1611,7 +1607,7 @@ class TestStructuredProfilerNullValues(unittest.TestCase):
         data = dp.Data(filename_null_in_file)
         profile = dp.StructuredProfiler(data, options=profiler_options)
 
-        report = profile.report(report_options={"output_format":"pretty"})
+        report = profile.report(report_options={"output_format": "pretty"})
         count_idx = report["global_stats"]["profile_schema"]["COUNT"][0]
         numbers_idx = report["global_stats"]["profile_schema"][" NUMBERS"][0]
         

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -561,6 +561,11 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(1, profiler.row_is_null_count)
         self.assertEqual(2, profiler.total_samples)
 
+    def test_duplicate_columns(self):
+        data = pd.DataFrame([[1, 2, 3, 4, 5, 6],
+                             [10, 20, 30, 40, 50, 60]],
+                            columns=["a", "b", "a", "b", "c", "d"])
+        profiler = dp.StructuredProfiler(data)
 
 class TestStructuredColProfilerClass(unittest.TestCase):
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -298,14 +298,16 @@ class TestStructuredProfiler(unittest.TestCase):
             [
                 "samples_used", "column_count", "row_count", 
                 "row_has_null_ratio", 'row_is_null_ratio',
-                "unique_row_ratio", "duplicate_row_count", "file_type", "encoding"
+                "unique_row_ratio", "duplicate_row_count", "file_type",
+                "encoding", "profile_schema"
             ]
         )
         flat_report = self.trained_schema.report(report_options={"output_format":"flat"})
         self.assertEqual(test_utils.get_depth(flat_report), 1)
         with mock.patch('dataprofiler.profilers.helpers.report_helpers._prepare_report') as pr_mock:
             self.trained_schema.report(report_options={"output_format":'pretty'})
-            self.assertEqual(pr_mock.call_count, 2)
+            # Once for global_stats, once for each of 16 columns
+            self.assertEqual(pr_mock.call_count, 17)
 
     def test_report_quantiles(self):
         report_none = self.trained_schema.report(

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -152,7 +152,8 @@ class TestStructuredProfiler(unittest.TestCase):
         profile2._profile.pop(0)
         profile2._col_name_to_idx.pop(0)
         with self.assertRaisesRegex(ValueError,
-                                    "Cannot merge empty profiles."):
+                                    "Attempted to merge profiles with "
+                                    "different numbers of columns"):
             profile1 + profile2
 
         # test mismatched profiles due to options
@@ -746,6 +747,8 @@ class TestStructuredProfiler(unittest.TestCase):
         dupe_schema_2 = {"a": [0], "b": [1, 3], "c": [2, 4, 5]}
         dupe_schema_3 = {"a": [0, 1], "b": [2, 3, 4], "c": [5]}
 
+        four_col_schema = {"a": [0], "b": [1, 2], "c": [3, 4, 5], "d": [6]}
+
         msg = ("Different number of columns detected for "
                "'a', cannot update or merge profiles.")
         with self.assertRaisesRegex(ValueError, msg):
@@ -758,6 +761,12 @@ class TestStructuredProfiler(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             dp.StructuredProfiler._get_and_validate_schema_mapping(dupe_schema_1,
                                                                    dupe_schema_2)
+
+        # In strict case, column number must match
+        msg = "Attempted to merge profiles with different numbers of columns"
+        with self.assertRaisesRegex(ValueError, msg):
+            dp.StructuredProfiler._get_and_validate_schema_mapping(
+                dupe_schema_1, four_col_schema, True)
 
         expected_schema = {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5}
         actual_schema = dp.StructuredProfiler.\


### PR DESCRIPTION
Refactor summary:
- `StructuredProfiler._profile` is now a list of column profilers instead of a dictionary of {`col_name` -> `col_profiler`}
- Added `StructuredProfiler._col_name_to_idx` that maps {`col_name` -> [`id1`, `id2`, `id3`, ...]} where `id1`, `id2`, `id3` correspond to the indices in `_profile` that correspond to columns in `data` that have name `col_name`
- StructuredProfiler report's "data_stats" field is now a list instead of a dictionary, and the `_col_name_to_idx` mapping is stored in "global_stats" for use with report. As far as readability is concerned, this doesn't affect much, since the column name is a field in each of the individual column profiles, so that information is not lost, only one layer deeper in report now.
- Added helper function `_profile_idx_to_data` to go from `_profile` index to column in data it corresponds to
- Added helper function `profile_by_name` that is the traditional dictionary structure of the past, but this reconciles duplicate columns by just returning the first one that appears in profile. This should only be used if there are definitely no duplicate column names (used throughout tests)
- Updated tests to type check with `_profile` being a list instead of a dictionary

PENDING TASKS: Update documentation

WILL PROBABLY BREAK UP INTO SEVERAL PRS ON A SEPARATE BRANCH
DO NOT REVIEW THIS ONE