### PR TITLE
StructuredProfiler report dict -> list refactor (part 2/3)

### DIFF
--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -5,7 +5,7 @@ name: Test Python Package
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, duplicate_column_fix ]
 
 jobs:
   build:

--- a/dataprofiler/profilers/helpers/report_helpers.py
+++ b/dataprofiler/profilers/helpers/report_helpers.py
@@ -87,24 +87,6 @@ def _prepare_report(report, output_format=None, omit_keys=None):
             "data_stats.*.statistics.histogram"
         ])
         output_format = "pretty"
-
-    # Modify omit_keys to account for data_stats being a list and not a dict
-    # With column names for keys
-    new_omit_keys = []
-    for omit_key in omit_keys:
-        key_list = omit_key.split(".")
-        if len(key_list) > 1 and key_list[0] == "data_stats" \
-                and key_list[1] != "*":
-            idxs = report["global_stats"]["profile_schema"][key_list[1]]
-            for i in idxs:
-                swapped_list = key_list
-                swapped_list[1] = str(i)
-                swapped_str = ".".join(swapped_list)
-                new_omit_keys.append(swapped_str)
-        else:
-            new_omit_keys.append(omit_key)
-
-    omit_keys = new_omit_keys
     
     for key in report:
         
@@ -118,47 +100,65 @@ def _prepare_report(report, output_format=None, omit_keys=None):
         if isinstance(value, set):
             value = sorted(list(value))
 
+        if "*" in omit_keys:
+            continue
+
         # For data_stats (in structured case), need to recurse through a list
         # As well as account for omit_keys containing indices instead of keys
-        if key == "data_stats" and isinstance(value, list):
-            fmt_report["data_stats"] = []
-            # split off any remaining keys for the recursion
-            # i.e. [test0, test1.test2] -> omit_keys => [test1.test2]
-            # This will filter out all the data_stats omit keys
-            data_stat_omit_keys = []
-            for omit_key in omit_keys:
-                omit_key_split = omit_key.split('.', 1)
+        elif key == "data_stats" and isinstance(value, list) \
+                and "data_stats" not in omit_keys:
 
-                # Must have more keys left for recursion
-                if len(omit_key_split) > 1:
-                    next_key_layer = omit_key_split[-1]
-                    prior_key_layer = omit_key_split[0]
-                    if len(next_key_layer) > 0:
-                        if prior_key_layer == '*' or prior_key_layer == key:
-                            data_stat_omit_keys.append(next_key_layer)
+            # Map cols to keep in report with their layer's omit keys
+            kept_cols_oks = dict()
+            # Cols that will have None in report since they were omitted
+            none_cols = []
+            for col_ind in range(len(value)):
+                # column is being omitted
+                if f"data_stats.{str(value[col_ind].get('column_name'))}" \
+                        in omit_keys:
+                    none_cols.append(col_ind)
+                    continue
 
-            # Recurse through indices in data_stats and call report_helper
-            for i in range(len(value)):
-                i_index_omit_keys = []
-                # Filter off data_stats omit keys depending on index
-                for nl_key in data_stat_omit_keys:
-                    key_split = nl_key.split(".", 1)
+                # update omit keys
+                next_layer_omit_keys = []
+                # Track omit_keys that pertain to data_stats
+                ds_omit_keys = [omit_key[11:] for omit_key in omit_keys
+                                if omit_key[:11] == "data_stats."]
+                for omit_key in ds_omit_keys:
+                    omit_key_split = omit_key.split('.', 1)
 
-                    # Must have more keys left for recursion
-                    if len(key_split) > 1:
-                        next_key_layer = key_split[-1]
-                        index = key_split[0]
-                        if len(next_key_layer) > 0:
-                            if (index.isdigit() and int(index) == i) \
-                                    or index == "*":
-                                i_index_omit_keys.append(next_key_layer)
+                    # this omit occurs only at this level, don't include
+                    if len(omit_key_split) == 1:
+                        continue
 
