### PR TITLE
StructuredProfiler _profile dict -> list refactor (part 1/3)

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1258,19 +1258,20 @@ class StructuredProfiler(BaseProfiler):
         :rtype: Dict[int, int]
         """
 
-        len_schema_1 = len(schema1)
-        len_schema_2 = len(schema2)
+        len_schema1 = len(schema1)
+        len_schema2 = len(schema2)
 
-        if strict and len_schema_1 != len_schema_2:
+        # If both non-empty, must be same length
+        if 0 < len_schema1 != len_schema2 > 0:
             raise ValueError("Attempted to merge profiles with different "
                              "numbers of columns")
 
         # In the case of __add__ with one of the schemas not initialized
-        if strict and (len_schema_1 == 0 or len_schema_2 == 0):
+        if strict and (len_schema1 == 0 or len_schema2 == 0):
             raise ValueError("Cannot merge empty profiles.")
 
         # In the case of _update_from_chunk with uninitialized schema
-        if not strict and len_schema_2 == 0:
+        if not strict and len_schema2 == 0:
             return {col_ind: col_ind for col_ind_list in schema1.values()
                     for col_ind in col_ind_list}
 

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1274,14 +1274,11 @@ class StructuredProfiler(BaseProfiler):
         :rtype: Dict[int, int]
         """
 
-        one_schema_empty = (len(schema1) == 0 and len(schema2) > 0) \
-                           or (len(schema1) > 0 and len(schema2) == 0)
-        # In the case of __add__ with one of the schemas not initialized
-        if strict and one_schema_empty:
-            raise ValueError("Cannot merge profiles due to schema mismatch")
+        if strict and (len(schema1) == 0 or len(schema2) == 0):
+            raise ValueError("Cannot merge empty profiles.")
 
         # In the case of _update_from_chunk with uninitialized schema
-        if len(schema2) == 0:
+        if not strict and len(schema2) == 0:
             return {col_ind: col_ind for col_ind_list in schema1.values()
                     for col_ind in col_ind_list}
 

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1240,13 +1240,6 @@ class StructuredProfiler(BaseProfiler):
         """
         return min([col._last_batch_size for col in self._profile], default=0)
 
-    @property
-    def is_initialized(self):
-        """
-        Determines if profiler has been initialized with data
-        """
-        return self.total_samples > 0
-
     @staticmethod
     def _get_and_validate_schema_mapping(schema1, schema2, strict=False):
         """
@@ -1438,8 +1431,6 @@ class StructuredProfiler(BaseProfiler):
         elif isinstance(data, list):
             data = pd.DataFrame(data)
 
-        initialized = self.is_initialized
-
         # Calculate schema of incoming data
         mapping_given = defaultdict(list)
         for col_idx in range(len(data.columns)):
@@ -1479,7 +1470,7 @@ class StructuredProfiler(BaseProfiler):
         # Create StructuredColProfilers upon initialization
         # Record correlation between columns in data and index in _profile
         new_cols = False
-        if not initialized:
+        if len(self._profile) == 0:
             for col_idx in range(data.shape[1]):
                 col_name = data.columns[col_idx]
                 # Pandas cols are int by default, but need to fuzzy match strs

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1162,7 +1162,6 @@ class StructuredProfiler(BaseProfiler):
         self.hashed_row_dict = dict()
         self._profile = []
         self._col_name_to_idx = defaultdict(list)
-        self._duplicate_cols_present = False
 
         if data is not None:
             self.update_profile(data)
@@ -1608,12 +1607,6 @@ class StructuredProfiler(BaseProfiler):
 
         self._update_row_statistics(data, samples_for_row_stats)
 
-        # Update personal attributes about state of profile
-        if not initialized:
-            num_cols = [len(self._col_name_to_idx[col])
-                        for col in self._col_name_to_idx]
-            self._duplicate_cols_present = any(num > 1 for num in num_cols)
-
     def save(self, filepath=None):
         """
         Save profiler to disk
@@ -1635,7 +1628,6 @@ class StructuredProfiler(BaseProfiler):
                 "options": self.options,
                 "_profile": self.profile,
                 "_col_name_to_idx": self._col_name_to_idx,
-                "_duplicate_cols_present": self._duplicate_cols_present
                } 
 
         self._save_helper(filepath, data_dict)

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1187,7 +1187,7 @@ class StructuredProfiler(BaseProfiler):
     def __add__(self, other):
         """
         Merges two Structured profiles together overriding the `+` operator.
-        
+
         :param other: profile being added to this one.
         :type other: StructuredProfiler
         :return: merger of the two profiles
@@ -1273,6 +1273,7 @@ class StructuredProfiler(BaseProfiler):
         :return: a mapping of indices in schema1 to indices in schema2
         :rtype: Dict[int, int]
         """
+
         one_schema_empty = (len(schema1) == 0 and len(schema2) > 0) \
                            or (len(schema1) > 0 and len(schema2) == 0)
         # In the case of __add__ with one of the schemas not initialized

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1187,6 +1187,7 @@ class StructuredProfiler(BaseProfiler):
     def __add__(self, other):
         """
         Merges two Structured profiles together overriding the `+` operator.
