### PR TITLE
Added the statistic descriptions to GitHub pages

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/docs/source/profiler.rst
+++ b/docs/source/profiler.rst
@@ -403,6 +403,103 @@ Example of specifying a seed for reproducibility.
     dp.set_seed(0)
 
 
+Profile Statistic Descriptions
+==============================
+
+Structured Profile
+~~~~~~~~~~~~~~~~~~
+
+**global_stats**:
+
+* samples_used - number of input data samples used to generate this profile
+* column_count - the number of columns contained in the input dataset
+* row_count - the number of rows contained in the input dataset
+* row_has_null_ratio - the proportion of rows that contain at least one null value to the total number of rows
+* row_is_null_ratio - the proportion of rows that are fully comprised of null values (null rows) to the total number of rows
+* unique_row_ratio - the proportion of distinct rows in the input dataset to the total number of rows
+* duplicate_row_count - the number of rows that occur more than once in the input dataset
+* file_type - the format of the file containing the input dataset (ex: .csv)
+* encoding - the encoding of the file containing the input dataset (ex: UTF-8)
+* correlation_matrix - matrix of shape `column_count` x `column_count` containing the correlation coefficients between each column in the dataset 
+* chi2_matrix - matrix of shape `column_count` x `column_count` containing the chi-square statistics between each column in the dataset
+* profile_schema - a description of the format of the input dataset labeling each column and its index in the dataset
+    * string - the label of the column in question and its index in the profile schema
+* times - the duration of time it took to generate the global statistics for this dataset in milliseconds
+
+**data_stats**:
+
+* column_name - the label/title of this column in the input dataset
+* data_type - the primitive python data type that is contained within this column
+* data_label - the label/entity of the data in this column as determined by the Labeler component
+* categorical - 'true' if this column contains categorical data
+* order - the way in which the data in this column is ordered, if any, otherwise “random”
+* samples - a small subset of data entries from this column
+* statistics - statistical information on the column
+    * sample_size - number of input data samples used to generate this profile
+    * null_count - the number of null entries in the sample
+    * null_types - a list of the different null types present within this sample
+    * null_types_index - a dict containing each null type and a respective list of the indicies that it is present within this sample
+    * data_type_representation - the percentage of samples used identifying as each data_type
+    * min - minimum value in the sample
+    * max - maximum value in the sample
+    * mode - mode of the entries in the sample
+    * median - median of the entries in the sample
+    * median_absolute_deviation - the median absolute deviation of the entries in the sample
+    * sum - the total of all sampled values from the column
+    * mean - the average of all entries in the sample
+    * variance - the variance of all entries in the sample
+    * stddev - the standard deviation of all entries in the sample
+    * skewness - the statistical skewness of all entries in the sample
+    * kurtosis - the statistical kurtosis of all entries in the sample
+    * num_zeros - the number of entries in this sample that have the value 0
+    * num_negatives - the number of entries in this sample that have a value less than 0
+    * histogram - contains histogram relevant information
+        * bin_counts - the number of entries within each bin
+        * bin_edges - the thresholds of each bin
+    * quantiles - the value at each percentile in the order they are listed based on the entries in the sample
+    * vocab - a list of the characters used within the entries in this sample
+    * avg_predictions - average of the data label prediction confidences across all data points sampled
+    * categories - a list of each distinct category within the sample if `categorial` = 'true'
+    * unique_count - the number of distinct entries in the sample
+    * unique_ratio - the proportion of the number of distinct entries in the sample to the total number of entries in the sample
+    * categorical_count - number of entries sampled for each category if `categorical` = 'true'
+    * gini_impurity - measure of how often a randomly chosen element from the set would be incorrectly labeled if it was randomly labeled according to the distribution of labels in the subset
+    * unalikeability - a value denoting how frequently entries differ from one another within the sample
+    * precision - a dict of statistics with respect to the number of digits in a number for each sample
+    * times - the duration of time it took to generate this sample's statistics in milliseconds
+    * format - list of possible datetime formats
+
+Unstructured Profile
+~~~~~~~~~~~~~~~~~~~~
+
+**global_stats**:
+
+* samples_used - number of input data samples used to generate this profile
+* empty_line_count - the number of empty lines in the input data
+* file_type - the file type of the input data (ex: .txt)
+* encoding - file encoding of the input data file (ex: UTF-8)
+* memory_size - size of the input data in MB
+* times - duration of time it took to generate this profile in milliseconds
+
+**data_stats**:
+
+* data_label - labels and statistics on the labels of the input data
+    * entity_counts - the number of times a specific label or entity appears inside the input data
+        * word_level - the number of words counted within each label or entity
+        * true_char_level - the number of characters counted within each label or entity as determined by the model
+        * postprocess_char_level - the number of characters counted within each label or entity as determined by the postprocessor
+    * entity_percentages - the percentages of each label or entity within the input data
+        * word_level - the percentage of words in the input data that are contained within each label or entity
+        * true_char_level - the percentage of characters in the input data that are contained within each label or entity as determined by the model
+        * postprocess_char_level - the percentage of characters in the input data that are contained within each label or entity as determined by the postprocessor
+    * times - the duration of time it took for the data labeler to predict on the data
+* statistics - statistics of the input data
+    * vocab - a list of each character in the input data
+    * vocab_count - the number of occurrences of each distinct character in the input data
+    * words - a list of each word in the input data
+    * word_count - the number of occurrences of each distinct word in the input data
+    * times - the duration of time it took to generate the vocab and words statistics in milliseconds
+
 
 Profile Options
 ===============
