### PR TITLE
Bug fix for confidence output not returning all the data appropriately at post-processing

### DIFF
--- a/dataprofiler/labelers/character_level_cnn_model.py
+++ b/dataprofiler/labelers/character_level_cnn_model.py
@@ -966,7 +966,7 @@ class CharacterLevelCnnModel(BaseTrainableModel,
                 in enumerate(sentence_lengths[:allocation_index]):
             predictions_list[index] = list(predictions[index][:sentence_length])
             if show_confidences:
-                confidences_list = list(confidences[index][:sentence_length])
+                confidences_list[index] = list(confidences[index][:sentence_length])
                 
         if show_confidences:
             return {'pred': predictions_list, 'conf': confidences_list} 

--- a/dataprofiler/tests/labelers/test_data_processing.py
+++ b/dataprofiler/tests/labelers/test_data_processing.py
@@ -1209,6 +1209,7 @@ class TestCharPostprocessor(unittest.TestCase):
                                              inplace=True)
         self.assertEqual(results, post_process_results)
 
+
 class TestPreandPostCharacterProcessorConnection(unittest.TestCase):
 
     def test_flatten_convert(self):

--- a/dataprofiler/tests/labelers/test_integration_unstructured_data_labeler.py
+++ b/dataprofiler/tests/labelers/test_integration_unstructured_data_labeler.py
@@ -115,8 +115,16 @@ class TestUnstructuredDataLabeler(unittest.TestCase):
         model_predictions_char_level, model_confidences_char_level = \
             results["pred"], results["conf"]
 
-        # for now just checking that it's not empty
+        # for now just checking that it's not empty and appropriate size
+        num_labels = max(default.label_mapping.values()) + 1
+        len_text = len(sample[0])
         self.assertIsNotNone(model_confidences_char_level)
+        self.assertEqual((len_text, num_labels),
+                         model_confidences_char_level[0].shape)
+
+        len_text = len(sample[1])
+        self.assertEqual((len_text, num_labels),
+                         model_confidences_char_level[1].shape)
 
     def test_default_edge_cases(self):
         """more complicated test for edge cases for the default model"""


### PR DESCRIPTION
Model was slicing the data at the output of predict, this fixes that issue.