### PR TITLE
Add timing of profiles to StructuredProfiler and UnstructuredProfiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The format for a structured profile is below:
     "profile_schema": {
         string: list(int)
     },
+    "times": dict[string, float],
 },
 "data_stats": [
     {
@@ -133,6 +134,7 @@ The format for an unstructured profile is below:
     "file_type": string,
     "encoding": string,
     "memory_size": float, # in MB
+    "times": dict[string, float],
 },
 "data_stats": {
     "data_label": {

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1658,10 +1658,9 @@ class TestUnstructuredProfiler(unittest.TestCase):
         data = pd.Series(['here\n', '\t    ', 'a', ' is', '\n\r', 'more data'])
 
         # needed bc _clean_data_and_get_base_stats is not static
-        class TestProfiler:
-            # for timeit which wraps this func and uses the class
-            times = {'clean_and_base_stats': 0}
-        profiler = TestProfiler()
+        # for timeit which wraps this func and uses the class
+        profiler = mock.Mock(spec=UnstructuredProfiler)
+        profiler.times = {'clean_and_base_stats': 0}
 
         # case when min_true_samples not set and subset of data
         df_series, base_stats = \

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -51,8 +51,9 @@ class TestStructuredProfiler(unittest.TestCase):
         cls.aws_dataset = pd.read_csv(cls.input_file_path)
         profiler_options = ProfilerOptions()
         profiler_options.set({'data_labeler.is_enabled': False})
-        cls.trained_schema = dp.StructuredProfiler(cls.aws_dataset, len(cls.aws_dataset),
-                                                   options=profiler_options)
+        with test_utils.mock_timeit():
+            cls.trained_schema = dp.StructuredProfiler(
+                cls.aws_dataset, len(cls.aws_dataset), options=profiler_options)
 
     @mock.patch('dataprofiler.profilers.profile_builder.'
                 'ColumnPrimitiveTypeProfileCompiler')
@@ -86,7 +87,8 @@ class TestStructuredProfiler(unittest.TestCase):
                 'StructuredProfiler._update_correlation')
     def test_list_data(self, *mocks):
         data = [1, None, 3, 4, 5, None, 1]
-        profiler = dp.StructuredProfiler(data)
+        with test_utils.mock_timeit():
+            profiler = dp.StructuredProfiler(data)
 
         # test properties
         self.assertEqual("<class 'list'>", profiler.file_type)
@@ -97,6 +99,7 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(5, len(profiler.hashed_row_dict))
         self.assertListEqual([0], list(profiler._col_name_to_idx.keys()))
         self.assertIsNone(profiler.correlation_matrix)
+        self.assertDictEqual({'row_stats': 1}, profiler.times)
 
     @mock.patch('dataprofiler.profilers.profile_builder.'
                 'ColumnPrimitiveTypeProfileCompiler')
@@ -110,7 +113,8 @@ class TestStructuredProfiler(unittest.TestCase):
                 'StructuredProfiler._update_correlation')
     def test_pandas_series_data(self, *mocks):
         data = pd.Series([1, None, 3, 4, 5, None, 1])
-        profiler = dp.StructuredProfiler(data)
+        with test_utils.mock_timeit():
+            profiler = dp.StructuredProfiler(data)
 
         # test properties
         self.assertEqual(
@@ -122,6 +126,7 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(5, len(profiler.hashed_row_dict))
         self.assertListEqual([0], list(profiler._col_name_to_idx.keys()))
         self.assertIsNone(profiler.correlation_matrix)
+        self.assertDictEqual({'row_stats': 1}, profiler.times)
 
         # test properties when series has name
         data.name = 'test'
@@ -150,8 +155,9 @@ class TestStructuredProfiler(unittest.TestCase):
                 'StructuredProfiler._merge_correlation')
     def test_add_profilers(self, *mocks):
         data = pd.DataFrame([1, None, 3, 4, 5, None, 1])
-        profile1 = dp.StructuredProfiler(data[:2])
-        profile2 = dp.StructuredProfiler(data[2:])
+        with test_utils.mock_timeit():
+            profile1 = dp.StructuredProfiler(data[:2])
+            profile2 = dp.StructuredProfiler(data[2:])
 
         # test incorrect type
         with self.assertRaisesRegex(TypeError,
@@ -191,6 +197,7 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(2, merged_profile.row_is_null_count)
         self.assertEqual(7, merged_profile.total_samples)
         self.assertEqual(5, len(merged_profile.hashed_row_dict))
+        self.assertDictEqual({'row_stats': 2}, merged_profile.times)
 
         # test success if drawn from multiple files
         profile2.encoding = 'test'
@@ -221,15 +228,18 @@ class TestStructuredProfiler(unittest.TestCase):
             ['test3', 7.0]])
 
         # check prior to update
