### PR TITLE
Bug fix to make sure samples being stored by UnstructuredProfiler save

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -884,6 +884,7 @@ class UnstructuredProfiler(BaseProfiler):
 
         # Unstructured specific properties
         self._empty_line_count = 0
+        self.sample = []
 
         if data is not None:
             self.update_profile(data)
@@ -1107,6 +1108,7 @@ class UnstructuredProfiler(BaseProfiler):
         # Create dictionary for all metadata, options, and profile
         data_dict = {
             "total_samples": self.total_samples,
+            "sample": self.sample,
             "encoding": self.encoding,
             "file_type": self.file_type,
             "_samples_per_update": self._samples_per_update,

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1530,6 +1530,11 @@ class TestUnstructuredProfilerWData(unittest.TestCase):
         load_report = load_profile.report()
         self.assertDictEqual(save_report, load_report)
 
+        # Check that sample was properly saved and loaded
+        save_sample = save_profile.sample
+        load_sample = load_profile.sample
+        self.assertEqual(save_sample, load_sample)
+
         # validate both are still usable after
         save_profile.update_profile(pd.DataFrame(['test', 'test2']))
         load_profile.update_profile(pd.DataFrame(['test', 'test2']))

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1493,6 +1493,11 @@ class TestUnstructuredProfilerWData(unittest.TestCase):
             load_report = load_profile.report()
             self.assertDictEqual(save_report, load_report)
 
+            # Check that sample was properly saved and loaded
+            save_sample = save_profile.sample
+            load_sample = load_profile.sample
+            self.assertEqual(save_sample, load_sample)
+
             # validate both are still usable after
             save_profile.update_profile(pd.DataFrame(['test', 'test2']))
             load_profile.update_profile(pd.DataFrame(['test', 'test2']))

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1045,6 +1045,7 @@ class TestUnstructuredProfiler(unittest.TestCase):
         self.assertEqual(0, profiler._empty_line_count)
         self.assertEqual(0.2, profiler._sampling_ratio)
         self.assertEqual(5000, profiler._min_sample_size)
+        self.assertEqual([], profiler.sample)
         self.assertIsInstance(profiler.options, UnstructuredOptions)
 
         # can set samples_per_update and min_true_samples
@@ -1057,6 +1058,7 @@ class TestUnstructuredProfiler(unittest.TestCase):
         data = pd.Series(['this', 'is my', '\n\r', 'test'])
         profiler = UnstructuredProfiler(data)
         self.assertEqual(4, profiler.total_samples)
+        self.assertCountEqual(['this', 'is my', 'test'], profiler.sample)
         self.assertEqual(1, profiler._empty_line_count)
         self.assertEqual("<class 'pandas.core.series.Series'>",
                          profiler.file_type)
@@ -1073,6 +1075,7 @@ class TestUnstructuredProfiler(unittest.TestCase):
 
         profiler = UnstructuredProfiler(mock_data_reader)
         self.assertEqual(4, profiler.total_samples)
+        self.assertCountEqual(['this', 'is my', 'test'], profiler.sample)
         self.assertEqual(1, profiler._empty_line_count)
         self.assertEqual("csv", profiler.file_type)
         self.assertEqual("utf-8", profiler.encoding)


### PR DESCRIPTION
Previous bug had issue where when loading UnstructuredProfiler, `.sample` was not saved (and therefore not loaded) so when trying to do any operations with it you received an AttributeError saying UnstructuredProfiler does not have a 'sample' attribute. This fixes that bug and includes a test inclusion that failed before the inclusion of the bug fix.