### PR TITLE
readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The format for a structured profile is below:
             "null_types_index": {
                 string: list[int]
             },
-            "data_type_representation": [string, list[string]],
+            "data_type_representation": dict[string, float], 
             "min": [null, float, str],
             "max": [null, float, str],
             "mode": float,

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ The format for a structured profile is below:
                 string: list[int]
             },
             "data_type_representation": [string, list[string]],
-            "min": [null, float],
-            "max": [null, float],
+            "min": [null, float, str],
+            "max": [null, float, str],
             "mode": float,
             "median", float, 
             "median_absolute_deviation", float,


### PR DESCRIPTION
min and max can also be strings if working with datetime variables. Not sure if the same is true for `mode` or `median`