### PR TITLE
Validate min_true_samples in update_profile

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -726,6 +726,10 @@ class BaseProfiler(object):
         encoding = None
         file_type = None
 
+        if min_true_samples is not None \
+                and not isinstance(min_true_samples, int):
+            raise ValueError('`min_true_samples` must be an integer or `None`.')
+
         if isinstance(data, data_readers.base_data.BaseData):
             encoding = data.file_encoding
             file_type = data.data_type

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -940,7 +940,7 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(2, sparse_profile._min_col_samples_used)
 
     @mock.patch('dataprofiler.profilers.profile_builder.StructuredProfiler.'
-                'update_profile')
+                '_update_profile_from_chunk')
     @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
     def test_min_true_samples(self, *mocks):
         empty_df = pd.DataFrame([])
@@ -949,6 +949,11 @@ class TestStructuredProfiler(unittest.TestCase):
         msg = "`min_true_samples` must be an integer or `None`."
         with self.assertRaisesRegex(ValueError, msg):
             profile = dp.StructuredProfiler(empty_df, min_true_samples="Bloop")
+
+        # Test invalid input given to update_profile
+        profile = dp.StructuredProfiler(empty_df)
+        with self.assertRaisesRegex(ValueError, msg):
+            profile.update_profile(empty_df, min_true_samples="Bloop")
 
         # Test None input (equivalent to zero)
         profile = dp.StructuredProfiler(empty_df, min_true_samples=None)
@@ -2080,7 +2085,7 @@ class TestUnstructuredProfiler(unittest.TestCase):
         self.assertDictEqual({'clean_and_base_stats': 2}, profiler.times)
 
     @mock.patch('dataprofiler.profilers.profile_builder.UnstructuredProfiler.'
-                'update_profile')
+                '_update_profile_from_chunk')
     def test_min_true_samples(self, *mocks):
         empty_df = pd.DataFrame([])
 
@@ -2089,6 +2094,11 @@ class TestUnstructuredProfiler(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             profile = dp.UnstructuredProfiler(empty_df, 
                                               min_true_samples="Bloop")
+
+        # Test invalid input given to update_profile
+        profile = dp.UnstructuredProfiler(empty_df)
+        with self.assertRaisesRegex(ValueError, msg):
+            profile.update_profile(empty_df, min_true_samples="Bloop")
 
         # Test None input (equivalent to zero)
         profile = dp.UnstructuredProfiler(empty_df, min_true_samples=None)
@@ -2817,7 +2827,7 @@ class TestProfilerFactoryClass(unittest.TestCase):
             load_profile.update_profile(pd.DataFrame(['test', 'test2']))
 
     @mock.patch('dataprofiler.profilers.profile_builder.StructuredProfiler.'
-                'update_profile')
+                '_update_profile_from_chunk')
     @mock.patch('dataprofiler.profilers.profile_builder.DataLabeler')
     def test_min_true_samples(self, *mocks):
         empty_df = pd.DataFrame([])
@@ -2826,6 +2836,11 @@ class TestProfilerFactoryClass(unittest.TestCase):
         msg = "`min_true_samples` must be an integer or `None`."
         with self.assertRaisesRegex(ValueError, msg):
             profile = dp.Profiler(empty_df, min_true_samples="Bloop")
+
+        # Test invalid input given to update_profile
+        profile = dp.Profiler(empty_df)
+        with self.assertRaisesRegex(ValueError, msg):
+            profile.update_profile(empty_df, min_true_samples="Bloop")
 
         # Test None input (equivalent to zero)
         profile = dp.Profiler(empty_df, min_true_samples=None)


### PR DESCRIPTION
Follow up to #365, adds error check in update_profile, along with enhancing existing tests to cover new functionality.