### PR TITLE
Ability to internally store counts of each category in a CategoricalColumn

### DIFF
--- a/dataprofiler/profilers/categorical_column_profile.py
+++ b/dataprofiler/profilers/categorical_column_profile.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from . import BaseColumnProfiler
 from .profiler_options import CategoricalOptions
 from . import utils
@@ -29,7 +30,7 @@ class CategoricalColumn(BaseColumnProfiler):
             raise ValueError("CategoricalColumn parameter 'options' must be of"
                              " type CategoricalOptions.")
         super(CategoricalColumn, self).__init__(name)
-        self._categories = list()
+        self._categories = defaultdict(int)
         self.__calculations = {}
         self._filter_properties_w_options(self.__calculations, options)
 
@@ -49,8 +50,8 @@ class CategoricalColumn(BaseColumnProfiler):
                                 other.__class__.__name__))
 
         merged_profile = CategoricalColumn(None)
-        merged_profile._categories = self._categories.copy()
-        merged_profile._update_categories(other._categories)
+        merged_profile._categories = \
+            utils.add_nested_dictionaries(self._categories, other._categories)
         BaseColumnProfiler._add_helper(merged_profile, self, other)
         self._merge_calculations(merged_profile.__calculations,
                                  self.__calculations,
@@ -82,7 +83,7 @@ class CategoricalColumn(BaseColumnProfiler):
         """
         Property for categories.
         """
-        return self._categories
+        return list(self._categories.keys())
 
     @property
     def unique_ratio(self):
@@ -126,11 +127,8 @@ class CategoricalColumn(BaseColumnProfiler):
         :type df_series: pandas.DataFrame
         :return: None
         """
-        if hasattr(df_series, 'tolist'):
-            df_series = df_series.tolist()
 
-        self._categories = utils._combine_unique_sets(
-            self._categories, df_series)
+        self._categories.update(df_series.value_counts(dropna = False).to_dict())
 
     def _update_helper(self, df_series_clean, profile):
         """
@@ -167,3 +165,10 @@ class CategoricalColumn(BaseColumnProfiler):
         self._update_helper(df_series, profile)
 
         return self
+
+    def dict_of_categories(self):
+        """
+        Returns the dict of categories with the number of occurrences
+        for each category.
+        """
+        return dict(self._categories.items())

--- a/dataprofiler/profilers/categorical_column_profile.py
+++ b/dataprofiler/profilers/categorical_column_profile.py
@@ -128,7 +128,7 @@ class CategoricalColumn(BaseColumnProfiler):
         :return: None
         """
 
-        self._categories.update(df_series.value_counts(dropna = False).to_dict())
+        self._categories.update(df_series.value_counts(dropna=False).to_dict())
 
     def _update_helper(self, df_series_clean, profile):
         """

--- a/dataprofiler/profilers/categorical_column_profile.py
+++ b/dataprofiler/profilers/categorical_column_profile.py
@@ -127,8 +127,9 @@ class CategoricalColumn(BaseColumnProfiler):
         :type df_series: pandas.DataFrame
         :return: None
         """
-
-        self._categories.update(df_series.value_counts(dropna=False).to_dict())
+        category_count = df_series.value_counts(dropna=False).to_dict()
+        self._categories = utils.add_nested_dictionaries(self._categories,
+                                                         category_count)
 
     def _update_helper(self, df_series_clean, profile):
         """

--- a/dataprofiler/profilers/categorical_column_profile.py
+++ b/dataprofiler/profilers/categorical_column_profile.py
@@ -166,10 +166,3 @@ class CategoricalColumn(BaseColumnProfiler):
         self._update_helper(df_series, profile)
 
         return self
-
-    def dict_of_categories(self):
-        """
-        Returns the dict of categories with the number of occurrences
-        for each category.
-        """
-        return dict(self._categories.items())

--- a/dataprofiler/tests/profilers/test_categorical_column_profile.py
+++ b/dataprofiler/tests/profilers/test_categorical_column_profile.py
@@ -116,7 +116,9 @@ class TestCategoricalColumn(unittest.TestCase):
         self.assertEqual(
             num_nan_count, len(
                 column_profile.null_types_index["nan"]))
-
+        expected = {"abcd": 2, "aa": 2, "b": 1, "4": 1, "3": 1, "2": 2,
+                    "dfd": 1}
+        self.assertDictEqual(expected, cat_profiler._categories)
         num_null_types = 4
         num_nan_count = 2
         categories = pd.concat([df1, df2]).apply(str).unique().tolist()
@@ -127,6 +129,9 @@ class TestCategoricalColumn(unittest.TestCase):
         self.assertEqual(num_null_types, len(column_profile.null_types))
         self.assertEqual(
             num_nan_count, len(column_profile.null_types_index["nan"]))
+        expected = {"abcd": 2, "aa": 3, "b": 2, "4": 1, "3": 1, "2": 2,
+                    "dfd": 1, "1": 1, "ee": 2, "ff": 1, "gg": 1}
+        self.assertDictEqual(expected, cat_profiler._categories)
 
         num_null_types = 4
         num_nan_count = 3
@@ -191,9 +196,13 @@ class TestCategoricalColumn(unittest.TestCase):
         profile = CategoricalColumn("Name")
         profile.update(df1)
 
+        expected_dict = {"abcd": 2, "aa": 2, "b": 1, "4": 1, "3": 1, "2": 2,
+                         "dfd": 1, np.nan: 1}
+        self.assertDictEqual(expected_dict, profile._categories)
+
         profile2 = CategoricalColumn("Name")
         profile2.update(df2)
-        
+
         # Add profiles
         profile3 = profile + profile2
         self.assertCountEqual(expected_categories, profile3.categories)
@@ -202,6 +211,10 @@ class TestCategoricalColumn(unittest.TestCase):
             profile.sample_size +
             profile2.sample_size)
         self.assertEqual(profile3.is_match, False)