-        profiler = dp.StructuredProfiler(data[:3])
+        with test_utils.mock_timeit():
+            profiler = dp.StructuredProfiler(data[:3])
         self.assertEqual(1, profiler.row_has_null_count)
         self.assertEqual(0, profiler.row_is_null_count)
         self.assertEqual(3, profiler.total_samples)
         self.assertEqual(2, len(profiler.hashed_row_dict))
         self.assertIsNone(profiler.correlation_matrix)
+        self.assertDictEqual({'row_stats': 1}, profiler.times)
 
         # check after update
-        profiler.update_profile(data[3:])
+        with test_utils.mock_timeit():
+            profiler.update_profile(data[3:])
 
         self.assertIsNone(profiler.encoding)
         self.assertEqual(
@@ -239,6 +249,7 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(8, profiler.total_samples)
         self.assertEqual(5, len(profiler.hashed_row_dict))
         self.assertIsNone(profiler.correlation_matrix)
+        self.assertDictEqual({'row_stats': 2}, profiler.times)
 
     def test_correct_unique_row_ratio_test(self):
         self.assertEqual(2999, len(self.trained_schema.hashed_row_dict))
@@ -273,10 +284,12 @@ class TestStructuredProfiler(unittest.TestCase):
 
         # data with a sole numeric column
         data = pd.DataFrame([1.0, 8.0, 1.0, -2.0, 5.0])
-        profiler = dp.StructuredProfiler(data, options=profile_options)
+        with test_utils.mock_timeit():
+            profiler = dp.StructuredProfiler(data, options=profile_options)
         expected_corr_mat = np.array([[1.0]])
         np.testing.assert_array_equal(expected_corr_mat,
                                       profiler.correlation_matrix)
+        self.assertDictEqual({'row_stats': 1, 'correlation': 1}, profiler.times)
 
         # data with one column with non-numeric calues
         data = pd.DataFrame([1.0, None, 1.0, None, 5.0])
@@ -326,7 +339,8 @@ class TestStructuredProfiler(unittest.TestCase):
         np.testing.assert_array_almost_equal(expected_corr_mat,
                                       profiler.correlation_matrix)
 
-        # data with multiple numerical columns, with nan values in only one column
+        # data with multiple numerical columns, with nan values in only one
+        # column
         data = pd.DataFrame({'a': [np.nan, np.nan, 1, 7, 5, 9, 4, 10, 7, 2],
                              'b': [10, 11, 1, 4, 2, 5, 6, 3, 9, 8],
                              'c': [1, 5, 3, 5, 7, 2, 6, 8, 1, 2]})
@@ -421,8 +435,9 @@ class TestStructuredProfiler(unittest.TestCase):
         data1 = data[:5]
         data2 = data[5:]
 
-        profile1 = dp.StructuredProfiler(data1, options=profile_options)
-        profile2 = dp.StructuredProfiler(data2, options=profile_options)
+        with test_utils.mock_timeit():
+            profile1 = dp.StructuredProfiler(data1, options=profile_options)
+            profile2 = dp.StructuredProfiler(data2, options=profile_options)
         merged_profile = profile1 + profile2
 
         expected_corr_mat = np.array([
@@ -432,10 +447,13 @@ class TestStructuredProfiler(unittest.TestCase):
         ])
         np.testing.assert_array_almost_equal(expected_corr_mat,
                                    merged_profile.correlation_matrix)
+        self.assertDictEqual({'row_stats': 2, 'correlation': 2},
+                             merged_profile.times)
 
         # merge between an existing corr and None correlation (without data)
-        profile1 = dp.StructuredProfiler(None, options=profile_options)
-        profile2 = dp.StructuredProfiler(data, options=profile_options)
+        with test_utils.mock_timeit():
+            profile1 = dp.StructuredProfiler(None, options=profile_options)
+            profile2 = dp.StructuredProfiler(data, options=profile_options)
         # TODO: remove the mock below when merge profile is update
         with mock.patch('dataprofiler.profilers.profile_builder.'
                         'StructuredProfiler._add_error_checks'):
@@ -448,6 +466,8 @@ class TestStructuredProfiler(unittest.TestCase):
         ])
         np.testing.assert_array_almost_equal(expected_corr_mat,
                                       merged_profile.correlation_matrix)
