### PR TITLE
Add warnings for insufficient match count and invalid data for skew/kurt calculations

### DIFF
--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -413,6 +413,9 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         :rtype: NaN if sample size is too small, float otherwise
         """
         if np.isnan(biased_skewness) or match_count < 3:
+            warnings.warn("Insufficient match count to correct bias in skewness. Bias correction"
+                          "can be manually disabled by setting bias_correction.is_enabled to"
+                          "False in ProfilerOptions.", RuntimeWarning)
             return np.nan
 
         skewness = np.sqrt(match_count * (match_count - 1)) \
@@ -485,6 +488,9 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         :rtype: NaN if sample size is too small, float otherwise
         """
         if np.isnan(biased_kurtosis) or match_count < 4:
+            warnings.warn("Insufficient match count to correct bias in kurtosis. Bias correction"
+                          "can be manually disabled by setting bias_correction.is_enabled to"
+                          "False in ProfilerOptions.", RuntimeWarning)
             return np.nan
 
         kurtosis = (match_count - 1) / ((match_count - 2) *

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -958,6 +958,12 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         :type subset_properties: dict
         :return None
         """
+        # If skewness is still NaN but has a valid match count, this
+        # must mean that there were previous invalid values in
+        # the dataset.
+        if np.isnan(self._biased_skewness) and self.match_count > 0:
+            return
+
         batch_biased_skewness = utils.biased_skew(df_series)
         subset_properties["biased_skewness"] = batch_biased_skewness
         batch_count = subset_properties["match_count"]
@@ -987,6 +993,11 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         :type subset_properties: dict
         :return None
         """
+        # If kurtosis is still NaN but has a valid match count, this
+        # must mean that there were previous invalid values in
+        # the dataset.
+        if np.isnan(self._biased_kurtosis) and self.match_count > 0:
+            return
         batch_biased_kurtosis = utils.biased_kurt(df_series)
         subset_properties["biased_kurtosis"] = batch_biased_kurtosis
         batch_count = subset_properties["match_count"]

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -333,10 +333,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
             return biased_variance2
         elif match_count2 < 1:
             return biased_variance1
-        if np.isnan(biased_variance1):
-            biased_variance1 = 0
-        if np.isnan(biased_variance2):
-            biased_variance2 = 0
+        elif np.isnan(biased_variance1) or np.isnan(biased_variance2):
+            return np.nan
 
         curr_count = match_count1
         delta = mean2 - mean1
@@ -376,10 +374,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
             return biased_skewness2
         elif match_count2 < 1:
             return biased_skewness1
-        if np.isnan(biased_skewness1):
-            biased_skewness1 = 0
-        if np.isnan(biased_skewness2):
-            biased_skewness2 = 0
+        elif np.isnan(biased_skewness1) or np.isnan(biased_skewness2):
+            return np.nan
 
         delta = mean2 - mean1
         N = match_count1 + match_count2
@@ -446,10 +442,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
             return biased_kurtosis2
         elif match_count2 < 1:
             return biased_kurtosis1
-        if np.isnan(biased_kurtosis1):
-            biased_kurtosis1 = 0
-        if np.isnan(biased_kurtosis2):
-            biased_kurtosis1 = 0
+        elif np.isnan(biased_kurtosis1) or np.isnan(biased_kurtosis2):
+            return np.nan
 
         delta = mean2 - mean1
         N = match_count1 + match_count2

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -329,14 +329,14 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         :return: combined variance
         :rtype: float
         """
-        if np.isnan(biased_variance1):
-            biased_variance1 = 0
-        if np.isnan(biased_variance2):
-            biased_variance2 = 0
         if match_count1 < 1:
             return biased_variance2
         elif match_count2 < 1:
             return biased_variance1
+        if np.isnan(biased_variance1):
+            biased_variance1 = 0
+        if np.isnan(biased_variance2):
+            biased_variance2 = 0
 
         curr_count = match_count1
         delta = mean2 - mean1
@@ -372,14 +372,14 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         :return: combined skewness
         :rtype: float
         """
-        if np.isnan(biased_skewness1):
-            biased_skewness1 = 0
-        if np.isnan(biased_skewness2):
-            biased_skewness2 = 0
         if match_count1 < 1:
             return biased_skewness2
         elif match_count2 < 1:
             return biased_skewness1
+        if np.isnan(biased_skewness1):
+            biased_skewness1 = 0
+        if np.isnan(biased_skewness2):
+            biased_skewness2 = 0
 
         delta = mean2 - mean1
         N = match_count1 + match_count2
@@ -439,14 +439,14 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         :return: combined skewness
         :rtype: float
         """
-        if np.isnan(biased_kurtosis1):
-            biased_kurtosis1 = 0
-        if np.isnan(biased_kurtosis2):
-            biased_kurtosis1 = 0
         if match_count1 < 1:
             return biased_kurtosis2
         elif match_count2 < 1:
             return biased_kurtosis1
+        if np.isnan(biased_kurtosis1):
+            biased_kurtosis1 = 0
+        if np.isnan(biased_kurtosis2):
+            biased_kurtosis1 = 0
 
         delta = mean2 - mean1
         N = match_count1 + match_count2

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -296,8 +296,6 @@ def biased_skew(df_series):
 
     mean = sum(df_series) / n
     if np.isinf(mean) or np.isnan(mean):
-        warnings.warn("Invalid values found in data. Future values of skew "
-                      "will not be computed.", RuntimeWarning)
         return np.nan
 
     diffs = df_series - mean
@@ -333,8 +331,6 @@ def biased_kurt(df_series):
 
     mean = sum(df_series) / n
     if np.isinf(mean) or np.isnan(mean):
-        warnings.warn("Invalid values found in data. Future values of kurtosis"
-                      " will not be computed.", RuntimeWarning)
         return np.nan
 
     diffs = df_series - mean

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -295,6 +295,11 @@ def biased_skew(df_series):
         return np.nan
 
     mean = sum(df_series) / n
+    if np.isinf(mean) or np.isnan(mean):
+        warnings.warn("Invalid values found in data. Future values of skew "
+                      "will not be computed.", RuntimeWarning)
+        return np.nan
+
     diffs = df_series - mean
     squared_diffs = diffs ** 2
     cubed_diffs = squared_diffs * diffs
@@ -327,6 +332,11 @@ def biased_kurt(df_series):
         return np.nan
 
     mean = sum(df_series) / n
+    if np.isinf(mean) or np.isnan(mean):
+        warnings.warn("Invalid values found in data. Future values of kurtosis"
+                      " will not be computed.", RuntimeWarning)
+        return np.nan
+
     diffs = df_series - mean
     squared_diffs = diffs ** 2
     fourth_diffs = squared_diffs * squared_diffs

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 import pandas as pd
 import numpy as np
+import warnings
 
 from dataprofiler.profilers import IntColumn
 from dataprofiler.profilers.profiler_options import IntOptions
@@ -788,3 +789,39 @@ class TestIntColumn(unittest.TestCase):
         profile_2.update(data_2)
 
         profile_1 + profile_2
+
+    def test_insufficient_count_skew_kurt(self):
+        data = pd.Series(['1'])
+        profiler = IntColumn(data.name)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            profiler.update(data)
+            skew = profiler.skewness
+            kurt = profiler.kurtosis
+            # Verify values are NaN
+            self.assertTrue(np.isnan(skew))
+            self.assertTrue(np.isnan(kurt))
+            # Verify warning was raised properly
+            self.assertEqual(2, len(w))
+            for i in range(0, len(w)):
+                self.assertEqual(w[i].category, RuntimeWarning)
+                self.assertTrue("Insufficient match count to correct bias in" \
+                                in str(w[i].message))
+
+        # Update the data so that the match count is good
+        data2 = pd.Series(['-2', '-1', '1', '2'])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            profiler.update(data2)
+            skew = profiler.skewness
+            kurt = profiler.kurtosis
+            # Verify values are no longer NaN
+            self.assertFalse(np.isnan(skew))
+            self.assertFalse(np.isnan(kurt))
+            # Verify warning-related things. In this case, we check
+            # to make sure NO warnings were thrown since we have
+            # a sufficient match count.
+            self.assertEqual(0, len(w))

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -790,7 +790,7 @@ class TestIntColumn(unittest.TestCase):
 
         profile_1 + profile_2
 
-    def test_insufficient_count_skew_kurt(self):
+    def test_insufficient_counts(self):
         data = pd.Series(['1'])
         profiler = IntColumn(data.name)
 
@@ -798,13 +798,15 @@ class TestIntColumn(unittest.TestCase):
             warnings.simplefilter("always")
 
             profiler.update(data)
+            var = profiler.variance
             skew = profiler.skewness
             kurt = profiler.kurtosis
             # Verify values are NaN
+            self.assertTrue(np.isnan(var))
             self.assertTrue(np.isnan(skew))
             self.assertTrue(np.isnan(kurt))
             # Verify warning was raised properly
-            self.assertEqual(2, len(w))
+            self.assertEqual(3, len(w))
             for i in range(0, len(w)):
                 self.assertEqual(w[i].category, RuntimeWarning)
                 self.assertTrue("Insufficient match count to correct bias in" \
@@ -816,9 +818,11 @@ class TestIntColumn(unittest.TestCase):
             warnings.simplefilter("always")
 
             profiler.update(data2)
+            var = profiler.variance
             skew = profiler.skewness
             kurt = profiler.kurtosis
             # Verify values are no longer NaN
+            self.assertFalse(np.isnan(var))
             self.assertFalse(np.isnan(skew))
             self.assertFalse(np.isnan(kurt))
             # Verify warning-related things. In this case, we check


### PR DESCRIPTION
There are a couple of cases where the skewness and kurtosis values cannot be computed. Warnings are added for when skewness/kurtosis cannot be corrected for bias despite it being enabled in options. Furthermore, when invalid data is detected (e.g. infinite values), warnings are raised and any future updates of skewness/kurtosis are no longer computed.