### PR TITLE
Raise known exception when ssl_verify fails so user knows they can correct it.

### DIFF
--- a/dataprofiler/data_readers/data_utils.py
+++ b/dataprofiler/data_readers/data_utils.py
@@ -668,9 +668,10 @@ def url_to_bytes(url_as_string, options):
 
                 if total_bytes > 1024 ** 3:
                     raise ValueError('The downloaded file from the url may not be larger than 1GB')
-    except requests.exceptions.SSLError:
-        raise ValueError("The URL given has an untrusted SSL certificate. Although highly discouraged, "
-                         "you can proceed with profiling by setting 'verify_url' to False in options.")
+    except requests.exceptions.SSLError as e:
+        raise RuntimeError("The URL given has an untrusted SSL certificate. Although highly discouraged, "
+                           "you can proceed with reading the data by setting 'verify_url' to False in "
+                           "options (i.e. options=dict(verify_url=False)).") from e
 
     stream.seek(0)
     return stream

--- a/dataprofiler/data_readers/data_utils.py
+++ b/dataprofiler/data_readers/data_utils.py
@@ -652,12 +652,7 @@ def url_to_bytes(url_as_string, options):
         verify_url = options['verify_ssl']
 
     try:
-        url = requests.get(url_as_string, stream=True, verify=verify_url)
-    except requests.exceptions.SSLError:
-        raise ValueError("The URL given has an untrusted SSL certificate. Although highly discouraged, "
-                         "you can proceed with profiling by setting 'verify_url' to False in options.")
-    else:
-        with url:
+        with requests.get(url_as_string, stream=True, verify=verify_url) as url:
             url.raise_for_status()
             if 'Content-length' in url.headers \
                     and int(url.headers['Content-length']) >= 1024 ** 3:
@@ -673,6 +668,9 @@ def url_to_bytes(url_as_string, options):
 
                 if total_bytes > 1024 ** 3:
                     raise ValueError('The downloaded file from the url may not be larger than 1GB')
+    except requests.exceptions.SSLError:
+        raise ValueError("The URL given has an untrusted SSL certificate. Although highly discouraged, "
+                         "you can proceed with profiling by setting 'verify_url' to False in options.")
 
     stream.seek(0)
     return stream

--- a/dataprofiler/tests/data_readers/test_data.py
+++ b/dataprofiler/tests/data_readers/test_data.py
@@ -3,6 +3,7 @@ from unittest import mock
 import os
 
 import pandas as pd
+import requests
 
 from dataprofiler.data_readers.data import Data
 
@@ -112,6 +113,15 @@ class TestDataReadFromURL(unittest.TestCase):
             'The downloaded file from the url may not be larger than 1GB'):
             # stub URL, mock_request_get replaces the content requests.get will see
             data_obj = Data('https://test.com')
+
+    @mock.patch('requests.get')
+    def test_read_url_verify_ssl(self, mock_request_get):
+        mock_request_get.side_effect = requests.exceptions.SSLError()
+
+        with self.assertRaisesRegex(ValueError, \
+            "The URL given has an untrusted SSL certificate."):
+            data_obj = Data('https://test.com')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/dataprofiler/tests/data_readers/test_data.py
+++ b/dataprofiler/tests/data_readers/test_data.py
@@ -118,8 +118,11 @@ class TestDataReadFromURL(unittest.TestCase):
     def test_read_url_verify_ssl(self, mock_request_get):
         mock_request_get.side_effect = requests.exceptions.SSLError()
 
-        with self.assertRaisesRegex(ValueError, \
-            "The URL given has an untrusted SSL certificate."):
+        with self.assertRaises(RuntimeError, msg="The URL given has an untrusted "
+                               "SSL certificate. Although highly discouraged, "
+                               "you can proceed with reading the data by setting"
+                               " 'verify_url' to False in options (i.e. options"
+                               "=dict(verify_url=False))."):
             data_obj = Data('https://test.com')
 
 


### PR DESCRIPTION
Catches the SSLError that occurs if verify = True