### PR TITLE
Allow user to have non-str in pandas passed to Labeler

### DIFF
--- a/dataprofiler/labelers/data_processing.py
+++ b/dataprofiler/labelers/data_processing.py
@@ -1438,7 +1438,7 @@ class StructCharPostprocessor(BaseDataPostprocessor,
             column_labels, sentence = label_sentences
 
             # get count of all labels in prediction
-            column_label_counter = Counter(column_labels[:len(sentence)])
+            column_label_counter = Counter(column_labels[:len(str(sentence))])
             column_label_counter.pop(ignore_value, None)
             modes = [entity_id for entity_id, count in
                      column_label_counter.most_common() if

--- a/dataprofiler/labelers/data_processing.py
+++ b/dataprofiler/labelers/data_processing.py
@@ -1434,11 +1434,11 @@ class StructCharPostprocessor(BaseDataPostprocessor,
         if 'conf' in results:
             confs_out = np.zeros((len(results['pred']), num_labels))
 
-        for i, label_sentences in enumerate(zip(results['pred'], sentences)):
-            column_labels, sentence = label_sentences
+        for i, label_samples in enumerate(zip(results['pred'], sentences)):
+            column_labels, sample = label_samples
 
             # get count of all labels in prediction
-            column_label_counter = Counter(column_labels[:len(str(sentence))])
+            column_label_counter = Counter(column_labels[:len(str(sample))])
             column_label_counter.pop(ignore_value, None)
             modes = [entity_id for entity_id, count in
                      column_label_counter.most_common() if

--- a/dataprofiler/tests/labelers/test_integration_struct_data_labeler.py
+++ b/dataprofiler/tests/labelers/test_integration_struct_data_labeler.py
@@ -63,6 +63,14 @@ class TestStructuredDataLabeler(unittest.TestCase):
         # validate epoch id
         self.assertEqual(2, default.model._epoch_id)
 
+    def test_labeling_mixed_df(self):
+        labeler = dp.labelers.StructuredDataLabeler()
+
+        # test int, float, str, dict
+        data = pd.DataFrame([1, 1.1, 'string', {'random': 3}])
+        predictions = labeler.predict(data)
+        self.assertEqual(4, len(predictions['pred']))
+
     def test_data_labeler_change_labels(self):
         """test changing labels of data labeler with fitting data"""
         # constructing default StructuredDataLabeler()
@@ -390,6 +398,7 @@ class TestStructuredDataLabeler(unittest.TestCase):
         profile2 = dp.StructuredProfiler(data, options=profile_options)
 
         profile1.update_profile(data)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently, the structured labeler can only accept datasets which have been converted to string prior to entering the labeler. This PR resolves that issue by converting it internally for evaluation.

```python
import pandas as pd

import dataprofiler as dp

# previously not possible because it could not take in non-str dataframes
labeler = dp.DataLabeler(labeler_type='structured')
preds = labeler.predict(pd.DataFrame([1, 22, 3, 4]))
```