@@ -703,101 +800,3 @@ For every profile, we can provide a report and customize it with a couple option
     report  = profile.report(report_options={"output_format": "compact"})
     report  = profile.report(report_options={"output_format": "serializable"})
     report  = profile.report(report_options={"output_format": "flat"})
-
-
-Profile Statistic Descriptions
-==============================
-
-Structured Profile
-~~~~~~~~~~~~~~~~~~
-
-**global_stats**:
-
-* samples_used - number of input data samples used to generate this profile
-* column_count - the number of columns contained in the input dataset
-* row_count - the number of rows contained in the input dataset
-* row_has_null_ratio - the proportion of rows that contain at least one null value to the total number of rows
-* row_is_null_ratio - the proportion of rows that are fully comprised of null values (null rows) to the total number of rows
-* unique_row_ratio - the proportion of distinct rows in the input dataset to the total number of rows
-* duplicate_row_count - the number of rows that occur more than once in the input dataset
-* file_type - the format of the file containing the input dataset (ex: .csv)
-* encoding - the encoding of the file containing the input dataset (ex: UTF-8)
-* correlation_matrix - matrix of shape `column_count` x `column_count` containing the correlation coefficients between each column in the dataset 
-* chi2_matrix - matrix of shape `column_count` x `column_count` containing the chi-square statistics between each column in the dataset
-* profile_schema - a description of the format of the input dataset labeling each column and its index in the dataset
-    * string - the label of the column in question and its index in the profile schema
-* times - the duration of time it took to generate the global statistics for this dataset in milliseconds
-
-**data_stats**:
-
-* column_name - the label/title of this column in the input dataset
-* data_type - the primitive python data type that is contained within this column
-* data_label - the label/entity of the data in this column as determined by the Labeler component
-* categorical - 'true' if this column contains categorical data
-* order - the way in which the data in this column is ordered, if any, otherwise “random”
-* samples - a small subset of data entries from this column
-* statistics - statistical information on the column
-    * sample_size - number of input data samples used to generate this profile
-    * null_count - the number of null entries in the sample
-    * null_types - a list of the different null types present within this sample
-    * null_types_index - a dict containing each null type and a respective list of the indicies that it is present within this sample
-    * data_type_representation - the percentage of samples used identifying as each data_type
-    * min - minimum value in the sample
-    * max - maximum value in the sample
-    * mode - mode of the entries in the sample
-    * median - median of the entries in the sample
-    * median_absolute_deviation - the median absolute deviation of the entries in the sample
-    * sum - the total of all sampled values from the column
-    * mean - the average of all entries in the sample
-    * variance - the variance of all entries in the sample
-    * stddev - the standard deviation of all entries in the sample
-    * skewness - the statistical skewness of all entries in the sample
-    * kurtosis - the statistical kurtosis of all entries in the sample
-    * num_zeros - the number of entries in this sample that have the value 0
-    * num_negatives - the number of entries in this sample that have a value less than 0
-    * histogram - contains histogram relevant information
-        * bin_counts - the number of entries within each bin
-        * bin_edges - the thresholds of each bin
-    * quantiles - the value at each percentile in the order they are listed based on the entries in the sample
-    * vocab - a list of the characters used within the entries in this sample
-    * avg_predictions - average of the data label prediction confidences across all data points sampled
-    * categories - a list of each distinct category within the sample if `categorial` = 'true'
-    * unique_count - the number of distinct entries in the sample
-    * unique_ratio - the proportion of the number of distinct entries in the sample to the total number of entries in the sample
-    * categorical_count - number of entries sampled for each category if `categorical` = 'true'
-    * gini_impurity - measure of how often a randomly chosen element from the set would be incorrectly labeled if it was randomly labeled according to the distribution of labels in the subset
-    * unalikeability - a value denoting how frequently entries differ from one another within the sample
-    * precision - a dict of statistics with respect to the number of digits in a number for each sample
-    * times - the duration of time it took to generate this sample's statistics in milliseconds
-    * format - list of possible datetime formats
-
-Unstructured Profile
-~~~~~~~~~~~~~~~~~~~~
-
-**global_stats**:
-
-* samples_used - number of input data samples used to generate this profile
-* empty_line_count - the number of empty lines in the input data
-* file_type - the file type of the input data (ex: .txt)
-* encoding - file encoding of the input data file (ex: UTF-8)
-* memory_size - size of the input data in MB
-* times - duration of time it took to generate this profile in milliseconds
-
-**data_stats**:
-
-* data_label - labels and statistics on the labels of the input data
-    * entity_counts - the number of times a specific label or entity appears inside the input data
-        * word_level - the number of words counted within each label or entity
-        * true_char_level - the number of characters counted within each label or entity as determined by the model
-        * postprocess_char_level - the number of characters counted within each label or entity as determined by the postprocessor
-    * entity_percentages - the percentages of each label or entity within the input data
-        * word_level - the percentage of words in the input data that are contained within each label or entity
-        * true_char_level - the percentage of characters in the input data that are contained within each label or entity as determined by the model
-        * postprocess_char_level - the percentage of characters in the input data that are contained within each label or entity as determined by the postprocessor
-    * times - the duration of time it took for the data labeler to predict on the data
-* statistics - statistics of the input data
-    * vocab - a list of each character in the input data
-    * vocab_count - the number of occurrences of each distinct character in the input data
-    * words - a list of each word in the input data
-    * word_count - the number of occurrences of each distinct word in the input data
-    * times - the duration of time it took to generate the vocab and words statistics in milliseconds