+        
         :param other: profile being added to this one.
         :type other: StructuredProfiler
         :return: merger of the two profiles
@@ -1262,6 +1263,7 @@ class StructuredProfiler(BaseProfiler):
         mapping indices in schema1 to their corresponding indices in schema2.
         In __add__: want to map self _profile idx -> other _profile idx
         In _update_profile_from_chunk: want to map data idx -> _profile idx
+
         :param schema1: a column name to index mapping
         :type schema1: Dict[str, list[int]]
         :param schema2: a column name to index mapping

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1636,7 +1636,9 @@ class StructuredProfiler(BaseProfiler):
                 "_min_true_samples": self._min_true_samples,
                 "options": self.options,
                 "_profile": self.profile,
-                "_col_name_to_idx": self._col_name_to_idx
+                "_col_name_to_idx": self._col_name_to_idx,
+                "_initialized": self._initialized,
+                "_duplicate_cols_present": self._duplicate_cols_present
                } 
 
         self._save_helper(filepath, data_dict)

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1174,9 +1174,9 @@ class StructuredProfiler(BaseProfiler):
         """
 
         # Pass with strict = True to enforce both needing to be non-empty
-        self_to_other_idx = self._get_and_validate_schema(self._col_name_to_idx,
-                                                          other._col_name_to_idx,
-                                                          True)
+        self_to_other_idx = self._get_and_validate_schema_mapping(self._col_name_to_idx,
+                                                                  other._col_name_to_idx,
+                                                                  True)
         if not all([isinstance(other._profile[self_to_other_idx[idx]],
                                type(self._profile[idx]))
                     for idx in range(len(self._profile))]):  # options check
@@ -1203,8 +1203,8 @@ class StructuredProfiler(BaseProfiler):
         merged_profile.hashed_row_dict.update(self.hashed_row_dict)
         merged_profile.hashed_row_dict.update(other.hashed_row_dict)
 
-        self_to_other_idx = self._get_and_validate_schema(self._col_name_to_idx,
-                                                          other._col_name_to_idx)
+        self_to_other_idx = self._get_and_validate_schema_mapping(self._col_name_to_idx,
+                                                                  other._col_name_to_idx)
 
         # merge profiles
         for idx in range(len(self._profile)):
@@ -1257,7 +1257,7 @@ class StructuredProfiler(BaseProfiler):
                 return col_name
 
     @staticmethod
-    def _get_and_validate_schema(schema1, schema2, strict=False):
+    def _get_and_validate_schema_mapping(schema1, schema2, strict=False):
         """
         Validate compatibility between schema1 and schema2 and return a dict
         mapping indices in schema1 to their corresponding indices in schema2.
@@ -1462,8 +1462,8 @@ class StructuredProfiler(BaseProfiler):
             mapping_given[col].append(col_idx)
 
         # Validate schema compatibility and index mapping from data to _profile
-        col_idx_to_prof_idx = self._get_and_validate_schema(mapping_given,
-                                                            self._col_name_to_idx)
+        col_idx_to_prof_idx = self._get_and_validate_schema_mapping(mapping_given,
+                                                                    self._col_name_to_idx)
 
         try:
             from tqdm import tqdm

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1480,12 +1480,13 @@ class StructuredProfiler(BaseProfiler):
             # If duplicates present, schema enforced, so col_idx = prof_idx
             col_idx_to_prof_idx = {i: i for i in range(len(self._profile))}
             if not self._duplicate_cols_present:
+                # If columns unique, can allow permutation
                 for col_idx in range(data.shape[1]):
                     col_name = data.columns[col_idx]
                     if isinstance(col_name, str):
                         col_name = col_name.lower()
                     col_idx_to_prof_idx[col_idx] = \
-                    self._col_name_to_idx[col_name][0]
+                        self._col_name_to_idx[col_name][0]
 
         # Generate pool and estimate datasize
         pool = None

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1248,14 +1248,6 @@ class StructuredProfiler(BaseProfiler):
         """
         return self.total_samples > 0
 
-    def _get_col_name_from_idx(self, idx):
-        """
-        Determine which column name corresponds to a _profile index
-        """
-        for col_name in self._col_name_to_idx:
-            if idx in self._col_name_to_idx[col_name]:
-                return col_name
-
     @staticmethod
     def _get_and_validate_schema_mapping(schema1, schema2, strict=False):
         """

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1162,6 +1162,8 @@ class StructuredProfiler(BaseProfiler):
         self.hashed_row_dict = dict()
         self._profile = []
         self._col_name_to_idx = dict()
+        self._initialized = False
+        self._duplicate_cols_present = False
 
         if data is not None:
             self.update_profile(data)
