### PR TITLE
Bug fix for profiling not requiring graphs reqs for profiler usage

### DIFF
--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -135,7 +135,7 @@ def shuffle_in_chunks(data_length, chunk_size):
 
 def warn_on_profile(col_profile, e):
     """
-    Returns a warning if a given profile errors (tensorflow typcially)
+    Returns a warning if a given profile errors (tensorflow typically)
 
     :param col_profile: Name of the column profile
     :type col_profile: str

--- a/dataprofiler/reports/graphs.py
+++ b/dataprofiler/reports/graphs.py
@@ -2,15 +2,22 @@
 import math
 import warnings
 
-import matplotlib.patches
-import matplotlib.pyplot as plt
 import numpy as np
-import seaborn as sns
+try:
+    import matplotlib.patches
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+except ImportError:
+    # don't require if using graphs will below recommend to install if not
+    # installed
+    pass
 
 from ..profilers.profile_builder import StructuredProfiler, \
     StructuredColProfiler
+from . import utils
 
 
+@utils.require_module(['matplotlib', 'seaborn'])
 def plot_histograms(profiler, column_names=None, column_inds=None):
     """
     Take a input of StructuredProfiler class and a list of specified column
@@ -113,6 +120,7 @@ def plot_histograms(profiler, column_names=None, column_inds=None):
     return fig
 
 
+@utils.require_module(['matplotlib', 'seaborn'])
 def plot_col_histogram(data_type_profiler, ax=None, title=None):
     """
     Take a input of a Int or Float Column and plots the histogram
@@ -134,6 +142,7 @@ def plot_col_histogram(data_type_profiler, ax=None, title=None):
     ax = sns.histplot(
         x=histogram['bin_edges'][:-1], bins=histogram['bin_edges'].tolist(),
         weights=histogram['bin_counts'], ax=ax)
+
     ax.set(xlabel='bins')
     if title is None:
         title = str(data_type_profiler.name)
@@ -141,6 +150,7 @@ def plot_col_histogram(data_type_profiler, ax=None, title=None):
     return ax
 
 
+@utils.require_module(['matplotlib', 'seaborn'])
 def plot_missing_values_matrix(profiler, ax=None, title=None):
     """
     Generates a matrix of bar graphs for the missing value locations within
@@ -160,6 +170,7 @@ def plot_missing_values_matrix(profiler, ax=None, title=None):
     return plot_col_missing_values(profiler.profile, ax=ax, title=title)
 
 
