### PR TITLE
List now maintains same visual data representation

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1849,7 +1849,10 @@ class StructuredProfiler(BaseProfiler):
         if isinstance(data, pd.Series):
             data = data.to_frame()
         elif isinstance(data, list):
-            data = pd.DataFrame(data)
+            # pd.DataFrame will convert integers to float representation which
+            # is inaccurate. pd.DataFrame(data, dtypes='object') also makes the
+            # conversion, hence best option was to str map initially.
+            data = pd.DataFrame(map(str, data), dtype=object)
 
         # Calculate schema of incoming data
         mapping_given = defaultdict(list)

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1852,7 +1852,7 @@ class StructuredProfiler(BaseProfiler):
             # pd.DataFrame will convert integers to float representation which
             # is inaccurate. pd.DataFrame(data, dtypes='object') also makes the
             # conversion, hence best option was to str map initially.
-            data = pd.DataFrame(map(str, data), dtype=object)
+            data = pd.DataFrame(np.vectorize(str)(data), dtype=object)
 
         # Calculate schema of incoming data
         mapping_given = defaultdict(list)

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1849,10 +1849,7 @@ class StructuredProfiler(BaseProfiler):
         if isinstance(data, pd.Series):
             data = data.to_frame()
         elif isinstance(data, list):
-            # pd.DataFrame will convert integers to float representation which
-            # is inaccurate. pd.DataFrame(data, dtypes='object') also makes the
-            # conversion, hence best option was to str map initially.
-            data = pd.DataFrame(np.vectorize(str)(data), dtype=object)
+            data = pd.DataFrame(data, dtype=object)
 
         # Calculate schema of incoming data
         mapping_given = defaultdict(list)

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -86,7 +86,13 @@ class TestStructuredProfiler(unittest.TestCase):
     @mock.patch('dataprofiler.profilers.profile_builder.'
                 'StructuredProfiler._update_correlation')
     def test_list_data(self, *mocks):
-        data = [1, None, 3, 4, 5, None, 1]
+        data = [[1, 1],
+                [None, None],
+                [3, 3],
+                [4, 4],
+                [5, 5],
+                [None, None],
+                [1, 1]]
         with test_utils.mock_timeit():
             profiler = dp.StructuredProfiler(data)
 
@@ -97,7 +103,7 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(2, profiler.row_is_null_count)
         self.assertEqual(7, profiler.total_samples)
         self.assertEqual(5, len(profiler.hashed_row_dict))
-        self.assertListEqual([0], list(profiler._col_name_to_idx.keys()))
+        self.assertListEqual([0, 1], list(profiler._col_name_to_idx.keys()))
         self.assertIsNone(profiler.correlation_matrix)
         self.assertDictEqual({'row_stats': 1}, profiler.times)
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -101,6 +101,11 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertIsNone(profiler.correlation_matrix)
         self.assertDictEqual({'row_stats': 1}, profiler.times)
 
+        # validates the sample out maintains the same visual data format as the
+        # input.
+        self.assertListEqual(['5', '1', '1', '3', '4'],
+                             profiler.profile[0].sample)
+
     @mock.patch('dataprofiler.profilers.profile_builder.'
                 'ColumnPrimitiveTypeProfileCompiler')
     @mock.patch('dataprofiler.profilers.profile_builder.'


### PR DESCRIPTION
Previously if inputing list into the profiler, the data representation would change ints to floats when illustrating samples:
```python
import dataprofiler as dp

data = [1, 2, None]
profiler = dp.Profiler(data)

# output would have: ['1.0', '2.0'] as opposed to ['1', '2']
print(profiler.profile[0].sample)
```

This fixes that to show the latter repsentation.