### PR TITLE
Fix: Removing ignore value logic for `conf_out` in data processing 

### DIFF
--- a/dataprofiler/labelers/data_processing.py
+++ b/dataprofiler/labelers/data_processing.py
@@ -1429,6 +1429,7 @@ class StructCharPostprocessor(BaseDataPostprocessor,
         :return: prediction value for a single column
         """
         default_ind = label_mapping[default_label]
+        ignore_value = label_mapping[pad_label]
         num_labels = max(label_mapping.values()) + 1
 
         labels_out = np.ones((len(results['pred']),))
@@ -1440,6 +1441,7 @@ class StructCharPostprocessor(BaseDataPostprocessor,
 
             # get count of all labels in prediction
             column_label_counter = Counter(column_labels[:len(str(sample))])
+            column_label_counter.pop(ignore_value, None)
             modes = [entity_id for entity_id, count in
                      column_label_counter.most_common() if
                      column_label_counter.most_common(1)[0][1] == count]
@@ -1458,6 +1460,9 @@ class StructCharPostprocessor(BaseDataPostprocessor,
                     confs_out[i, int(label_id)] = count / sample_count
 
         results['pred'] = labels_out
+        if 'conf' in results:
+            results['conf'] = confs_out
+
         return results
 
     def process(self, data, results, label_mapping):

--- a/dataprofiler/labelers/data_processing.py
+++ b/dataprofiler/labelers/data_processing.py
@@ -1429,7 +1429,6 @@ class StructCharPostprocessor(BaseDataPostprocessor,
         :return: prediction value for a single column
         """
         default_ind = label_mapping[default_label]
-        ignore_value = label_mapping[pad_label]
         num_labels = max(label_mapping.values()) + 1
 
         labels_out = np.ones((len(results['pred']),))
@@ -1460,9 +1459,6 @@ class StructCharPostprocessor(BaseDataPostprocessor,
                     confs_out[i, int(label_id)] = count / sample_count
 
         results['pred'] = labels_out
-        if 'conf' in results:
-            results['conf'] = confs_out
-            results['conf'] = np.delete(results['conf'], ignore_value, axis=1)
         return results
 
     def process(self, data, results, label_mapping):

--- a/dataprofiler/labelers/data_processing.py
+++ b/dataprofiler/labelers/data_processing.py
@@ -1440,7 +1440,6 @@ class StructCharPostprocessor(BaseDataPostprocessor,
 
             # get count of all labels in prediction
             column_label_counter = Counter(column_labels[:len(str(sample))])
-            column_label_counter.pop(ignore_value, None)
             modes = [entity_id for entity_id, count in
                      column_label_counter.most_common() if
                      column_label_counter.most_common(1)[0][1] == count]

--- a/dataprofiler/profilers/data_labeler_column_profile.py
+++ b/dataprofiler/profilers/data_labeler_column_profile.py
@@ -283,6 +283,11 @@ class DataLabelerColumn(BaseColumnProfiler):
         """
         predictions = self.data_labeler.predict(
             df_series, predict_options=dict(show_confidences=True))
+        # remove PAD from output (reserved zero index)
+        if self.data_labeler.model.requires_zero_mapping:
+            ignore_value = 0  # PAD index
+            predictions['conf'] = np.delete(
+                predictions['conf'], ignore_value, axis=1)
         sum_predictions = np.sum(predictions['conf'], axis=0)
         self._sum_predictions += sum_predictions
 

--- a/dataprofiler/tests/labelers/test_data_processing.py
+++ b/dataprofiler/tests/labelers/test_data_processing.py
@@ -1921,11 +1921,11 @@ class TestStructCharPostprocessor(unittest.TestCase):
         results['conf'] = confidences
 
         expected_confidence_output = np.array([
-            [0, 1, 0, 0],
-            [0, 0, 1, 0],
-            [1, 0, 0, 0],
-            [0, 0, 1, 0],
-            [0, 1, 0, 0],
+            [0, 0, 1, 0, 0],
+            [0, 0, 0, 1, 0],
+            [0, 1, 0, 0, 0],
+            [0, 0, 0, 1, 0],
+            [0, 0, 1, 0, 0],
         ])
 
         output = processor.process(data, results, label_mapping)

--- a/dataprofiler/tests/profilers/test_data_labeler_column_profile.py
+++ b/dataprofiler/tests/profilers/test_data_labeler_column_profile.py
@@ -31,6 +31,8 @@ class TestDataLabelerColumnProfiler(unittest.TestCase):
             if len_data % 2:
                 output += [[1, 0]]
             conf = np.array(output)
+            if mock_DataLabeler.model.requires_zero_mapping:
+                conf = np.concatenate([[[0]] * len_data, conf], axis=1)
             pred = np.argmax(conf, axis=1)
             return {'pred': pred, 'conf': conf}
         mock_DataLabeler.predict.side_effect = mock_predict


### PR DESCRIPTION
- As part of the initial integration with Great Expecations, we need to ensure the padding value from the labeler_mapping is not removed on the `conf_out` variable
- We are simply removing that logic here such that the `conf_out` contains all the required labels and their mappings. 