+@utils.require_module(['matplotlib', 'seaborn'])
 def plot_col_missing_values(col_profiler_list, ax=None, title=None):
     """
     Generates a bar graph of the missing value locations within a column where
@@ -270,6 +281,8 @@ def plot_col_missing_values(col_profiler_list, ax=None, title=None):
     ax.legend(by_label.values(), by_label.keys())
     ax.set_xlabel('column name')
     ax.set_ylabel('row index')
+    if title:
+        ax.set_title(title)
 
     if is_own_fig:
         fig.set_tight_layout(True)

--- a/dataprofiler/reports/utils.py
+++ b/dataprofiler/reports/utils.py
@@ -1,0 +1,45 @@
+import sys
+import warnings
+
+
+def warn_missing_module(graph_func, module_name):
+    """
+    Returns a warning if a given graph module doesn't exist
+
+    :param graph_func: Name of the graphing function
+    :type graph_func: str
+    :param module_name: module name that was missing
+    :type module_name: str
+    """
+    warning_msg = "\n\n!!! WARNING Graphing Failure !!!\n\n"
+    warning_msg += "Graph Function: {}".format(graph_func)
+    warning_msg += "\nMissing Module: {}".format(module_name)
+    warning_msg += "\n\nFor report errors, try installing "
+    warning_msg += "the extra reports requirements via:\n\n"
+    warning_msg += "$ pip install dataprofiler[reports] --user\n\n"
+    warnings.warn(warning_msg, RuntimeWarning, stacklevel=3)
+
+
+def require_module(names):
+    """
+    Decorator to check if a set of modules exist in sys.modules prior to running
+    the function. If they do not, give a user a warning and do not run the
+    function.
+
+    :param names: list of module names to check for in sys.modules
+    :type names: list[str]
+    """
+    def check_module(f):
+        def new_f(*args, **kwds):
+            for module_name in names:
+                if module_name not in sys.modules.keys():
+                    # attempt to reload if missing
+                    import importlib
+                    importlib.reload(sys.modules[f.__module__])
+                    if module_name not in sys.modules.keys():
+                        warn_missing_module(f.__name__, module_name)
+                        return
+            return f(*args, **kwds)
+        new_f.__name__ = f.__name__
+        return new_f
+    return check_module

--- a/dataprofiler/tests/reports/test_graphs.py
+++ b/dataprofiler/tests/reports/test_graphs.py
@@ -57,8 +57,8 @@ class TestGraphImport(unittest.TestCase):
 
 
 
-@mock.patch("dataprofiler.reports.graphs.plt.show")
-@mock.patch("dataprofiler.reports.graphs.plot_col_histogram")
+@mock.patch("dataprofiler.graphs.plt.show")
+@mock.patch("dataprofiler.graphs.plot_col_histogram")
 class TestPlotHistograms(unittest.TestCase):
 
     @classmethod

--- a/dataprofiler/tests/reports/test_graphs.py
+++ b/dataprofiler/tests/reports/test_graphs.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest import mock
+import sys
 
 import numpy as np
 import pandas as pd
@@ -12,8 +13,48 @@ from dataprofiler.reports import graphs
 
 class TestGraphImport(unittest.TestCase):
 
+    def missing_module_test(self, graph_func, module_name):
+        orig_import = __import__
+
+        # necessary for any wrapper around the library to test if snappy caught
+        # as an issue
+
+        def import_mock(name, *args, **kwargs):
+            if name.startswith(module_name):
+                raise ImportError('test')
+            return orig_import(name, *args, **kwargs)
+
+        import re
+        warning_regex = re.compile(
+            ".*WARNING Graphing Failure.*" + module_name + '.*', re.DOTALL)
+        with mock.patch('builtins.__import__', side_effect=import_mock):
+            with self.assertWarnsRegex(RuntimeWarning, warning_regex):
+                modules_to_remove = [
+                    'dataprofiler.reports.graphs',
+                    module_name,
+                ]
+                for module in modules_to_remove:
+                    if module in sys.modules:
+                        del sys.modules[module]
+                # re-add module for testing
+                for module in modules_to_remove[:-1]:
+                    import importlib
+                    importlib.import_module(module)
+                graph_func(None)
+
     def test_import_from_base_repo(self):
         self.assertTrue(hasattr(dp, 'graphs'))
+
+    def test_no_seaborn(self):
+        self.missing_module_test(dp.graphs.plot_histograms, 'seaborn')
+        self.missing_module_test(dp.graphs.plot_missing_values_matrix, 'seaborn')
+        self.missing_module_test(dp.graphs.plot_col_missing_values, 'seaborn')
+
+    def test_no_matplotlib(self):
+        self.missing_module_test(dp.graphs.plot_histograms, 'matplotlib')
+        self.missing_module_test(dp.graphs.plot_missing_values_matrix, 'matplotlib')
+        self.missing_module_test(dp.graphs.plot_col_missing_values, 'matplotlib')
+
 
 
 @mock.patch("dataprofiler.reports.graphs.plt.show")

--- a/dataprofiler/tests/test_data_profiler.py
+++ b/dataprofiler/tests/test_data_profiler.py
@@ -102,10 +102,10 @@ class TestDataProfiler(unittest.TestCase):
         # necessary for any wrapper around the library to test if snappy caught
         # as an issue
 
-        def import_mock(name, *args):
+        def import_mock(name, *args, **kwargs):
             if name == 'tensorflow':
                 raise ImportError('test')
-            return orig_import(name, *args)
+            return orig_import(name, *args, **kwargs)
 
         with mock.patch('builtins.__import__', side_effect=import_mock):
 

--- a/dataprofiler/tests/test_data_profiler.py
+++ b/dataprofiler/tests/test_data_profiler.py
@@ -74,10 +74,10 @@ class TestDataProfiler(unittest.TestCase):
                     if isinstance(module, types.ModuleType):
                         importlib.reload(module)
 
-        def import_mock(name, *args):
+        def import_mock(name, *args, **kwargs):
             if name == 'snappy':
                 raise ImportError('test')
-            return orig_import(name, *args)
+            return orig_import(name, *args, **kwargs)
 
         with mock.patch('builtins.__import__', side_effect=import_mock):
             with self.assertWarns(ImportWarning) as w:

--- a/dataprofiler/version.py
+++ b/dataprofiler/version.py
@@ -4,7 +4,7 @@ File containers the version number for the package
 
 MAJOR               = 0
 MINOR               = 7
-MICRO               = 1
+MICRO               = 2
 
 VERSION             = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Currently, if the graphs aren't installed, these will cause import errors. This fixes that by not requiring the imports unless the functions are called.

If desired, we could still raise the error instead of a warning.