### PR TITLE
Add correlation update with NaNs - Impute with mean

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1437,6 +1437,9 @@ class StructuredProfiler(BaseProfiler):
 
         :param clean_samples: the input cleaned dataset
         :type clean_samples: dict()
+        :param batch_properties: mean/std/counts of each batch column necessary
+        for correlation computation
+        :type batch_properties: dict()
         """
         columns = self.options.correlation.columns
         clean_column_ids = []

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1468,14 +1468,14 @@ class StructuredProfiler(BaseProfiler):
         data = data.fillna(value=means)
 
         # Update the counts/std if needed (i.e. if null rows or exist)
-        if (len(data.index) != batch_properties['count']).any():
+        if (len(data) != batch_properties['count']).any():
             adjusted_stds = np.sqrt(
                 batch_properties['std']**2 * (batch_properties['count'] - 1) \
-                / (len(data.index) - 1)
+                / (len(data) - 1)
             )
             batch_properties['std'] = adjusted_stds
         # Set count key to a single number now that everything's been adjusted
-        batch_properties['count'] = len(data.index)
+        batch_properties['count'] = len(data)
 
         # fill correlation matrix with nan initially
         n_cols = len(self._profile)

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1442,7 +1442,9 @@ class StructuredProfiler(BaseProfiler):
         clean_column_ids = []
         if columns is None:
             for idx in range(len(self._profile)):
-                if self._profile[idx].profile['data_type'] not in ['int', 'float']:
+                data_type = self._profile[idx].\
+                    profiles["data_type_profile"].selected_data_type
+                if data_type not in ["int", "float"]:
                     clean_samples.pop(idx)
                 else:
                     clean_column_ids.append(idx)
@@ -1456,26 +1458,8 @@ class StructuredProfiler(BaseProfiler):
         corr_mat = np.full((n_cols, n_cols), np.nan)
 
         # then, fill in the correlations for valid columns
-        for i in range(len(clean_column_ids)):
-            for j in range(i, len(clean_column_ids)):
-                id1 = clean_column_ids[i]
-                id2 = clean_column_ids[j]
-                if id1 == id2:
-                    corr_mat[id1][id2] = 1
-                    corr_mat[id1][id2] = 1
-                    continue
-
-                col1 = data.loc[:, id1]
-                col2 = data.loc[:, id2]
-                std1 = batch_properties['std'][id1]
-                std2 = batch_properties['std'][id2]
-
-                comoment = ((col1 * col2).sum() \
-                            - col1.sum() * col2.sum() / batch_properties['count'])
-                corr = (comoment / (batch_properties['count'] - 1)) / (std1 * std2)
-
-                corr_mat[id1][id2] = corr
-                corr_mat[id2][id1] = corr
+        rows = [[id] for id in clean_column_ids]
+        corr_mat[rows, clean_column_ids] = np.corrcoef(data, rowvar=False)
 
         return corr_mat
 

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -483,33 +483,3 @@ def find_diff_of_dicts(dict1, dict2):
         diff = "unchanged"
 
     return diff
-
-def get_pairwise_corr(data1, data2, mean1, mean2, std1, std2):
-    """
-    Computes the pairwise correlation of the data if the mean and
-    unbiased standard deviation of the respective data is known.
-    One-pass calculation.
-
-    :param data1: The first set of data
-    :type data1: pd.Dataframe
-    :param data2: The second set of data
-    :type data2: pd.Dataframe
-    :param mean1: The mean of the first data
-    :type mean1: float
-    :param mean2: The mean of the second set of data
-    :type mean2: float
-    :param std1: The stddev of the first set of data
-    :type std1: float
-    :param std2: The stddev of the second set of data
-    :type std2: float
-    :return: The correlation
-    :rtype: float
-    """
-    covariance = 0
-    for i1, i2 in zip(data1, data2):
-        if (not np.isnan(i1)) and (not np.isnan(i2)):
-            a = i1 - mean1
-            b = i2 - mean2
-            covariance += a * b
-
-    return (covariance / (len(data1.index) - 1)) / (std1 * std2)

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -483,3 +483,33 @@ def find_diff_of_dicts(dict1, dict2):
         diff = "unchanged"
 
     return diff
+
+def get_pairwise_corr(data1, data2, mean1, mean2, std1, std2):
+    """
+    Computes the pairwise correlation of the data if the mean and
+    unbiased standard deviation of the respective data is known.
+    One-pass calculation.
+
+    :param data1: The first set of data
+    :type data1: pd.Dataframe
+    :param data2: The second set of data
+    :type data2: pd.Dataframe
+    :param mean1: The mean of the first data
+    :type mean1: float
+    :param mean2: The mean of the second set of data
+    :type mean2: float
+    :param std1: The stddev of the first set of data
+    :type std1: float
+    :param std2: The stddev of the second set of data
+    :type std2: float
+    :return: The correlation
+    :rtype: float
+    """
+    covariance = 0
+    for i1, i2 in zip(data1, data2):
+        if (not np.isnan(i1)) and (not np.isnan(i2)):
+            a = i1 - mean1
+            b = i2 - mean2
+            covariance += a * b
+
+    return (covariance / (len(data1.index) - 1)) / (std1 * std2)

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -292,9 +292,10 @@ class TestStructuredProfiler(unittest.TestCase):
             ['test1', 1.0],
             [None, None]])
         profiler = dp.StructuredProfiler(data, options=profile_options)
+        # Even the correlation with itself is NaN because the variance is zero
         expected_corr_mat = np.array([
             [np.nan, np.nan],
-            [np.nan, 1]
+            [np.nan, np.nan]
         ])
         np.testing.assert_array_equal(expected_corr_mat,
                                       profiler.correlation_matrix)

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -547,9 +547,9 @@ class TestStructuredProfiler(unittest.TestCase):
                                              profile.correlation_matrix)
 
         # Data with null rows and some imputed values
-        data = pd.DataFrame({'a': [None, np.nan, 1, 7, 5, 9, 4, 10, np.nan, 2],
-                             'b': [10, 11, 1, 4, 2, 5, 'NaN', 3, np.nan, 8],
-                             'c': [1, 5, 3, 5, np.nan, 2, 6, 8, np.nan, 2]})
+        data = pd.DataFrame({'a': [None, np.nan, 1, 7, 5, 9, 4, 10, 'nan', 2],
+                             'b': [10, 11, 1, 4, 2, 5, 'NaN', 3, None, 8],
+                             'c': [1, 5, 3, 5, np.nan, 2, 6, 8, None, 2]})
         data1 = data[:5]
         data2 = data[5:]
         profile = dp.StructuredProfiler(data1, options=profile_options)
@@ -557,7 +557,7 @@ class TestStructuredProfiler(unittest.TestCase):
         # correlation between [*13/3*, *13/3*, 1, 7, 5]
         #                     [10, 11, 1, 4, 2]
         #                     [1, 5, 3, 5, *7/2*]
-        # then updated with correlation (9th row dropped) btwn
+        # then updated with correlation (9th row dropped) between
         #                     [9, 4, 10, 2],
         #                     [5, *16/3*, 3, 8],
         #                     [2, 6, 8, 2]

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -281,7 +281,7 @@ class TestStructuredProfiler(unittest.TestCase):
         # data with one column with non-numeric calues
         data = pd.DataFrame([1.0, None, 1.0, None, 5.0])
         profiler = dp.StructuredProfiler(data, options=profile_options)
-        expected_corr_mat = np.array([[np.nan]])
+        expected_corr_mat = np.array([[1]])
         np.testing.assert_array_equal(expected_corr_mat,
                                       profiler.correlation_matrix)
 
@@ -294,7 +294,7 @@ class TestStructuredProfiler(unittest.TestCase):
         profiler = dp.StructuredProfiler(data, options=profile_options)
         expected_corr_mat = np.array([
             [np.nan, np.nan],
-            [np.nan, np.nan]
+            [np.nan, 1]
         ])
         np.testing.assert_array_equal(expected_corr_mat,
                                       profiler.correlation_matrix)
@@ -318,13 +318,12 @@ class TestStructuredProfiler(unittest.TestCase):
                              'c': [1, 5, 3, 5, 7, 2, 6, 8, np.nan, np.nan]})
         profiler = dp.StructuredProfiler(data, options=profile_options)
         expected_corr_mat = np.array([
-            [np.nan, np.nan, np.nan],
-            [np.nan, np.nan, np.nan],
-            [np.nan, np.nan, np.nan]
+            [1, -0.28527657, 0.18626508],
+            [-0.28527657, 1, -0.52996792],
+            [0.18626508, -0.52996792, 1]
         ])
-        np.testing.assert_array_equal(expected_corr_mat,
+        np.testing.assert_array_almost_equal(expected_corr_mat,
                                       profiler.correlation_matrix)
-
 
         # data with multiple numerical columns, with nan values in only one column
         data = pd.DataFrame({'a': [np.nan, np.nan, 1, 7, 5, 9, 4, 10, 7, 2],
@@ -332,10 +331,9 @@ class TestStructuredProfiler(unittest.TestCase):
                              'c': [1, 5, 3, 5, 7, 2, 6, 8, 1, 2]})
         profiler = dp.StructuredProfiler(data, options=profile_options)
         expected_corr_mat = np.array([
-            [np.nan, np.nan, np.nan],
-            [np.nan, 1.0, -0.49072329],
-            [np.nan, -0.4907239, 1.0]
-        ])
+            [1, 0.03673504, 0.22844891],
+            [0.03673504, 1, -0.49072329],
+            [0.22844891, -0.49072329, 1]])
         np.testing.assert_array_almost_equal(expected_corr_mat,
                                       profiler.correlation_matrix)
 
@@ -458,6 +456,7 @@ class TestStructuredProfiler(unittest.TestCase):
                                              profile.correlation_matrix)
 
         # Data with multiple numerical and non-numeric columns, with nan values in only one column
+        # NaNs imputed to (9+4+10)/3
         data = pd.DataFrame({'a': [7, 2, 1, 7, 5, 9, 4, 10, np.nan, np.nan],
                              'b': [10, 11, 1, 4, 2, 5, 6, 3, 9, 8],
                              'c': ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
@@ -468,11 +467,11 @@ class TestStructuredProfiler(unittest.TestCase):
         profile = dp.StructuredProfiler(data1, options=profile_options)
         profile.update_profile(data2)
         expected_corr_mat = np.array([
+            [ 1,  0.04721482, np.nan, -0.09383408],
+            [ 0.04721482,  1, np.nan,-0.49072329],
             [np.nan, np.nan, np.nan, np.nan],
-            [np.nan, 1.0, np.nan, -0.4907239],
-            [np.nan, np.nan, np.nan, np.nan],
-            [np.nan, -0.490723290044827, np.nan, 1]
-        ])
+            [-0.09383408, -0.49072329, np.nan, 1]]
+        )
         np.testing.assert_array_almost_equal(expected_corr_mat,
                                              profile.correlation_matrix)
 


### PR DESCRIPTION
This PR enables correlation statistics to be updated with NaNs by replacing the NaN values with the mean of the batch of data the value belongs to.

This is an alternative/more computationally efficient method of handling NaNs in correlation update compared to #338.