### PR TITLE
NEP 29 Version Minimums

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 h5py>=2.10.0
 wheel>=0.33.1
 future>=0.18.2
-numpy>=1.19.0
+numpy>=1.22.0
 pandas>=1.1.2
 python-dateutil>=2.7.5
 pytz>=2020.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 h5py>=2.10.0
 wheel>=0.33.1
 future>=0.18.2
-numpy==1.19.0
+numpy>=1.18.5
 pandas>=1.1.2
 python-dateutil>=2.7.5
 pytz>=2020.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 h5py>=2.10.0
 wheel>=0.33.1
 future>=0.18.2
-numpy>=1.22.0
+numpy>=1.19.0
 pandas>=1.1.2
 python-dateutil>=2.7.5
 pytz>=2020.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 h5py>=2.10.0
 wheel>=0.33.1
 future>=0.18.2
-numpy>=1.19.0
+numpy==1.19.0
 pandas>=1.1.2
 python-dateutil>=2.7.5
 pytz>=2020.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 h5py>=2.10.0
 wheel>=0.33.1
 future>=0.18.2
-numpy>=1.22.0rc1
+numpy>=1.19.0
 pandas>=1.1.2
 python-dateutil>=2.7.5
 pytz>=2020.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 h5py>=2.10.0
 wheel>=0.33.1
 future>=0.18.2
-numpy>=1.18.5
+numpy>=1.19.0
 pandas>=1.1.2
 python-dateutil>=2.7.5
 pytz>=2020.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 h5py>=2.10.0
 wheel>=0.33.1
 future>=0.18.2
-numpy>=1.19.0
+numpy>=1.22.0rc1
 pandas>=1.1.2
 python-dateutil>=2.7.5
 pytz>=2020.1

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ DESCRIPTION = "What is in your data? Detect schema, statistics and entities in a
 setup(
     name='DataProfiler',
     version=__version__,
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
- Update to python version minimum and numpy version minimum
- NEP 29 version minimums as of Dec 26, 2021
    - `numpy>=1.19`
    - `python>=3.8`
 - link to NEP 29 versions [here](https://numpy.org/neps/nep-0029-deprecation_policy.html)