+        self.assertDictEqual({'row_stats': 1, 'correlation': 1},
+                             merged_profile.times)
 
         # Merge between existing data and empty data that still has samples
         data = pd.DataFrame({'a': [1, 2, 4, np.nan, None, np.nan],
@@ -478,8 +498,9 @@ class TestStructuredProfiler(unittest.TestCase):
         data1 = data[:5]
         data2 = data[5:]
 
-        profile = dp.StructuredProfiler(data1, options=profile_options)
-        profile.update_profile(data2)
+        with test_utils.mock_timeit():
+            profiler = dp.StructuredProfiler(data1, options=profile_options)
+            profiler.update_profile(data2)
 
         expected_corr_mat = np.array([
             [1.0, -0.26559388521279237, 0.26594894270403086],
@@ -487,7 +508,8 @@ class TestStructuredProfiler(unittest.TestCase):
             [0.26594894270403086, -0.4907239, 1.0]
         ])
         np.testing.assert_array_almost_equal(expected_corr_mat,
-                                             profile.correlation_matrix)
+                                             profiler.correlation_matrix)
+        self.assertDictEqual({'row_stats': 2, 'correlation': 2}, profiler.times)
 
         # Test when there's a non-numeric column
         data = pd.DataFrame({'a': [3, 2, 1, 7, 5, 9, 4, 10, 7, 2],
@@ -496,8 +518,8 @@ class TestStructuredProfiler(unittest.TestCase):
         data1 = data[:5]
         data2 = data[5:]
 
-        profile = dp.StructuredProfiler(data1, options=profile_options)
-        profile.update_profile(data2)
+        profiler = dp.StructuredProfiler(data1, options=profile_options)
+        profiler.update_profile(data2)
 
         expected_corr_mat = np.array([
             [1.0, -0.26559388521279237, np.nan],
@@ -505,7 +527,7 @@ class TestStructuredProfiler(unittest.TestCase):
             [np.nan, np.nan, np.nan]
         ])
         np.testing.assert_array_almost_equal(expected_corr_mat,
-                                             profile.correlation_matrix)
+                                             profiler.correlation_matrix)
 
         # Data with multiple numerical and non-numeric columns, with nan values in only one column
         # NaNs imputed to (9+4+10)/3
@@ -516,8 +538,8 @@ class TestStructuredProfiler(unittest.TestCase):
         data1 = data[:5]
         data2 = data[5:]
 
-        profile = dp.StructuredProfiler(data1, options=profile_options)
-        profile.update_profile(data2)
+        profiler = dp.StructuredProfiler(data1, options=profile_options)
+        profiler.update_profile(data2)
         expected_corr_mat = np.array([
             [ 1,  0.04721482, np.nan, -0.09383408],
             [ 0.04721482,  1, np.nan,-0.49072329],
@@ -544,7 +566,7 @@ class TestStructuredProfiler(unittest.TestCase):
             [0.32423975, -0.3613099, 1]
         ])
         np.testing.assert_array_almost_equal(expected_corr_mat,
-                                             profile.correlation_matrix)
+                                             profiler.correlation_matrix)
 
         # Data with null rows and some imputed values
         data = pd.DataFrame({'a': [None, np.nan, 1, 7, 5, 9, 4, 10, 'nan', 2],
@@ -629,13 +651,16 @@ class TestStructuredProfiler(unittest.TestCase):
                 "samples_used", "column_count", "row_count",
                 "row_has_null_ratio", 'row_is_null_ratio',
                 "unique_row_ratio", "duplicate_row_count", "file_type",
-                "encoding", "correlation_matrix", "profile_schema"
+                "encoding", "correlation_matrix", "profile_schema", "times"
             ]
         )
-        flat_report = self.trained_schema.report(report_options={"output_format":"flat"})
+        flat_report = self.trained_schema.report(
+            report_options={"output_format": "flat"})
         self.assertEqual(test_utils.get_depth(flat_report), 1)
-        with mock.patch('dataprofiler.profilers.helpers.report_helpers._prepare_report') as pr_mock:
-            self.trained_schema.report(report_options={"output_format":'pretty'})
+        with mock.patch('dataprofiler.profilers.helpers.report_helpers'
+                        '._prepare_report') as pr_mock:
+            self.trained_schema.report(
+                report_options={"output_format": 'pretty'})
             # Once for global_stats, once for each of 16 columns
             self.assertEqual(pr_mock.call_count, 17)
 
@@ -732,7 +757,6 @@ class TestStructuredProfiler(unittest.TestCase):
 
         for col_report in report["data_stats"]:
             self.assertIsNone(col_report)
-
 
     def test_report_quantiles(self):
         report_none = self.trained_schema.report(
@@ -1497,6 +1521,7 @@ class TestUnstructuredProfiler(unittest.TestCase):
         self.assertEqual(5000, profiler._min_sample_size)
         self.assertEqual([], profiler.sample)
         self.assertIsInstance(profiler.options, UnstructuredOptions)
+        self.assertDictEqual({}, profiler.times)
 
         # can set samples_per_update and min_true_samples
         profiler = UnstructuredProfiler(None, samples_per_update=10,
@@ -1515,6 +1540,7 @@ class TestUnstructuredProfiler(unittest.TestCase):
                          profiler.file_type)
         self.assertIsNone(profiler.encoding)
         self.assertIsInstance(profiler._profile, UnstructuredCompiler)
+        self.assertIn('clean_and_base_stats', profiler.times)
 
         # can properties update correctly for data loaded from file
         data = pd.Series(['this', 'is my', '\n\r', 'test'])
@@ -1582,15 +1608,20 @@ class TestUnstructuredProfiler(unittest.TestCase):
         data2 = pd.Series(['here\n', '\t    ', ' ', ' is', '\n\r', 'more data'])
 
         # create profilers
-        profiler1 = UnstructuredProfiler(data1)
-        profiler2 = UnstructuredProfiler(data2)
+        with test_utils.mock_timeit():
+            profiler1 = UnstructuredProfiler(data1)
+            profiler2 = UnstructuredProfiler(data2)
+
+        self.assertDictEqual({'clean_and_base_stats': 1}, profiler1.times)
+        self.assertDictEqual({'clean_and_base_stats': 1}, profiler2.times)
 
         # mock out _profile
         profiler1._profile = 1
         profiler2._profile = 2
 
         # merge profilers
-        merged_profile = profiler1 + profiler2
+        with test_utils.mock_timeit():
+            merged_profile = profiler1 + profiler2
         self.assertEqual(10, merged_profile.total_samples)
         self.assertEqual(4, merged_profile._empty_line_count)
         self.assertEqual(40 / 1024 ** 2, merged_profile.memory_size)
@@ -1598,6 +1629,7 @@ class TestUnstructuredProfiler(unittest.TestCase):
         self.assertCountEqual(['this', ' is', 'here\n', 'more data', 'is my'],
                               merged_profile.sample)
         self.assertEqual(3, merged_profile._profile)
+        self.assertDictEqual({'clean_and_base_stats': 2}, merged_profile.times)
 
     def test_get_sample_size(self, *mocks):
         data = pd.DataFrame([0] * int(50e3))
@@ -1625,10 +1657,16 @@ class TestUnstructuredProfiler(unittest.TestCase):
     def test_clean_data_and_get_base_stats(self, *mocks):
         data = pd.Series(['here\n', '\t    ', 'a', ' is', '\n\r', 'more data'])
 
+        # needed bc _clean_data_and_get_base_stats is not static
+        class TestProfiler:
+            # for timeit which wraps this func and uses the class
+            times = {'clean_and_base_stats': 0}
+        profiler = TestProfiler()
+
         # case when min_true_samples not set and subset of data
         df_series, base_stats = \
             UnstructuredProfiler._clean_data_and_get_base_stats(
-                data=data, sample_size=3)
+                profiler, data=data, sample_size=3)
 
         # note: bc the sample size is 3, only a subset of the data was sampled
         self.assertTrue(np.issubdtype(np.object_, df_series.dtype))
@@ -1644,7 +1682,7 @@ class TestUnstructuredProfiler(unittest.TestCase):
         # case when min_true_samples set and subset of data
         df_series, base_stats = \
             UnstructuredProfiler._clean_data_and_get_base_stats(
-                data=data, sample_size=3, min_true_samples=2)
+                profiler, data=data, sample_size=3, min_true_samples=2)
 
         # note: bc the sample size is 3, only a subset of the data was sampled
         self.assertTrue(np.issubdtype(np.object_, df_series.dtype))