-                # Recursively prepare each column in data_stats list
-                fmt_report["data_stats"].append(
-                    _prepare_report(value[i], output_format, i_index_omit_keys))
+                    # this omit applies to everything below
+                    elif omit_key_split[0] == "*":
+                        next_layer_omit_keys.append(omit_key_split[1])
+
+                    # this omit applies to the name of this indexed column
+                    elif omit_key_split[0] == \
+                            str(value[col_ind].get("column_name")):
+                        next_layer_omit_keys.append(omit_key_split[1])
+
+                # update report and list for column we are keeping
+                kept_cols_oks[col_ind] = next_layer_omit_keys
+
+            # Helper to create reports based on whether ind is kept or omitted
+            def ds_helper(ind):
+                # Return None if col is to be omitted
+                if ind in none_cols:
+                    return None
+                # Return prepared report with this columns next level omit keys
+                # Index into report["data_stats"][ind] (value[ind])
+                return _prepare_report(value[ind], output_format,
+                                       kept_cols_oks[ind])
+
+            # Get subset of columns to keep
+            fmt_report["data_stats"] = [ds_helper(ind)
+                                        for ind in range(len(value))]
 
         # Do not recurse or modify profile_schema
-        elif key == "profile_schema":
+        elif key == "profile_schema" and "profile_schema" not in omit_keys:
             fmt_report[key] = value
 
         elif isinstance(value, dict):

--- a/dataprofiler/profilers/helpers/report_helpers.py
+++ b/dataprofiler/profilers/helpers/report_helpers.py
@@ -104,7 +104,6 @@ def _prepare_report(report, output_format=None, omit_keys=None):
             continue
 
         # For data_stats (in structured case), need to recurse through a list
-        # As well as account for omit_keys containing indices instead of keys
         elif key == "data_stats" and isinstance(value, list) \
                 and "data_stats" not in omit_keys:
 

--- a/dataprofiler/profilers/helpers/report_helpers.py
+++ b/dataprofiler/profilers/helpers/report_helpers.py
@@ -107,55 +107,41 @@ def _prepare_report(report, output_format=None, omit_keys=None):
         elif key == "data_stats" and isinstance(value, list) \
                 and "data_stats" not in omit_keys:
 
-            # Map cols to keep in report with their layer's omit keys
-            kept_cols_oks = dict()
-            # Cols that will have None in report since they were omitted
-            none_cols = []
+            fmt_report["data_stats"] = []
+
             for col_ind in range(len(value)):
                 col_name = str(value[col_ind].get('column_name'))
                 # column is being omitted
-                if f"data_stats.{col_name}" \
-                        in omit_keys:
-                    none_cols.append(col_ind)
+                if f"data_stats.{col_name}" in omit_keys \
+                        or "data_stats.*" in omit_keys:
+                    fmt_report["data_stats"].append(None)
                     continue
 
                 # update omit keys
                 next_layer_omit_keys = []
-                # Track omit_keys that pertain to data_stats
-                ds_omit_keys = [omit_key[11:] for omit_key in omit_keys
-                                if omit_key[:11] == "data_stats."]
-                for omit_key in ds_omit_keys:
+                for omit_key in omit_keys:
+                    # Only look at data_stats omit keys
+                    if omit_key[:11] != "data_stats.":
+                        continue
+                    else:
+                        # Pull out omit_key information given its for data_stats
+                        omit_key = omit_key[11:]
+
                     omit_key_split = omit_key.split('.', 1)
 
-                    # this omit occurs only at this level, don't include
-                    if len(omit_key_split) == 1 and omit_key in {"*", col_name}:
-                        none_cols.append(col_ind)
-                        continue
+                    if omit_key_split[0] in {"*", col_name}:
+                        # Already omitted entire column in case above
+                        # Therefore guaranteed to have further keys in this case
+                        if len(omit_key_split) < 2:
+                            raise ValueError("Invalid omit keys given to report")
 
-                    # this omit applies to everything below
-                    elif omit_key_split[0] == "*":
-                        next_layer_omit_keys.append(omit_key_split[1])
-
-                    # this omit applies to the name of this indexed column
-                    elif omit_key_split[0] == col_name:
+                        # Need to omit further stats contained in this column
                         next_layer_omit_keys.append(omit_key_split[1])
 
                 # update report and list for column we are keeping
