### PR TITLE
Allow internal data function calls directly from our data class

### DIFF
--- a/dataprofiler/data_readers/base_data.py
+++ b/dataprofiler/data_readers/base_data.py
@@ -172,3 +172,32 @@ class BaseData(object):
         :return: length of the dataset
         """
         return len(self)
+
+    def __getattribute__(self, name):
+        """
+        Overrides getattr for the class such that functions can be applied
+        directly to the data class if the function is not part of the data
+        class.
+        e.g. if data is BaseData where self.data = [1, 2, 3, 1]
+        ```
+        data.count(1)  # returns 2, bc data.data has the function 'count'
+        ```
+        """
+        try:
+            returned = object.__getattribute__(self, name)
+        except AttributeError as attr_error:
+            class_name = self.__class__.__name__
+            data_class_name = self.data.__class__.__name__
+            if (not f"'{class_name}' object has no attribute '{name}'"
+                    == str(attr_error)):
+                raise
+            try:
+                returned = object.__getattribute__(self.data, name)
+            except AttributeError as attr_error:
+                if (not f"'{data_class_name}' object has no attribute '{name}'"
+                        == str(attr_error)):
+                    raise
+                raise AttributeError(f"'{class_name}' nor '{data_class_name}'"
+                                     f"objects have no attribute '{name}'")
+        return returned
+

--- a/dataprofiler/data_readers/base_data.py
+++ b/dataprofiler/data_readers/base_data.py
@@ -197,7 +197,8 @@ class BaseData(object):
                 if (not f"'{data_class_name}' object has no attribute '{name}'"
                         == str(attr_error)):
                     raise
-                raise AttributeError(f"'{class_name}' nor '{data_class_name}'"
-                                     f"objects have no attribute '{name}'")
+                raise AttributeError(f"Neither '{class_name}' nor "
+                                     f"'{data_class_name}' objects have "
+                                     f"attribute '{name}'")
         return returned
 

--- a/dataprofiler/profilers/column_profile_compilers.py
+++ b/dataprofiler/profilers/column_profile_compilers.py
@@ -271,6 +271,7 @@ class ColumnPrimitiveTypeProfileCompiler(BaseCompiler):
 
         return diff_profile
 
+
 class ColumnStatsProfileCompiler(BaseCompiler):
 
     # NOTE: these profilers are ordered. Test functionality if changed.
@@ -308,6 +309,7 @@ class ColumnStatsProfileCompiler(BaseCompiler):
                 diff_profile.update(diff)
 
         return diff_profile
+
 
 class ColumnDataLabelerCompiler(BaseCompiler):
 

--- a/dataprofiler/tests/data_readers/test_base_data.py
+++ b/dataprofiler/tests/data_readers/test_base_data.py
@@ -1,0 +1,40 @@
+from __future__ import print_function
+from __future__ import absolute_import
+
+import os
+import unittest
+
+from dataprofiler.data_readers.base_data import BaseData
+
+
+test_root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+
+class TestBaseDataClass(unittest.TestCase):
+
+    def test_can_apply_data_functions(self):
+        class FakeDataClass:
+            # matches the `data_type` value in BaseData for validating priority
+            data_type = "FakeData"
+
+            def func1(self):
+                return "success"
+
+        # initialize the data class
+        data = BaseData(input_file_path="", data=FakeDataClass(), options={})
+
+        # if the function exists in BaseData fail the test because the results
+        # may become inaccurate.
+        self.assertFalse(hasattr(BaseData, 'func1'))
+
+        with self.assertRaisesRegex(AttributeError,
+                                    "'BaseData' nor 'FakeDataClass'"
+                                    "objects have no attribute 'test'"):
+            data.test
+
+        # validate it will take BaseData attribute over the data attribute
+        self.assertIsNone(data.data_type)
+
+        # validate will auto call the data function if it doesn't exist in
+        # BaseData
+        self.assertEqual("success", data.func1())

--- a/dataprofiler/tests/data_readers/test_base_data.py
+++ b/dataprofiler/tests/data_readers/test_base_data.py
@@ -28,8 +28,8 @@ class TestBaseDataClass(unittest.TestCase):
         self.assertFalse(hasattr(BaseData, 'func1'))
 
         with self.assertRaisesRegex(AttributeError,
-                                    "'BaseData' nor 'FakeDataClass'"
-                                    "objects have no attribute 'test'"):
+                                    "Neither 'BaseData' nor 'FakeDataClass' "
+                                    "objects have attribute 'test'"):
             data.test
 
         # validate it will take BaseData attribute over the data attribute


### PR DESCRIPTION
This allows the user to directly access functions of the wrapped data inside of our data class. e.g. if the data internally is a pandas dataframe:
```python
data = CSVData(...)  # has pandas dataframe
df_without_na= data.dropna() # will not be in place unless user specifies it

# or iterating through rows
for row in data.iterrows():
    print(row)
```