--- a/docs/source/profiler.rst
+++ b/docs/source/profiler.rst
@@ -703,3 +703,101 @@ For every profile, we can provide a report and customize it with a couple option
     report  = profile.report(report_options={"output_format": "compact"})
     report  = profile.report(report_options={"output_format": "serializable"})
     report  = profile.report(report_options={"output_format": "flat"})
+
+
+Profile Statistic Descriptions
+==============================
+
+Structured Profile
+~~~~~~~~~~~~~~~~~~
+
+**global_stats**:
+
+* samples_used - number of input data samples used to generate this profile
+* column_count - the number of columns contained in the input dataset
+* row_count - the number of rows contained in the input dataset
+* row_has_null_ratio - the proportion of rows that contain at least one null value to the total number of rows
+* row_is_null_ratio - the proportion of rows that are fully comprised of null values (null rows) to the total number of rows
+* unique_row_ratio - the proportion of distinct rows in the input dataset to the total number of rows
+* duplicate_row_count - the number of rows that occur more than once in the input dataset
+* file_type - the format of the file containing the input dataset (ex: .csv)
+* encoding - the encoding of the file containing the input dataset (ex: UTF-8)
+* correlation_matrix - matrix of shape `column_count` x `column_count` containing the correlation coefficients between each column in the dataset 
+* chi2_matrix - matrix of shape `column_count` x `column_count` containing the chi-square statistics between each column in the dataset
+* profile_schema - a description of the format of the input dataset labeling each column and its index in the dataset
+    * string - the label of the column in question and its index in the profile schema
+* times - the duration of time it took to generate the global statistics for this dataset in milliseconds
+
+**data_stats**:
+
+* column_name - the label/title of this column in the input dataset
+* data_type - the primitive python data type that is contained within this column
+* data_label - the label/entity of the data in this column as determined by the Labeler component
+* categorical - 'true' if this column contains categorical data
+* order - the way in which the data in this column is ordered, if any, otherwise “random”
+* samples - a small subset of data entries from this column
+* statistics - statistical information on the column
+    * sample_size - number of input data samples used to generate this profile
+    * null_count - the number of null entries in the sample
+    * null_types - a list of the different null types present within this sample
+    * null_types_index - a dict containing each null type and a respective list of the indicies that it is present within this sample
+    * data_type_representation - the percentage of samples used identifying as each data_type
+    * min - minimum value in the sample
+    * max - maximum value in the sample
+    * mode - mode of the entries in the sample
+    * median - median of the entries in the sample
+    * median_absolute_deviation - the median absolute deviation of the entries in the sample
+    * sum - the total of all sampled values from the column
+    * mean - the average of all entries in the sample
+    * variance - the variance of all entries in the sample
+    * stddev - the standard deviation of all entries in the sample
+    * skewness - the statistical skewness of all entries in the sample
+    * kurtosis - the statistical kurtosis of all entries in the sample
+    * num_zeros - the number of entries in this sample that have the value 0
+    * num_negatives - the number of entries in this sample that have a value less than 0
+    * histogram - contains histogram relevant information
+        * bin_counts - the number of entries within each bin
+        * bin_edges - the thresholds of each bin
+    * quantiles - the value at each percentile in the order they are listed based on the entries in the sample
+    * vocab - a list of the characters used within the entries in this sample
+    * avg_predictions - average of the data label prediction confidences across all data points sampled
+    * categories - a list of each distinct category within the sample if `categorial` = 'true'
+    * unique_count - the number of distinct entries in the sample
+    * unique_ratio - the proportion of the number of distinct entries in the sample to the total number of entries in the sample
+    * categorical_count - number of entries sampled for each category if `categorical` = 'true'
+    * gini_impurity - measure of how often a randomly chosen element from the set would be incorrectly labeled if it was randomly labeled according to the distribution of labels in the subset
+    * unalikeability - a value denoting how frequently entries differ from one another within the sample
+    * precision - a dict of statistics with respect to the number of digits in a number for each sample
+    * times - the duration of time it took to generate this sample's statistics in milliseconds
+    * format - list of possible datetime formats
+
+Unstructured Profile
+~~~~~~~~~~~~~~~~~~~~
+
+**global_stats**:
+
+* samples_used - number of input data samples used to generate this profile
+* empty_line_count - the number of empty lines in the input data
+* file_type - the file type of the input data (ex: .txt)
+* encoding - file encoding of the input data file (ex: UTF-8)
+* memory_size - size of the input data in MB
+* times - duration of time it took to generate this profile in milliseconds
+
+**data_stats**:
+
+* data_label - labels and statistics on the labels of the input data
+    * entity_counts - the number of times a specific label or entity appears inside the input data
+        * word_level - the number of words counted within each label or entity
+        * true_char_level - the number of characters counted within each label or entity as determined by the model
+        * postprocess_char_level - the number of characters counted within each label or entity as determined by the postprocessor
+    * entity_percentages - the percentages of each label or entity within the input data
+        * word_level - the percentage of words in the input data that are contained within each label or entity
+        * true_char_level - the percentage of characters in the input data that are contained within each label or entity as determined by the model
+        * postprocess_char_level - the percentage of characters in the input data that are contained within each label or entity as determined by the postprocessor
+    * times - the duration of time it took for the data labeler to predict on the data
+* statistics - statistics of the input data
+    * vocab - a list of each character in the input data
+    * vocab_count - the number of occurrences of each distinct character in the input data
+    * words - a list of each word in the input data
+    * word_count - the number of occurrences of each distinct word in the input data
+    * times - the duration of time it took to generate the vocab and words statistics in milliseconds


### PR DESCRIPTION
Modified profiler.rst in source folder to contain a the Profiler Statistic Descriptions section that was recently added to the README.

I checked to ensure that the docs would still be generated correctly without error. This section will be added the next time the update_documentation is ran.