### PR TITLE
Abstract timeit function to allow other classes in the library to utilize the timeit property

### DIFF
--- a/dataprofiler/profilers/base_column_profilers.py
+++ b/dataprofiler/profilers/base_column_profilers.py
@@ -80,25 +80,7 @@ class BaseColumnProfiler(with_metaclass(abc.ABCMeta, object)):
         :param name: key argument for the times dictionary
         :type name: str
         """
-
-        def decorator(method, name_dec=None):
-            @functools.wraps(method)
-            def wrapper(self, *args, **kw):
-                # necessary bc can't reassign external name
-                name_dec = name
-                if not name_dec:
-                    name_dec = method.__name__
-                ts = time.time()
-                result = method(self, *args, **kw)
-                te = time.time()
-                self.times[name_dec] += (te - ts)
-                return result
-
-            return wrapper
-
-        if callable(method):
-            return decorator(method, name_dec=name)
-        return decorator
+        return utils.method_timeit(method, name)
 
     @staticmethod
     def _filter_properties_w_options(calculations, options):

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -908,10 +908,11 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
                                      "biased_kurtosis": self._biased_kurtosis}
         subset_properties = copy.deepcopy(profile)
         df_series_clean = df_series_clean.astype(float)
-        super(NumericStatsMixin, self)._perform_property_calcs(self.__calculations,
-                                     df_series=df_series_clean,
-                                     prev_dependent_properties=prev_dependent_properties,
-                                     subset_properties=subset_properties)
+        super(NumericStatsMixin, self)._perform_property_calcs(
+            self.__calculations,
+            df_series=df_series_clean,
+            prev_dependent_properties=prev_dependent_properties,
+            subset_properties=subset_properties)
         if len(self._batch_history) == 5:
             self._batch_history.pop(0)
         self._batch_history.append(subset_properties)

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -723,7 +723,6 @@ class CategoricalOptions(BaseInspectorOptions):
         return errors
 
 
-
 class CorrelationOptions(BaseInspectorOptions):
 
     def __init__(self, is_enabled=False, columns=None):

--- a/dataprofiler/profilers/unstructured_labeler_profile.py
+++ b/dataprofiler/profilers/unstructured_labeler_profile.py
@@ -6,6 +6,7 @@ from ..labelers.data_processing import CharPostprocessor
 from .profiler_options import DataLabelerOptions
 from . import utils
 
+
 class UnstructuredLabelerProfile(object):
 
     type = "data_labeler"
@@ -252,8 +253,10 @@ class UnstructuredLabelerProfile(object):
             index = 0
             for entity in entities:
                 char_label_counts['UNKNOWN'] += (entity[0] - index)
+
                 #Add entity char count
                 char_label_counts[entity[2]] += (entity[1] - entity[0])
+
                 #Update index
                 index = entity[1]
 

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -1,12 +1,15 @@
-import datetime
 import os
+import time
+import datetime
 import collections
 import copy
 import math
 import warnings
 import psutil
-import numpy as np
 import multiprocessing as mp
+import functools
+
+import numpy as np
 
 from dataprofiler import settings
 
@@ -250,6 +253,7 @@ def overlap(x1, x2, y1, y2):
             (x1 <= y1 <= x2) or
             (x1 <= y2 <= x2))
 
+
 def add_nested_dictionaries(first_dict, second_dict):
     """
     Merges two dictionaries together and adds values together
@@ -279,6 +283,7 @@ def add_nested_dictionaries(first_dict, second_dict):
             merged_dict[item] = copy.deepcopy(second_dict[item])
 
     return merged_dict
+
 
 def biased_skew(df_series):
     """
@@ -314,6 +319,7 @@ def biased_skew(df_series):
 
     skew = np.sqrt(n) * M3 / M2 ** 1.5
     return skew
+
 
 def biased_kurt(df_series):
     """
@@ -483,3 +489,35 @@ def find_diff_of_dicts(dict1, dict2):
         diff = "unchanged"
 
     return diff
+
+
+def method_timeit(method=None, name=None):
+    """
+    Measure execution time of provided method
+    Records time into times dictionary
+
+    :param method: method to time
+    :type method: Callable
+    :param name: key argument for the times dictionary
+    :type name: str
+    """
+
+    def decorator(method, name_dec=None):
+        @functools.wraps(method)
+        def wrapper(self, *args, **kw):
+            # necessary bc can't reassign external name
+            name_dec = name
+            if not name_dec:
+                name_dec = method.__name__
+            ts = time.time()
+            result = method(self, *args, **kw)
+            te = time.time()
+            self.times[name_dec] += (te - ts)
+            return result
+
+        return wrapper
+
+    if callable(method):
+        return decorator(method, name_dec=name)
+    return decorator
+

--- a/dataprofiler/tests/profilers/test_column_profile_compilers.py
+++ b/dataprofiler/tests/profilers/test_column_profile_compilers.py
@@ -70,7 +70,6 @@ class TestBaseProfileCompilerClass(unittest.TestCase):
         merged_compiler = compiler1 + compiler2
         self.assertEqual(3, merged_compiler._profiles['test'])
         self.assertEqual('compiler1', merged_compiler.name)
-
     
     def test_diff_primitive_compilers(self):
         # Test different data types

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -876,7 +876,7 @@ class TestFloatColumn(unittest.TestCase):
         profiler.update(df)
         self.assertEqual(4, profiler.precision['sample_size'])
 
-        # Trun on precision, set 0.5 sample_size
+        # Turn on precision, set 0.5 sample_size
         options = FloatOptions()
         options.set({"precision.sample_ratio": 0.5})
         profiler = FloatColumn(df.name, options=options)


### PR DESCRIPTION
To allow for other classes besides those which have a super class of `BaseColumnProfiler`, this PR abstracts it out. Future releases will add time it to `StructuredProfiler` and `UnstructuredProfiler` such that functions like correlations can be timed.