-                kept_cols_oks[col_ind] = next_layer_omit_keys
-
-            # Helper to create reports based on whether ind is kept or omitted
-            def ds_helper(ind):
-                # Return None if col is to be omitted
-                if ind in none_cols:
-                    return None
-                # Return prepared report with this columns next level omit keys
-                # Index into report["data_stats"][ind] (value[ind])
-                return _prepare_report(value[ind], output_format,
-                                       kept_cols_oks[ind])
-
-            # Get subset of columns to keep
-            fmt_report["data_stats"] = [ds_helper(ind)
-                                        for ind in range(len(value))]
+                fmt_report["data_stats"].append(
+                    _prepare_report(value[col_ind], output_format,
+                                    next_layer_omit_keys))
 
         # Do not recurse or modify profile_schema
         elif key == "profile_schema" and "profile_schema" not in omit_keys:

--- a/dataprofiler/profilers/helpers/report_helpers.py
+++ b/dataprofiler/profilers/helpers/report_helpers.py
@@ -113,8 +113,9 @@ def _prepare_report(report, output_format=None, omit_keys=None):
             # Cols that will have None in report since they were omitted
             none_cols = []
             for col_ind in range(len(value)):
+                col_name = str(value[col_ind].get('column_name'))
                 # column is being omitted
-                if f"data_stats.{str(value[col_ind].get('column_name'))}" \
+                if f"data_stats.{col_name}" \
                         in omit_keys:
                     none_cols.append(col_ind)
                     continue
@@ -128,7 +129,8 @@ def _prepare_report(report, output_format=None, omit_keys=None):
                     omit_key_split = omit_key.split('.', 1)
 
                     # this omit occurs only at this level, don't include
-                    if len(omit_key_split) == 1:
+                    if len(omit_key_split) == 1 and omit_key in {"*", col_name}:
+                        none_cols.append(col_ind)
                         continue
 
                     # this omit applies to everything below
@@ -136,8 +138,7 @@ def _prepare_report(report, output_format=None, omit_keys=None):
                         next_layer_omit_keys.append(omit_key_split[1])
 
                     # this omit applies to the name of this indexed column
-                    elif omit_key_split[0] == \
-                            str(value[col_ind].get("column_name")):
+                    elif omit_key_split[0] == col_name:
                         next_layer_omit_keys.append(omit_key_split[1])
 
                 # update report and list for column we are keeping

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1312,11 +1312,6 @@ class StructuredProfiler(BaseProfiler):
         omit_keys = report_options.get("omit_keys", [])
         num_quantile_groups = report_options.get("num_quantile_groups", 4)
 
-        report_schema = dict()
-        for i in range(len(self._profile)):
-            col = self._profile[i].name
-            report_schema.setdefault(col, []).append(i)
-
         report = OrderedDict([
             ("global_stats", {
                 "samples_used": self._max_col_samples_used,
@@ -1328,12 +1323,14 @@ class StructuredProfiler(BaseProfiler):
                 "duplicate_row_count": self._get_duplicate_row_count(),
                 "file_type": self.file_type,
                 "encoding": self.encoding,
-                "profile_schema": report_schema
+                "profile_schema": defaultdict(list)
             }),
             ("data_stats", []),
         ])
 
         for i in range(len(self._profile)):
+            col_name = self._profile[i].name
+            report["global_stats"]["profile_schema"][col_name].append(i)
             report["data_stats"].append(self._profile[i].profile)
             quantiles = report["data_stats"][i]["statistics"].get('quantiles')
             if quantiles:

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1482,10 +1482,6 @@ class StructuredProfiler(BaseProfiler):
             # Already calculated incoming schema for validation
             self._col_name_to_idx = mapping_given
             for col_idx in range(data.shape[1]):
-                col_name = data.columns[col_idx]
-                # Pandas cols are int by default, but need to fuzzy match strs
-                if isinstance(col_name, str):
-                    col_name = col_name.lower()
                 # Add blank StructuredColProfiler to _profile
                 self._profile.append(StructuredColProfiler(
                     sample_size=sample_size,

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1493,7 +1493,6 @@ class StructuredProfiler(BaseProfiler):
                     sample_ids=sample_ids,
                     options=self.options
                 ))
