### PR TITLE
Update to Structured throughput changes for new timing in StructuredProfiler

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1235,7 +1235,9 @@ class StructuredProfiler(BaseProfiler):
         merged_profile._col_name_to_idx = copy.deepcopy(self._col_name_to_idx)
 
         # merge correlation
-        merged_profile.correlation_matrix = self._merge_correlation(other)
+        if (self.options.correlation.is_enabled
+                and other.options.correlation.is_enabled):
+            merged_profile.correlation_matrix = self._merge_correlation(other)
 
         return merged_profile
 

--- a/dataprofiler/tests/speed_tests/structured_throughput_testing.py
+++ b/dataprofiler/tests/speed_tests/structured_throughput_testing.py
@@ -105,6 +105,23 @@ if __name__ == "__main__":
             }
             profile_times += [column_profile_time]
 
+        # add time for for Top-level
+        if sample_size:
+            profile_times += [
+                {
+                    'name': 'StructuredProfiler',
+                    'sample_size': sample_size,
+                    'total_time': total_time,
+                    'column': profiler.times,
+                    'merge': merge_time,
+                    'percent_to_nan': PERCENT_TO_NAN,
+                    'allow_subsampling': ALLOW_SUBSAMPLING,
+                    'is_data_labeler':
+                        options.structured_options.data_labeler.is_enabled,
+                    'is_multiprocessing':
+                        options.structured_options.multiprocess.is_enabled,
+                }
+            ]
         
         print(f"COMPLETE sample size: {sample_size}")
         print(f"Profiled in {total_time} seconds")


### PR DESCRIPTION
Structured profiler is now included in the output of the timing report
e.g.
`StructuredProfiler.row_stats`
`StructuredProfiler.correlations`