@@ -1663,20 +1701,24 @@ class TestUnstructuredProfiler(unittest.TestCase):
         data2 = pd.Series(['here\n', '\t    ', ' ', ' is', '\n\r', 'more data'])
 
         # profiler with first dataset
-        profiler = UnstructuredProfiler(data1)
+        with test_utils.mock_timeit():
+            profiler = UnstructuredProfiler(data1)
         self.assertEqual(4, profiler.total_samples)
         self.assertEqual(1, profiler._empty_line_count)
         self.assertEqual(15 / 1024 ** 2, profiler.memory_size)
         # note how sample doesn't include whitespace lines
         self.assertCountEqual(['this', 'is my', 'test'], profiler.sample)
+        self.assertDictEqual({'clean_and_base_stats': 1}, profiler.times)
 
         # update with second dataset
-        profiler.update_profile(data2)
+        with test_utils.mock_timeit():
+            profiler.update_profile(data2)
         self.assertEqual(10, profiler.total_samples)
         self.assertEqual(4, profiler._empty_line_count)
         self.assertEqual(40 / 1024 ** 2, profiler.memory_size)
         # note how sample doesn't include whitespace lines
         self.assertCountEqual(['here\n', ' is', 'more data'], profiler.sample)
+        self.assertDictEqual({'clean_and_base_stats': 2}, profiler.times)
 
 
 class TestUnstructuredProfilerWData(unittest.TestCase):
