### PR TITLE
Logger implementation in profile_builder

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -15,6 +15,7 @@ from collections import OrderedDict, defaultdict
 import warnings
 import pickle
 from datetime import datetime
+import logging
 
 import pandas as pd
 import numpy as np
@@ -1868,10 +1869,16 @@ class StructuredProfiler(BaseProfiler):
                                                                     self._col_name_to_idx)
 
         try:
-            from tqdm import tqdm
+            # Only use imported tqdm if user specifies they want INFO logged
+            if logger.getEffectiveLevel() <= logging.INFO:
+                from tqdm import tqdm
+            else:
+                raise ImportError
         except ImportError:
             def tqdm(l):
                 for i, e in enumerate(l):
+                    # These will automatically be ignored if user sets logger
+                    # level as higher than INFO
                     logger.info("Processing Column {}/{}".format(i + 1, len(l)))
                     yield e
 

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -27,11 +27,9 @@ from ..labelers.data_labelers import DataLabeler
 from .helpers.report_helpers import calculate_quantiles, _prepare_report
 from .profiler_options import ProfilerOptions, StructuredOptions, \
     UnstructuredOptions
+from .. import dp_logging
 
-# Make these dp_logging and get_child_logger once other PR Merged
-import logging
-logger = logging.getLogger('DataProfiler').getChild(
-    __name__.replace('dataprofiler.', ''))
+logger = dp_logging.get_child_logger(__name__)
 
 
 class StructuredColProfiler(object):

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1872,18 +1872,18 @@ class StructuredProfiler(BaseProfiler):
                                                                     self._col_name_to_idx)
 
         try:
-            # Only use imported tqdm if user specifies they want INFO logged
-            if logger.getEffectiveLevel() <= logging.INFO:
-                from tqdm import tqdm
-            else:
-                raise ImportError
+            from tqdm import tqdm
+            has_tqdm = True
         except ImportError:
-            def tqdm(l):
-                for i, e in enumerate(l):
-                    # These will automatically be ignored if user sets logger
-                    # level as higher than INFO
-                    logger.info("Processing Column {}/{}".format(i + 1, len(l)))
-                    yield e
+            has_tqdm = False
+        finally:
+            if not has_tqdm or logger.getEffectiveLevel() > logging.INFO:
+                def tqdm(l):
+                    for i, e in enumerate(l):
+                        # These will automatically be ignored if user sets
+                        # logger level as higher than INFO
+                        logger.info(f"Processing Column {i + 1}/{len(l)}")
+                        yield e
 
         # Shuffle indices once and share with columns
         sample_ids = [*utils.shuffle_in_chunks(len(data), len(data))]

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1925,7 +1925,7 @@ class StructuredProfiler(BaseProfiler):
                 cols=len(data.columns))
 
         # Format the data
-        notification_str = "Finding the Null values in the columns..."
+        notification_str = "Finding the Null values in the columns... "
         if pool:
             notification_str += " (with " + str(pool_size) + " processes)"
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -7,6 +7,7 @@ import random
 import six
 import os
 import re
+import logging
 
 import numpy as np
 import pandas as pd
@@ -65,8 +66,8 @@ class TestStructuredProfiler(unittest.TestCase):
                 spec=StructuredDataLabeler)
     def test_bad_input_data(self, *mocks):
         allowed_data_types = (r"\(<class 'list'>, " 
-                             r"<class 'pandas.core.series.Series'>, " 
-                             r"<class 'pandas.core.frame.DataFrame'>\)")
+                              r"<class 'pandas.core.series.Series'>, " 
+                              r"<class 'pandas.core.frame.DataFrame'>\)")
         bad_data_types = [1, {}, np.inf, 'sdfs']
         for data in bad_data_types:
             with self.assertRaisesRegex(TypeError,
@@ -287,7 +288,7 @@ class TestStructuredProfiler(unittest.TestCase):
     @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler',
                 spec=StructuredDataLabeler)
     def test_correlation(self, *mock):
-        # Use the following formular to obtain the pairwise correlation
+        # Use the following formula to obtain the pairwise correlation
         # sum((x - np.mean(x))*(y-np.mean(y))) /
         # np.sqrt(sum((x - np.mean(x)**2)))/np.sqrt(sum((y - np.mean(y)**2)))
         profile_options = dp.ProfilerOptions()
@@ -1340,6 +1341,30 @@ class TestStructuredProfiler(unittest.TestCase):
         }
 
         self.assertDictEqual(expected_diff, profile1.diff(profile2))
+
+    @mock.patch("dataprofiler.profilers.data_labeler_column_profile."
+                "DataLabelerColumn.update")
+    @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
+    @mock.patch("dataprofiler.profilers.column_profile_compilers."
+                "ColumnPrimitiveTypeProfileCompiler.diff")
+    @mock.patch("dataprofiler.profilers.column_profile_compilers."
+                "ColumnStatsProfileCompiler.diff")
+    @mock.patch("dataprofiler.profilers.column_profile_compilers."
+                "ColumnDataLabelerCompiler.diff")
+    def test_logs(self, *mocks):
+        options = StructuredOptions()
+        options.multiprocess.is_enabled = False
+
+        with self.assertLogs('DataProfiler.profilers.profile_builder',
+                             level='INFO') as logs:
+            StructuredProfiler(pd.DataFrame([[0, 1], [2, 3]]), options=options)
+
+        self.assertEqual(['INFO:DataProfiler.profilers.profile_builder:'
+                          'Finding the Null values in the columns... ',
+                          'INFO:DataProfiler.profilers.profile_builder:'
+                          'Calculating the statistics... '],
+                         logs.output)
+
 
 class TestStructuredColProfilerClass(unittest.TestCase):
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1395,7 +1395,7 @@ class TestStructuredProfiler(unittest.TestCase):
         mock_stderr.truncate(0)
 
         # Now tqdm shouldn't be printed
-        dp.dp_logging.set_verbosity(logging.WARNING)
+        dp.set_verbosity(logging.WARNING)
 
         StructuredProfiler(pd.DataFrame([[0, 1], [2, 3]]))
 

--- a/dataprofiler/tests/test_dp_logging.py
+++ b/dataprofiler/tests/test_dp_logging.py
@@ -15,7 +15,7 @@ class TestDPLogging(unittest.TestCase):
         dp_logging._dp_logger = None
 
     @classmethod
-    def tearDown(cls):
+    def tearDownClass(cls):
         from dataprofiler import dp_logging
         root_logger = logging.getLogger()
         root_logger.removeHandler(dp_logging.get_logger())


### PR DESCRIPTION
Uses `logger.info` instead of prints and doesn't use tqdm if the user specifies a verbosity level above INFO.

Corresponding tests added.

Addresses #265