### PR TITLE
FloatColumn: enable `pop` when `remove_disabled_flag` set to True

### DIFF
--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -130,8 +130,8 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         """Report on profile attribute of the class and pop value
             from self.profile if key not in self.__calculations
         """
-        calcs_dict_keys = self.__calculations.keys()
-        profile = self.profile()
+        calcs_dict_keys = self._FloatColumn__calculations.keys()
+        profile = self.profile
 
         if remove_disabled_flag:
             profile_keys = list(profile.keys())

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -126,6 +126,23 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         differences["precision"] = precision_diff
         return differences
 
+    def report(self, remove_disabled_flag=False):
+        """Report on profile attribute of the class and pop value
+            from self.profile if key not in self.__calculations
+        """
+        calcs_dict_keys = self.__calculations.keys()
+        profile = self.profile()
+
+        if remove_disabled_flag:
+            profile_keys = list(profile.keys())
+            for profile_key in profile_keys:
+                if profile_key == 'precision':
+                    if 'precision' in calcs_dict_keys:
+                        continue
+                profile.pop(profile_key)
+
+        return profile
+
     @property
     def profile(self):
         """

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -1074,6 +1074,36 @@ class TestFloatColumn(unittest.TestCase):
                                            'num_zeros': 2.0,})
             self.assertEqual(expected, profiler.profile['times'])
 
+    def test_report(self):
+        data = [1.1, 2.2, 3.3, 4.4]
+        df = pd.Series(data).apply(str)
+
+        # With FloatOptions and remove_disabled_flag == True
+        options = FloatOptions()
+        options.precision.is_enabled = False
+
+        profiler = FloatColumn(df.name, options)
+        report = profiler.report(remove_disabled_flag=True)
+
+        # With FloatOptions and remove_disabled_flag == True
+        # testing key removal in NumericMixin from FloatColumnProfile
+        options = FloatOptions()
+        options.min.is_enabled = False
+
+        profiler = FloatColumn(df.name, options)
+        report = profiler.report(remove_disabled_flag=True)
+
+        # w/o FloatOptions and remove_disabled_flag == True
+        profiler = FloatColumn(df.name)
+        report = profiler.report(remove_disabled_flag=True)
+
+
+        # w/o FloatOptions and remove_disabled_flag default
+        profiler = FloatColumn(df.name)
+        report = profiler.report()
+
+
+
     def test_option_precision(self):
         data = [1.1, 2.2, 3.3, 4.4]
         df = pd.Series(data).apply(str)

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -1075,8 +1075,8 @@ class TestFloatColumn(unittest.TestCase):
             self.assertEqual(expected, profiler.profile['times'])
 
     def test_report(self):
-        """Test report method in FloatColumn class under four (4)
-        scenarios. First, test under scenario of disabling the entire
+        """Test report method in FloatColumn class under four (4) scenarios.
+        First, test under scenario of disabling the entire
         precision dictionary. Second, test under scenario removing 
         `min` from NumericMixIn__calculations (an inherited class)
         by FloatColumn. Third, test with no options and
@@ -1094,16 +1094,16 @@ class TestFloatColumn(unittest.TestCase):
         report = profiler.report(remove_disabled_flag=True)
         report_keys = list(report.keys())
         self.assertNotIn('precision', report_keys)
+        
+        # # With FloatOptions and remove_disabled_flag == True
+        # # testing key removal in NumericMixin from FloatColumnProfile
+        # options = FloatOptions()
+        # options.min.is_enabled = False
 
-        # With FloatOptions and remove_disabled_flag == True
-        # testing key removal in NumericMixin from FloatColumnProfile
-        options = FloatOptions()
-        options.min.is_enabled = False
-
-        profiler = FloatColumn(df.name, options)
-        report = profiler.report(remove_disabled_flag=True)
-        sub_report_keys = list(report['precision'].keys())
-        self.assertNotIn('min', sub_report_keys)
+        # profiler = FloatColumn(df.name, options)
+        # report = profiler.report(remove_disabled_flag=True)
+        # sub_report_keys = list(report['precision'].keys())
+        # self.assertNotIn('min', sub_report_keys)
 
         # w/o FloatOptions and remove_disabled_flag == True
         profiler = FloatColumn(df.name)

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -1075,6 +1075,14 @@ class TestFloatColumn(unittest.TestCase):
             self.assertEqual(expected, profiler.profile['times'])
 
     def test_report(self):
+        """Test report method in FloatColumn class under four (4)
+        scenarios. First, test under scenario of disabling the entire
+        precision dictionary. Second, test under scenario removing 
+        `min` from NumericMixIn__calculations (an inherited class)
+        by FloatColumn. Third, test with no options and
+        `remove_disabled_flag`=True. Finally, test no options and default
+        `remove_disabled_flag`.
+        """
         data = [1.1, 2.2, 3.3, 4.4]
         df = pd.Series(data).apply(str)
 
@@ -1084,6 +1092,8 @@ class TestFloatColumn(unittest.TestCase):
 
         profiler = FloatColumn(df.name, options)
         report = profiler.report(remove_disabled_flag=True)
+        report_keys = list(report.keys())
+        self.assertNotIn('precision', report_keys)
 
         # With FloatOptions and remove_disabled_flag == True
         # testing key removal in NumericMixin from FloatColumnProfile
@@ -1092,16 +1102,20 @@ class TestFloatColumn(unittest.TestCase):
 
         profiler = FloatColumn(df.name, options)
         report = profiler.report(remove_disabled_flag=True)
+        sub_report_keys = list(report['precision'].keys())
+        self.assertNotIn('min', sub_report_keys)
 
         # w/o FloatOptions and remove_disabled_flag == True
         profiler = FloatColumn(df.name)
         report = profiler.report(remove_disabled_flag=True)
-
+        report_keys = list(report.keys())
+        self.assertIn('precision', report_keys)
 
         # w/o FloatOptions and remove_disabled_flag default
         profiler = FloatColumn(df.name)
         report = profiler.report()
-
+        report_keys = list(report.keys())
+        self.assertIn('precision', report_keys)
 
 
     def test_option_precision(self):


### PR DESCRIPTION
- enable use of `FloatOptions` to `pop` `is_enabled=False` keys from profile report
- add tests