@@ -1392,19 +1394,17 @@ class StructuredProfiler(BaseProfiler):
             data = pd.DataFrame(data)
 
         duplicate_cols_given = len(data.columns) != len(data.columns.unique())
-        num_cols = [len(idxs) for idxs in self._col_name_to_idx.values()]
-        duplicate_cols_present = any([num > 1 for num in num_cols])
-        initialized = len(self._profile) > 0
 
         # Error out if initialized with unique columns but given duplicates
-        if initialized and duplicate_cols_given and not duplicate_cols_present:
+        if self._initialized and duplicate_cols_given \
+                and not self._duplicate_cols_present:
             raise ValueError("Attempted to update data with duplicate "
                              "column names that weren't present before "
                              "update. Schema must be identical when "
                              "profiling data with duplicate column names.")
 
         # Error out if duplicate columns present and given schema doesn't match
-        if duplicate_cols_present:
+        if self._duplicate_cols_present:
             mapping_given = dict()
             for i in range(len(data.columns)):
                 col = data.columns[i]
@@ -1439,14 +1439,14 @@ class StructuredProfiler(BaseProfiler):
         # Create StructuredColProfilers (must be either first initialization
         # or unique column names)
         new_cols = False
-        if not duplicate_cols_present:
+        if not self._duplicate_cols_present:
             # Either initializing _profile for the first time or updating
             # _profile that doesn't contain duplicate column names
             for col in data.columns:
                 # If initializing for the first time, must fill mapping
                 # If initialized, with no duplicate columns, only add to mapping
                 # if not already there, since this means we are updating