-                new_cols = True
 
         # Generate pool and estimate datasize
         pool = None

--- a/dataprofiler/tests/labelers/test_integration_struct_data_labeler.py
+++ b/dataprofiler/tests/labelers/test_integration_struct_data_labeler.py
@@ -291,9 +291,9 @@ class TestStructuredDataLabeler(unittest.TestCase):
 
         columns = []
         predictions = []
-        for col in results['data_stats']:
-            columns.append(col)
-            predictions.append(results['data_stats'][col]['data_label'])
+        for i in range(len(results['data_stats'])):
+            columns.append(i)
+            predictions.append(results['data_stats'][i]['data_label'])
 
     def test_warning_tf_run_dp_multiple_times(self):
         test_root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -319,9 +319,9 @@ class TestStructuredDataLabeler(unittest.TestCase):
 
             columns = []
             predictions = []
-            for col in results['data_stats']:
-                columns.append(col)
-                predictions.append(results['data_stats'][col]['data_label'])
+            for j in range(len(results['data_stats'])):
+                columns.append(j)
+                predictions.append(results['data_stats'][j]['data_label'])
 
     def test_warning_tf_run_dp_merge(self):
         test_root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -397,6 +397,12 @@ class TestStructuredProfiler(unittest.TestCase):
             else:
                 self.assertIsNotNone(report["data_stats"][idx])
 
+        # This will keep the data_stats key but remove all columns
+        report = profiler.report(report_options={"omit_keys": ["data_stats.*"]})
+
+        for col_report in report["data_stats"]:
+            self.assertIsNone(col_report)
+
 
     def test_report_quantiles(self):
         report_none = self.trained_schema.report(

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -339,13 +339,16 @@ class TestStructuredProfiler(unittest.TestCase):
     def test_pretty_report_doesnt_cast_schema(self):
         report = self.trained_schema.report(
             report_options={"output_format": "pretty"})
-        self.assertIsInstance(report["global_stats"]["profile_schema"], dict)
-        self.assertIsInstance(report["data_stats"], list)
-        for idx_list in report["global_stats"]["profile_schema"].values():
-            self.assertIsInstance(idx_list, list)
-            for idx in idx_list:
-                self.assertIsInstance(idx, int)
-                self.assertTrue(idx >= 0)
+        # Want to ensure the values of this dict are of type list[int]
+        # Since pretty "prettifies" lists into strings with ... to shorten
+        expected_schema = {"datetime": [0], "host": [1], "src": [2],
+                           "proto": [3], "type": [4], "srcport": [5],
+                           "destport": [6], "srcip": [7], "locale": [8],
+                           "localeabbr": [9], "postalcode": [10],
+                           "latitude": [11], "longitude": [12], "owner": [13],
+                           "comment": [14], "int_col": [15]}
+        self.assertDictEqual(expected_schema,
+                             report["global_stats"]["profile_schema"])
 
     def test_omit_keys_with_duplicate_cols(self):
         data = pd.DataFrame([[1, 2, 3, 4, 5, 6],

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -467,7 +467,7 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertNotIn("datetime", no_datetime["data_stats"])
 
         # Omit a statistic from each column
-        no_sum = no_data_stats = self.trained_schema.report(
+        no_sum = self.trained_schema.report(
             report_options={"omit_keys": ['data_stats.*.statistics.sum']})
         self.assertTrue(all(["sum" not in rep["statistics"]
                              for rep in no_sum["data_stats"]]))


### PR DESCRIPTION
This is the 2nd part of a 3 part refactor, as follows:

1. Refactor StructuredProfiler._profile to be a list instead of a dict, and store a mapping that maps column names to a list of indices (in _profile) that correspond to data that was in a column of the given name. Refactor tests accordingly.
2. Refactor StructuredProfiler report['data_stats'] to be a list that mirrors StructuredProfiler._profile, and stores a column name to index mapping in global_stats. Refactor tests accordingly.
3. Update documentation (README as well as notebooks)