### PR TITLE
fix: numpy removing trailing nulls from strings

### DIFF
--- a/dataprofiler/labelers/data_processing.py
+++ b/dataprofiler/labelers/data_processing.py
@@ -643,7 +643,9 @@ class CharPreprocessor(BaseDataPreprocessor, metaclass=AutoSubRegistrationMeta):
         for batch_data in batch_process_generator:
             # Convert to necessary training data format.
             X_train = np.array(
-                [[sentence] for sentence in batch_data['samples']])
+                [[sentence] for sentence in batch_data['samples']],
+                dtype=object
+            )
             if labels is not None:
                 num_classes = max(label_mapping.values()) + 1
                 


### PR DESCRIPTION
If a string ends in a null character, it is trimmed by numpy during training. This stops that for occurring by setting the dtrype to object