-                if not initialized or col not in self._col_name_to_idx:
+                if not self._initialized or col not in self._col_name_to_idx:
                     # Append StructuredColProfiler to list of profiles
                     # and record index where it was appended to in list
                     self._col_name_to_idx.setdefault(col, []).append(
@@ -1610,6 +1610,11 @@ class StructuredProfiler(BaseProfiler):
             samples_for_row_stats = np.concatenate(sample_ids)
 
         self._update_row_statistics(data, samples_for_row_stats)
+
+        # Update personal attributes about state of profile
+        if not self._initialized:
+            self._duplicate_cols_present = duplicate_cols_given
+        self._initialized = True
 
     def save(self, filepath=None):
         """

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -71,8 +71,8 @@ class TestProfilerOptions(unittest.TestCase):
                      "bias_correction.is_enabled": False})
         profile = Profiler(self.data, options=options)
 
-        for column_name in profile.profile.keys():
-            profile_column = profile.profile[column_name].profile
+        for col_profiler in profile.profile:
+            profile_column = col_profiler.profile
             if profile_column["statistics"] \
                     and "histogram" in profile_column["statistics"].keys() \
                     and profile_column["statistics"]["histogram"]:
@@ -92,8 +92,8 @@ class TestProfilerOptions(unittest.TestCase):
                      "bias_correction.is_enabled": True})
         profile = Profiler(self.data, options=options)
 
-        for column_name in profile.profile.keys():
-            profile_column = profile.profile[column_name].profile
+        for col_profiler in profile.profile:
+            profile_column = col_profiler.profile
             if profile_column["statistics"] \
                     and "histogram" in profile_column["statistics"].keys() \
                     and profile_column["statistics"]["histogram"]:
@@ -113,8 +113,8 @@ class TestProfilerOptions(unittest.TestCase):
         options = ProfilerOptions()
         options.structured_options.data_labeler.enable = False
         profile = Profiler(self.data, options=options)
-        for column_name in profile.profile.keys():
-            profile_column = profile.profile[column_name].profile
+        for col_profiler in profile.profile:
+            profile_column = col_profiler.profile
             if profile_column["statistics"] \
                     and "data_label_probability" in \
                     profile_column["statistics"].keys():
@@ -131,8 +131,8 @@ class TestProfilerOptions(unittest.TestCase):
         options.structured_options.category.is_enabled = False
         options.structured_options.data_labeler.is_enabled = False
         profile = Profiler(self.data, options=options)
-        for column_name in profile.profile.keys():
-            profile_column = profile.profile[column_name].profile
+        for col_profiler in profile.profile:
+            profile_column = col_profiler.profile
             self.assertIsNone(profile_column["data_type"])
             self.assertTrue("data_label" not in profile_column.keys())
             self.assertIsNone(profile_column["categorical"])
@@ -189,8 +189,8 @@ class TestProfilerOptions(unittest.TestCase):
         profile = Profiler(self.data, options=options)
 
         # Assert that the stats are non-existent
-        for column_name in profile.profile.keys():
-            profile_column = profile.profile[column_name].profile
+        for col_profiler in profile.profile:
+            profile_column = col_profiler.profile
             if profile_column["statistics"] \
                     and "histogram" in profile_column["statistics"].keys() \
                     and profile_column["statistics"]["histogram"]:

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -644,6 +644,12 @@ class TestStructuredProfiler(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             dupe_profile.update_profile(unique_data)
 
+        perm_data = pd.DataFrame([[1, 2, 3, 4, 5, 6],
+                                  [10, 20, 30, 40, 50, 60]],
+                                 columns=["a", "a", "b", "b", "c", "d"])
+        with self.assertRaisesRegex(ValueError, msg):
+            dupe_profile.update_profile(perm_data)
+
         msg = ("Attempted to update data with duplicate "
                "column names that weren't present before "
                "update. Schema must be identical when "

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -663,8 +663,8 @@ class TestStructuredProfiler(unittest.TestCase):
 
         msg = "Columns do not match, cannot update or merge profiles."
         with self.assertRaisesRegex(ValueError, msg):
-            dp.StructuredProfiler._get_and_validate_schema_mapping(unique_schema_1,
-                                                                   unique_schema_3)
+            dp.StructuredProfiler._get_and_validate_schema_mapping(
+                unique_schema_1,unique_schema_3)
 
         expected_schema = {0: 0, 1: 1, 2: 2}
         actual_schema = dp.StructuredProfiler. \
@@ -685,21 +685,20 @@ class TestStructuredProfiler(unittest.TestCase):
         msg = ("Different number of columns detected for "
                "'a', cannot update or merge profiles.")
         with self.assertRaisesRegex(ValueError, msg):
-            dp.StructuredProfiler._get_and_validate_schema_mapping(dupe_schema_1,
-                                                                   dupe_schema_3)
+            dp.StructuredProfiler._get_and_validate_schema_mapping(
+                dupe_schema_1, dupe_schema_3)
 
         msg = ("Different column indices under "
                "duplicate name 'b', cannot update "
                "or merge unless schema is identical.")
         with self.assertRaisesRegex(ValueError, msg):
-            dp.StructuredProfiler._get_and_validate_schema_mapping(dupe_schema_1,
-                                                                   dupe_schema_2)
+            dp.StructuredProfiler._get_and_validate_schema_mapping(
+                dupe_schema_1, dupe_schema_2)
 
-        # In strict case, column number must match
         msg = "Attempted to merge profiles with different numbers of columns"
         with self.assertRaisesRegex(ValueError, msg):
             dp.StructuredProfiler._get_and_validate_schema_mapping(
-                dupe_schema_1, four_col_schema, True)
+                dupe_schema_1, four_col_schema)
 
         expected_schema = {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5}
         actual_schema = dp.StructuredProfiler. \

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -152,8 +152,7 @@ class TestStructuredProfiler(unittest.TestCase):
         profile2._profile.pop(0)
         profile2._col_name_to_idx.pop(0)
         with self.assertRaisesRegex(ValueError,
-                                    "Attempted to merge profiles with "
-                                    "different numbers of columns"):
+                                    "Cannot merge empty profiles."):
             profile1 + profile2
 
         # test mismatched profiles due to options

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -663,17 +663,17 @@ class TestStructuredProfiler(unittest.TestCase):
 
         msg = "Columns do not match, cannot update or merge profiles."
         with self.assertRaisesRegex(ValueError, msg):
-            dp.StructuredProfiler._get_and_validate_schema(unique_schema_1,
-                                                           unique_schema_3)
+            dp.StructuredProfiler._get_and_validate_schema_mapping(unique_schema_1,
+                                                                   unique_schema_3)
 
         expected_schema = {0: 0, 1: 1, 2: 2}
         actual_schema = dp.StructuredProfiler. \
-            _get_and_validate_schema(unique_schema_1, {})
+            _get_and_validate_schema_mapping(unique_schema_1, {})
         self.assertDictEqual(actual_schema, expected_schema)
 
         expected_schema = {0: 2, 1: 0, 2: 1}
         actual_schema = dp.StructuredProfiler. \
-            _get_and_validate_schema(unique_schema_1, unique_schema_2)
+            _get_and_validate_schema_mapping(unique_schema_1, unique_schema_2)
         self.assertDictEqual(actual_schema, expected_schema)
 
         dupe_schema_1 = {"a": [0], "b": [1, 2], "c": [3, 4, 5]}
@@ -683,19 +683,19 @@ class TestStructuredProfiler(unittest.TestCase):
         msg = ("Different number of columns detected for "
                "'a', cannot update or merge profiles.")
         with self.assertRaisesRegex(ValueError, msg):
-            dp.StructuredProfiler._get_and_validate_schema(dupe_schema_1,
-                                                           dupe_schema_3)
+            dp.StructuredProfiler._get_and_validate_schema_mapping(dupe_schema_1,
+                                                                   dupe_schema_3)
 
         msg = ("Different column indices under "
                "duplicate name 'b', cannot update "
                "or merge unless schema is identical.")
         with self.assertRaisesRegex(ValueError, msg):
-            dp.StructuredProfiler._get_and_validate_schema(dupe_schema_1,
-                                                           dupe_schema_2)
+            dp.StructuredProfiler._get_and_validate_schema_mapping(dupe_schema_1,
+                                                                   dupe_schema_2)
 
         expected_schema = {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5}
         actual_schema = dp.StructuredProfiler. \
-            _get_and_validate_schema(dupe_schema_1, dupe_schema_1)
+            _get_and_validate_schema_mapping(dupe_schema_1, dupe_schema_1)
         self.assertDictEqual(actual_schema, expected_schema)
 
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -152,7 +152,8 @@ class TestStructuredProfiler(unittest.TestCase):
         profile2._profile.pop(0)
         profile2._col_name_to_idx.pop(0)
         with self.assertRaisesRegex(ValueError,
-                                    "Cannot merge empty profiles."):
+                                    "Attempted to merge profiles with "
+                                    "different numbers of columns"):
             profile1 + profile2
 
         # test mismatched profiles due to options
@@ -679,6 +680,8 @@ class TestStructuredProfiler(unittest.TestCase):
         dupe_schema_2 = {"a": [0], "b": [1, 3], "c": [2, 4, 5]}
         dupe_schema_3 = {"a": [0, 1], "b": [2, 3, 4], "c": [5]}
 
+        four_col_schema = {"a": [0], "b": [1, 2], "c": [3, 4, 5], "d": [6]}
+
         msg = ("Different number of columns detected for "
                "'a', cannot update or merge profiles.")
         with self.assertRaisesRegex(ValueError, msg):
@@ -691,6 +694,12 @@ class TestStructuredProfiler(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             dp.StructuredProfiler._get_and_validate_schema_mapping(dupe_schema_1,
                                                                    dupe_schema_2)
+
+        # In strict case, column number must match
+        msg = "Attempted to merge profiles with different numbers of columns"
+        with self.assertRaisesRegex(ValueError, msg):
+            dp.StructuredProfiler._get_and_validate_schema_mapping(
+                dupe_schema_1, four_col_schema, True)
 
         expected_schema = {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5}
         actual_schema = dp.StructuredProfiler. \

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -152,7 +152,8 @@ class TestStructuredProfiler(unittest.TestCase):
         profile2._profile.pop(0)
         profile2._col_name_to_idx.pop(0)
         with self.assertRaisesRegex(ValueError,
-                                    'Profiles do not have the same schema.'):
+                                    'Cannot merge profiles due to schema '
+                                    'mismatch'):
             profile1 + profile2
 
         # test mismatched profiles due to options

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -152,8 +152,7 @@ class TestStructuredProfiler(unittest.TestCase):
         profile2._profile.pop(0)
         profile2._col_name_to_idx.pop(0)
         with self.assertRaisesRegex(ValueError,
-                                    'Cannot merge profiles due to schema '
-                                    'mismatch'):
+                                    "Cannot merge empty profiles."):
             profile1 + profile2
 
         # test mismatched profiles due to options

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -657,6 +657,47 @@ class TestStructuredProfiler(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             unique_profile.update_profile(dupe_data)
 
+    def test_unique_col_permutation(self, *mocks):
+        data = pd.DataFrame([[1, 2, 3, 4],
+                             [5, 6, 7, 8]],
+                            columns=["a", "b", "c", "d"])
+        perm_data = pd.DataFrame([[4, 3, 2, 1],
+                                  [8, 7, 6, 5]],
+                                 columns=["d", "c", "b", "a"])
+
+        # Test via add
+        first_profiler = dp.StructuredProfiler(data)
+        perm_profiler = dp.StructuredProfiler(perm_data)
+        profiler = first_profiler + perm_profiler
+
+        for col_idx in range(len(profiler._profile)):
+            col_min = data.iloc[0, col_idx]
+            col_max = data.iloc[1, col_idx]
+            # Sum is doubled since it was updated with the same vals
+            col_sum = 2 * (col_min + col_max)
+            self.assertEqual(col_min, profiler._profile[col_idx].
+                             profile["statistics"]["min"])
+            self.assertEqual(col_max, profiler._profile[col_idx].
+                             profile["statistics"]["max"])
+            self.assertEqual(col_sum, profiler._profile[col_idx].
+                             profile["statistics"]["sum"])
+
+        # Test via update
+        profiler = dp.StructuredProfiler(data)
+        profiler.update_profile(perm_data)
+
+        for col_idx in range(len(profiler._profile)):
+            col_min = data.iloc[0, col_idx]
+            col_max = data.iloc[1, col_idx]
+            # Sum is doubled since it was updated with the same vals
+            col_sum = 2 * (col_min + col_max)
+            self.assertEqual(col_min, profiler._profile[col_idx].
+                             profile["statistics"]["min"])
+            self.assertEqual(col_max, profiler._profile[col_idx].
+                             profile["statistics"]["max"])
+            self.assertEqual(col_sum, profiler._profile[col_idx].
+                             profile["statistics"]["sum"])
+
 
 class TestStructuredColProfilerClass(unittest.TestCase):
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -93,7 +93,7 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(2, profiler.row_is_null_count)
         self.assertEqual(7, profiler.total_samples)
         self.assertEqual(5, len(profiler.hashed_row_dict))
-        self.assertListEqual([0], list(profiler._profile.keys()))
+        self.assertListEqual([0], list(profiler._col_name_to_idx.keys()))
 
     @mock.patch('dataprofiler.profilers.profile_builder.'
                 'ColumnPrimitiveTypeProfileCompiler')
@@ -115,7 +115,7 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(2, profiler.row_is_null_count)
         self.assertEqual(7, profiler.total_samples)
         self.assertEqual(5, len(profiler.hashed_row_dict))
-        self.assertListEqual([0], list(profiler._profile.keys()))
+        self.assertListEqual([0], list(profiler._col_name_to_idx.keys()))
 
         # test properties when series has name
         data.name = 'test'
@@ -127,7 +127,7 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(2, profiler.row_is_null_count)
         self.assertEqual(7, profiler.total_samples)
         self.assertEqual(5, len(profiler.hashed_row_dict))
-        self.assertListEqual(['test'], list(profiler._profile.keys()))
+        self.assertListEqual(['test'], list(profiler._col_name_to_idx.keys()))
 
     @mock.patch('dataprofiler.profilers.profile_builder.'
                 'ColumnPrimitiveTypeProfileCompiler')
@@ -149,13 +149,15 @@ class TestStructuredProfiler(unittest.TestCase):
             profile1 + 3
 
         # test mismatched profiles
-        popped_profile = profile2._profile.pop(0)
+        profile2._profile.pop(0)
+        profile2._col_name_to_idx.pop(0)
         with self.assertRaisesRegex(ValueError,
                                     'Profiles do not have the same schema.'):
             profile1 + profile2
 
         # test mismatched profiles due to options
-        profile2._profile[0] = None
+        profile2._profile.append(None)
+        profile2._col_name_to_idx[0] = [0]
         with self.assertRaisesRegex(ValueError,
                                     'The two profilers were not setup with the '
                                     'same options, hence they do not calculate '
@@ -164,10 +166,13 @@ class TestStructuredProfiler(unittest.TestCase):
             profile1 + profile2
 
         # test success
-        profile1._profile = dict(test=1)
-        profile2._profile = dict(test=2)
+        profile1._profile = [1]
+        profile1._col_name_to_idx = {"test": [0]}
+        profile2._profile = [2]
+        profile2._col_name_to_idx = {"test": [0]}
         merged_profile = profile1 + profile2
-        self.assertEqual(3, merged_profile._profile['test'])
+        self.assertEqual(3, merged_profile._profile[
+            merged_profile._col_name_to_idx["test"][0]])
         self.assertIsNone(merged_profile.encoding)
         self.assertEqual(
             "<class 'pandas.core.frame.DataFrame'>", merged_profile.file_type)
@@ -240,7 +245,8 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(0.0, self.trained_schema._get_duplicate_row_count())
 
     def test_correct_datatime_schema_test(self):
-        profile = self.trained_schema.profile["datetime"]
+        profile_idx = self.trained_schema._col_name_to_idx["datetime"][0]
+        profile = self.trained_schema.profile[profile_idx]
         col_schema_info = \
             profile.profiles['data_type_profile']._profiles["datetime"]
 
@@ -252,7 +258,8 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(['%m/%d/%y %H:%M'], col_schema_info['date_formats'])
 
     def test_correct_integer_column_detection_src(self):
-        profile = self.trained_schema.profile["src"]
+        profile_idx = self.trained_schema._col_name_to_idx["src"][0]
+        profile = self.trained_schema.profile[profile_idx]
         col_schema_info = profile.profiles['data_type_profile']._profiles["int"]
 
         self.assertEqual(2999, profile.sample_size)
@@ -261,7 +268,8 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(3, profile.null_count)
 
     def test_correct_integer_column_detection_int_col(self):
-        profile = self.trained_schema.profile["int_col"]
+        profile_idx = self.trained_schema._col_name_to_idx["int_col"][0]
+        profile = self.trained_schema.profile[profile_idx]
         col_schema_info = profile.profiles['data_type_profile']._profiles["int"]
         self.assertEqual(2999, profile.sample_size)
         self.assertEqual(col_schema_info.sample_size,
@@ -269,7 +277,8 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(0, profile.null_count)
 
     def test_correct_integer_column_detection_port(self):
-        profile = self.trained_schema.profile["srcport"]
+        profile_idx = self.trained_schema._col_name_to_idx["srcport"][0]
+        profile = self.trained_schema.profile[profile_idx]
         col_schema_info = profile.profiles['data_type_profile']._profiles["int"]
         self.assertEqual(2999, profile.sample_size)
         self.assertEqual(col_schema_info.sample_size,
@@ -277,7 +286,8 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(197, profile.null_count)
 
     def test_correct_integer_column_detection_destport(self):
-        profile = self.trained_schema.profile["destport"]
+        profile_idx = self.trained_schema._col_name_to_idx["destport"][0]
+        profile = self.trained_schema.profile[profile_idx]
         col_schema_info = profile.profiles['data_type_profile']._profiles["int"]
         self.assertEqual(2999, profile.sample_size)
         self.assertEqual(col_schema_info.sample_size,
@@ -384,22 +394,6 @@ class TestStructuredProfiler(unittest.TestCase):
             self.fail(
                 "Dataset tested did not have a non-null column and therefore "
                 "could not validate the test.")
-    
-    @mock.patch('dataprofiler.profilers.profile_builder.StructuredProfiler._update_row_statistics')
-    def test_duplicate_column_names(self, *mocks):
-        # validate works first
-        valid_data = pd.DataFrame([[1, 2]], columns=['a', 'b'])
-        profile = dp.StructuredProfiler(valid_data)
-        self.assertIn('a', profile._profile)
-        self.assertIn('b', profile._profile)
-
-        # data has duplicate column names
-        invalid_data = pd.DataFrame([[1, 2]], columns=['a', 'a'])
-        with self.assertRaisesRegex(ValueError,
-                                    '`StructuredProfiler` does not currently support '
-                                    'data which contains columns with duplicate'
-                                    ' names.'):
-            profile = dp.StructuredProfiler(invalid_data)
 
     def test_text_data_raises_error(self):
         text_file_path = os.path.join(
@@ -493,7 +487,7 @@ class TestStructuredProfiler(unittest.TestCase):
 
                 # only checks first columns
                 # get first column
-                first_column_profile = list(load_profile.profile.values())[0]
+                first_column_profile = load_profile.profile[0]
                 self.assertIsInstance(
                     first_column_profile.profiles['data_label_profile']
                         ._profiles['data_labeler'].data_labeler,
@@ -569,6 +563,93 @@ class TestStructuredProfiler(unittest.TestCase):
         profiler = dp.StructuredProfiler(pd.DataFrame([[{'test': 1}], [None]]))
         self.assertEqual(1, profiler.row_is_null_count)
         self.assertEqual(2, profiler.total_samples)
+
+    def test_duplicate_columns(self):
+        data = pd.DataFrame([[1, 2, 3, 4, 5, 6],
+                             [10, 20, 30, 40, 50, 60]],
+                            columns=["a", "b", "a", "b", "c", "d"])
+        profiler = dp.StructuredProfiler(data)
+
+        # Ensure columns are correctly allocated to profiles in list
+        expected_mapping = {"a": [0, 2], "b": [1, 3], "c": [4], "d": [5]}
+        self.assertDictEqual(expected_mapping, profiler._col_name_to_idx)
+        for col in profiler._col_name_to_idx:
+            for idx in profiler._col_name_to_idx[col]:
+                # Make sure every index that a column name maps to represents
+                # A profile for that named column
+                self.assertEqual(col, profiler._profile[idx].name)
+
+        # Check a few stats to ensure calculation with data occurred
+        # Initialization ensures column ids and profile ids are identical
+        for col_idx in range(len(profiler._profile)):
+            col_min = data.iloc[0, col_idx]
+            col_max = data.iloc[1, col_idx]
+            col_sum = col_min + col_max
+            self.assertEqual(col_min, profiler._profile[col_idx].
+                             profile["statistics"]["min"])
+            self.assertEqual(col_max, profiler._profile[col_idx].
+                             profile["statistics"]["max"])
+            self.assertEqual(col_sum, profiler._profile[col_idx].
+                             profile["statistics"]["sum"])
+
+        # Check that update works as expected
+        new_data = pd.DataFrame([[100, 200, 300, 400, 500, 600]],
+                                columns=["a", "b", "a", "b", "c", "d"])
+        profiler.update_profile(new_data)
+        self.assertDictEqual(expected_mapping, profiler._col_name_to_idx)
+        for col in profiler._col_name_to_idx:
+            for idx in profiler._col_name_to_idx[col]:
+                # Make sure every index that a column name maps to represents
+                # A profile for that named column
+                self.assertEqual(col, profiler._profile[idx].name)
+
+        for col_idx in range(len(profiler._profile)):
+            col_min = data.iloc[0, col_idx]
+            col_max = new_data.iloc[0, col_idx]
+            col_sum = col_min + col_max + data.iloc[1, col_idx]
+            self.assertEqual(col_min, profiler._profile[col_idx].
+                             profile["statistics"]["min"])
+            self.assertEqual(col_max, profiler._profile[col_idx].
+                             profile["statistics"]["max"])
+            self.assertEqual(col_sum, profiler._profile[col_idx].
+                             profile["statistics"]["sum"])
+
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnPrimitiveTypeProfileCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnStatsProfileCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.'
+                'ColumnDataLabelerCompiler')
+    @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
+    def test_schema_errors(self, *mocks):
+        # Can't merge profiles with different schemas
+        empty_profile1 = dp.StructuredProfiler(None)
+        empty_profile2 = dp.StructuredProfiler(None)
+        empty_profile1._col_name_to_idx = {"profile": [0], "one": [1]}
+        empty_profile2._col_name_to_idx = {"profile": [0], "two": [2]}
+        msg = 'Profiles do not have the same schema.'
+        with self.assertRaisesRegex(ValueError, msg):
+            empty_profile1._add_error_checks(empty_profile2)
+
+        # Can't change schema when updating
+        dupe_data = pd.DataFrame([[1, 2, 3, 4, 5, 6],
+                                  [10, 20, 30, 40, 50, 60]],
+                                 columns=["a", "b", "a", "b", "c", "d"])
+        unique_data = pd.DataFrame({"e": [1, 1], "f": [2, 2], "g": [3, 3]})
+        dupe_profile = dp.StructuredProfiler(dupe_data)
+        unique_profile = dp.StructuredProfiler(unique_data)
+
+        msg = ("Schema of data with duplicate column names not respected when "
+               "updating profile.")
+        with self.assertRaisesRegex(ValueError, msg):
+            dupe_profile.update_profile(unique_data)
+
+        msg = ("Attempted to update data with duplicate "
+               "column names that weren't present before "
+               "update. Schema must be identical when "
+               "profiling data with duplicate column names.")
+        with self.assertRaisesRegex(ValueError, msg):
+            unique_profile.update_profile(dupe_data)
 
 
 class TestStructuredColProfilerClass(unittest.TestCase):
@@ -1416,17 +1497,19 @@ class TestStructuredProfilerNullValues(unittest.TestCase):
         profiler_options.set({'data_labeler.is_enabled': False})
         trained_schema = dp.StructuredProfiler(test_dataset, len(test_dataset),
                                                options=profiler_options)
+        ts_profile = trained_schema.profile
+        ts_mapping = trained_schema._col_name_to_idx
 
         self.assertCountEqual(['', 'nan', 'None', 'null'],
-                         trained_schema.profile['1'].null_types)
-        self.assertEqual(5, trained_schema.profile['1'].null_count)
-        self.assertEqual({'': {4}, 'nan': {0}, 'None': {2, 3}, 'null': {
-                         1}}, trained_schema.profile['1'].null_types_index)
+                              ts_profile[ts_mapping['1'][0]].null_types)
+        self.assertEqual(5, ts_profile[ts_mapping['1'][0]].null_count)
+        self.assertEqual({'': {4}, 'nan': {0}, 'None': {2, 3}, 'null': {1}},
+                         ts_profile[ts_mapping['1'][0]].null_types_index)
         self.assertCountEqual(['', 'nan', 'None', 'null'],
-                         trained_schema.profile[1].null_types)
-        self.assertEqual(5, trained_schema.profile[1].null_count)
-        self.assertEqual({'': {4}, 'nan': {0}, 'None': {1, 3}, 'null': {
-                         2}}, trained_schema.profile[1].null_types_index)
+                              ts_profile[ts_mapping[1][0]].null_types)
+        self.assertEqual(5, ts_profile[ts_mapping[1][0]].null_count)
+        self.assertEqual({'': {4}, 'nan': {0}, 'None': {1, 3}, 'null': {2}},
+                         ts_profile[ts_mapping[1][0]].null_types_index)
 
     def test_correct_null_row_counts(self):
         file_path = os.path.join(test_root_path, 'data', 'csv/empty_rows.txt')
@@ -1723,7 +1806,7 @@ class TestProfilerFactoryClass(unittest.TestCase):
 
             # only checks first columns
             # get first column
-            first_column_profile = list(load_profile.profile.values())[0]
+            first_column_profile = load_profile.profile[0]
             self.assertIsInstance(
                 first_column_profile.profiles['data_label_profile']
                     ._profiles['data_labeler'].data_labeler,


### PR DESCRIPTION
This is the 1st part of a 3 part refactor, as follows:
1) Refactor `StructuredProfiler._profile` to be a list instead of a dict, and store a mapping that maps column names to a list of indices (in `_profile`) that correspond to data that was in a column of the given name. Refactor tests accordingly.
2) Refactor `StructuredProfiler` `report['data_stats']` to be a list that mirrors `StructuredProfiler._profile`, and stores a column name to index mapping in `global_stats`. Refactor tests accordingly.
3) Update documentation (README as well as notebooks)

Note that after this refactor (1/3) a lot of tests will fail due to `report` not being compatible with the new `_profile`, but to limit PR scope and streamline reviewing, this will have to be ignored until the 2nd refactor, at which point all tests (old and new) will pass.

To see the plan for the larger refactor (steps 1 and 2), it is here: #278
This PR is just a subset of changes made in #278