@@ -1715,12 +1757,14 @@ class TestUnstructuredProfilerWData(unittest.TestCase):
         profiler_options = ProfilerOptions()
         profiler_options.set({'data_labeler.is_enabled': False})
 
-        cls.profiler = UnstructuredProfiler(
-            cls.dataset, len(cls.dataset), options=profiler_options)
-        cls.profiler2 = UnstructuredProfiler(
-            pd.DataFrame(['extra', '\n', 'test\n', 'data .', 'For merging.']),
-            options=profiler_options
-        )
+        with test_utils.mock_timeit():
+            cls.profiler = UnstructuredProfiler(
+                cls.dataset, len(cls.dataset), options=profiler_options)
+            cls.profiler2 = UnstructuredProfiler(
+                pd.DataFrame(['extra', '\n', 'test\n', 'data .',
+                              'For merging.']),
+                options=profiler_options
+            )
         cls.report = cls.profiler.report()
 
     def test_sample(self):
@@ -1745,10 +1789,6 @@ class TestUnstructuredProfilerWData(unittest.TestCase):
         self.assertEqual(393 / 1024 ** 2, self.profiler.memory_size)
 
     def test_text_profiler_results(self):
-        # pop out times
-        self.assertIsNotNone(
-            self.report['data_stats']['statistics'].pop('times'))
-
         # vocab order doesn't matter
         expected_vocab = ['x', 'i', 'y', 's', '9', ',', 'u', 'b', 'f', 'Y', 'J',
                           'v', 'r', 'o', 'a', '6', 'n', 'h', ' ', 'g', 'R', 't',
@@ -1801,12 +1841,15 @@ class TestUnstructuredProfilerWData(unittest.TestCase):
                 'empty_line_count': 7,
                 'memory_size': 393 / 1024 ** 2,
                 'file_type': "<class 'pandas.core.frame.DataFrame'>",
-                'encoding': None},
+                'encoding': None,
+                'times': {'clean_and_base_stats': 1}
+            },
             'data_stats': {
                 'data_label': {},
                 'statistics': {
                     'word_count': expected_word_count,
-                    'vocab_count': expected_vocab_count
+                    'vocab_count': expected_vocab_count,
+                    'times': {'words': 1, 'vocab': 1},
                 }
             }
         }
