### PR TITLE
Hotfix: remove unused import causing profiler error

### DIFF
--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -14,7 +14,6 @@ import warnings
 import sys
 
 import numpy as np
-import scipy.stats
 
 from . import utils
 from . import histogram_utils

--- a/dataprofiler/version.py
+++ b/dataprofiler/version.py
@@ -4,7 +4,7 @@ File containers the version number for the package
 
 MAJOR               = 0
 MINOR               = 5
-MICRO               = 2
+MICRO               = 3
 
 VERSION             = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Fixes import error for scipy which was moved to ML imports in previous PR.

The scipy portion was removed from the stats, but the import did not get removed.

Reference: https://github.com/capitalone/DataProfiler/issues/289