+        expected_dict = {"abcd": 2, "aa": 3, "b": 2, "4": 1, "3": 1, "2": 2,
+                         np.nan: 1, "dfd": 1, "1": 1, "ee": 2, "ff": 1, "gg": 1,
+                         "NaN": 1, "None": 1, "nan": 1, "null": 1}
+        self.assertDictEqual(expected_dict, profile3._categories)
 
         # Add again
         profile3 = profile + profile3
@@ -264,7 +277,7 @@ class TestCategoricalSentence(unittest.TestCase):
         cat_sentence_df = pd.Series(cat_sentence_list)
         column_profile = StructuredColProfiler(cat_sentence_df)
         cat_profiler = column_profile.profiles['data_stats_profile']._profiles["category"]
-        
+
         self.assertEqual(False, cat_profiler.is_match)
 
     def test_less_than_CATEGORICAL_THRESHOLD_DEFAULT(self):
@@ -335,29 +348,3 @@ class TestCategoricalSentence(unittest.TestCase):
                                    "CategoricalColumn parameter 'options' must"
                                    " be of type CategoricalOptions."):
             profiler = CategoricalColumn("Categorical", options="wrong_data_type")
-
-    def test_categorical_column_is_counted(self):
-        df_categorical = pd.Series([
-            "a", "a", "a", "b", "b", "b", "b", "c", "c", "c", "c", "c",
-        ])
-        profile = CategoricalColumn(df_categorical.name)
-        # Check that _categories counts in profile is empty after init.
-        self.assertEqual(0, len(profile.dict_of_categories()))
-
-        profile.update(df_categorical)
-        # Check that _categories counts is correct after update function
-        self.assertEqual(profile.dict_of_categories()['a'], 3)
-        self.assertEqual(profile.dict_of_categories()['b'], 4)
-        self.assertEqual(profile.dict_of_categories()['c'], 5)
-
-        df_categorical2 = pd.Series([
-            "a", "a", "d", "d"
-        ])
-        profile2 = CategoricalColumn(df_categorical2.name)
-        profile2.update(df_categorical2)
-        profile3 = profile + profile2
-        # Check that _categories dict_of_categories is correct after merge/add function
-        self.assertEqual(profile3.dict_of_categories()['a'], 5)
-        self.assertEqual(profile3.dict_of_categories()['b'], 4)
-        self.assertEqual(profile3.dict_of_categories()['c'], 5)
-        self.assertTrue(profile3.dict_of_categories()['d'], 2)

--- a/dataprofiler/tests/profilers/test_categorical_column_profile.py
+++ b/dataprofiler/tests/profilers/test_categorical_column_profile.py
@@ -335,3 +335,29 @@ class TestCategoricalSentence(unittest.TestCase):
                                    "CategoricalColumn parameter 'options' must"
                                    " be of type CategoricalOptions."):
             profiler = CategoricalColumn("Categorical", options="wrong_data_type")
+
+    def test_categorical_column_is_counted(self):
+        df_categorical = pd.Series([
+            "a", "a", "a", "b", "b", "b", "b", "c", "c", "c", "c", "c",
+        ])
+        profile = CategoricalColumn(df_categorical.name)
+        # Check that _categories counts in profile is empty after init.
+        self.assertEqual(0, len(profile.dict_of_categories()))
+
+        profile.update(df_categorical)
+        # Check that _categories counts is correct after update function
+        self.assertEqual(profile.dict_of_categories()['a'], 3)
+        self.assertEqual(profile.dict_of_categories()['b'], 4)
+        self.assertEqual(profile.dict_of_categories()['c'], 5)
+
+        df_categorical2 = pd.Series([
+            "a", "a", "d", "d"
+        ])
+        profile2 = CategoricalColumn(df_categorical2.name)
+        profile2.update(df_categorical2)
+        profile3 = profile + profile2
+        # Check that _categories dict_of_categories is correct after merge/add function
+        self.assertEqual(profile3.dict_of_categories()['a'], 5)
+        self.assertEqual(profile3.dict_of_categories()['b'], 4)
+        self.assertEqual(profile3.dict_of_categories()['c'], 5)
+        self.assertTrue(profile3.dict_of_categories()['d'], 2)


### PR DESCRIPTION
I have allowed the system to track the counts of each category rather than just a list. Like, instead of just listing the categories like [a,b,c], we can now internally have a way to count each category. The categories will return as before like [a,b,c], but inside, _categories variable is now something like [a:1,b:2,c:3].