@@ -2178,8 +2221,8 @@ class TestStructuredProfilerNullValues(unittest.TestCase):
         opts.structured_options.multiprocess.is_enabled = False
 
         # When setting min true samples/samples per update
-        profile = dp.StructuredProfiler(data1, min_true_samples=2, samples_per_update=2,
-                                        options=opts)
+        profile = dp.StructuredProfiler(data1, min_true_samples=2,
+                                        samples_per_update=2, options=opts)
         self.assertEqual(3, profile.row_has_null_count)
         self.assertEqual(1, profile.row_is_null_count)
         self.assertEqual(0.75, profile._get_row_has_null_ratio())

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -324,7 +324,7 @@ class TestStructuredProfiler(unittest.TestCase):
             [0.26594894270403086, -0.49072329, 1.0]
         ])
         np.testing.assert_array_almost_equal(expected_corr_mat,
-                                      profiler.correlation_matrix)
+                                             profiler.correlation_matrix)
 
         # data with multiple numerical columns, with nan values
         data = pd.DataFrame({'a': [np.nan, np.nan, 1, 7, 5, 9, 4, 10, 7, 2],
@@ -337,7 +337,7 @@ class TestStructuredProfiler(unittest.TestCase):
             [0.18626508, -0.52996792, 1]
         ])
         np.testing.assert_array_almost_equal(expected_corr_mat,
-                                      profiler.correlation_matrix)
+                                             profiler.correlation_matrix)
 
         # data with multiple numerical columns, with nan values in only one
         # column
@@ -350,7 +350,7 @@ class TestStructuredProfiler(unittest.TestCase):
             [0.03673504, 1, -0.49072329],
             [0.22844891, -0.49072329, 1]])
         np.testing.assert_array_almost_equal(expected_corr_mat,
-                                      profiler.correlation_matrix)
+                                             profiler.correlation_matrix)
 
         # data with only one numerical columns without nan values
         data = pd.DataFrame({'a': [3, 2, 1, 7, 5, 9, 4, 10, 7, 2]})
@@ -446,7 +446,7 @@ class TestStructuredProfiler(unittest.TestCase):
             [0.26594894270403086, -0.49072329, 1.0]
         ])
         np.testing.assert_array_almost_equal(expected_corr_mat,
-                                   merged_profile.correlation_matrix)
+                                             merged_profile.correlation_matrix)
         self.assertDictEqual({'row_stats': 2, 'correlation': 2},
                              merged_profile.times)
 
@@ -465,7 +465,7 @@ class TestStructuredProfiler(unittest.TestCase):
             [0.26594894270403086, -0.4907239, 1.0]
         ])
         np.testing.assert_array_almost_equal(expected_corr_mat,
-                                      merged_profile.correlation_matrix)
+                                             merged_profile.correlation_matrix)
         self.assertDictEqual({'row_stats': 1, 'correlation': 1},
                              merged_profile.times)
 
