### PR TITLE
Fixes bug in _get_quantiles when median case occurs

### DIFF
--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -924,6 +924,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         :return: List of corresponding values for which the percentage of values
             in the distribution fall before each percentage
         """
+        percentiles = np.array(percentiles)
         bin_counts = self._stored_histogram['histogram']['bin_counts']
         bin_edges = self._stored_histogram['histogram']['bin_edges']
 
@@ -945,10 +946,10 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):
         cumsum_bin_counts = np.append([0], cumsum_bin_counts)
 
         quantiles = np.interp(percentiles / 100,
-                              cumsum_bin_counts, bin_edges).tolist()
+                              cumsum_bin_counts, bin_edges)
         if median_value:
-            quantiles[499] = median_value
-        return quantiles
+            quantiles[percentiles == 50] = median_value
+        return quantiles.tolist()
 
     def _get_quantiles(self):
         """

--- a/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
+++ b/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
@@ -402,6 +402,19 @@ class TestNumericStatsMixin(unittest.TestCase):
 
         assert best_histogram == "hist_1"
 
+    def test_get_percentile_median(self):
+        num_profiler = TestColumn()
+        # Dummy data for calculating bin error
+        num_profiler._stored_histogram = {
+            "histogram": {
+                "bin_counts": np.array([  1,   2,   0,    2,    1]),
+                "bin_edges": np.array([0.0, 4.0, 8.0, 12.0, 16.0, 20.0])
+            }
+        }
+        median = NumericStatsMixin._get_percentile(num_profiler,
+                                                   percentiles=[50, 50])
+        self.assertListEqual([10, 10], median)
+
     def test_num_zeros(self):
         num_profiler = TestColumn()
 


### PR DESCRIPTION
if quantiles was != 1000 and median split over bucket occurs, the median would either be assigned to the wrong bucket or to a non-existent index which would error