@@ -547,7 +547,7 @@ class TestStructuredProfiler(unittest.TestCase):
             [-0.09383408, -0.49072329, np.nan, 1]]
         )
         np.testing.assert_array_almost_equal(expected_corr_mat,
-                                             profile.correlation_matrix)
+                                             profiler.correlation_matrix)
 
         # Data with null rows, all null rows are dropped
         data = pd.DataFrame({'a': [np.nan, 2, 1, None, 5, np.nan, 4, 10, 7, 'NaN'],
@@ -555,8 +555,8 @@ class TestStructuredProfiler(unittest.TestCase):
                              'c': [np.nan, 5, 3, np.nan, 7, None, 6, 8, 1, np.nan]})
         data1 = data[:5]
         data2 = data[5:]
-        profile = dp.StructuredProfiler(data1, options=profile_options)
-        profile.update_profile(data2)
+        profiler = dp.StructuredProfiler(data1, options=profile_options)
+        profiler.update_profile(data2)
         # correlation between [2, 1, 5, 4, 10, 7],
         #                     [11, 1, 2, 6, 3, 9],
         #                     [5, 3, 7, 6, 8, 1]
@@ -574,8 +574,8 @@ class TestStructuredProfiler(unittest.TestCase):
                              'c': [1, 5, 3, 5, np.nan, 2, 6, 8, None, 2]})
         data1 = data[:5]
         data2 = data[5:]
-        profile = dp.StructuredProfiler(data1, options=profile_options)
-        profile.update_profile(data2)
+        profiler = dp.StructuredProfiler(data1, options=profile_options)
+        profiler.update_profile(data2)
         # correlation between [*13/3*, *13/3*, 1, 7, 5]
         #                     [10, 11, 1, 4, 2]
         #                     [1, 5, 3, 5, *7/2*]
@@ -589,7 +589,7 @@ class TestStructuredProfiler(unittest.TestCase):
             [0.43658332, -0.2801748, 1]
         ])
         np.testing.assert_array_almost_equal(expected_corr_mat,
-                                             profile.correlation_matrix)
+                                             profiler.correlation_matrix)
 
     def test_correct_datatime_schema_test(self):
         profile_idx = self.trained_schema._col_name_to_idx["datetime"][0]
@@ -879,7 +879,7 @@ class TestStructuredProfiler(unittest.TestCase):
         )
         with self.assertRaisesRegex(TypeError, 'Cannot provide TextData object'
                                                ' to StructuredProfiler'):
-            profile = dp.StructuredProfiler(dp.Data(text_file_path))
+            profiler = dp.StructuredProfiler(dp.Data(text_file_path))
 
     @mock.patch('dataprofiler.profilers.profile_builder.'
                 'StructuredProfiler._update_correlation')

--- a/dataprofiler/tests/profilers/utils.py
+++ b/dataprofiler/tests/profilers/utils.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import random
 import json
+from unittest import mock
 
 import numpy as np
 
@@ -132,3 +133,13 @@ def clean_report(report):
                 stats["histogram"]["bin_edges"] = \
                     stats["histogram"]["bin_edges"].tolist()
     return report
+
+
+def mock_timeit(*args, **kwargs):
+    def increment_counter():
+        counter = 0
+        while True:
+            counter += 1
+            yield counter
+    counter = increment_counter()
+    return mock.patch('time.time', side_effect=lambda: next(counter))

--- a/dataprofiler/tests/profilers/utils.py
+++ b/dataprofiler/tests/profilers/utils.py
@@ -136,6 +136,10 @@ def clean_report(report):
 
 
 def mock_timeit(*args, **kwargs):
+    """
+    Creates a mock for the time.time function that increments the time for
+    every call.
+    """
     def increment_counter():
         counter = 0
         while True:


### PR DESCRIPTION
Adds timeit to `StructuredProfiler` and `UnstructuredProfiler` for the following calculations in each.
StructuredProfiler: correlations, row stats
UnstructuredProfiler: getting null values and base stats