### PR TITLE
Binary Tree merging of multiple profiles 

### DIFF
--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -689,7 +689,9 @@ def perform_chi_squared_test_for_homogeneity(
 
 
 def merge_list_of_profiles(list_of_profiles):
-    """Using the profile object's `__add__` method,
+    """Using the profile object's `__add__` method, to merge all the
+        provided profiles in the list into a single profile, which
+        is returned by the function.
 
     :param list_of_profiles: List of Data Profiler profile objects.
         Acceptable profile types are `StructuredProfiler` and

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -686,3 +686,12 @@ def perform_chi_squared_test_for_homogeneity(
     results["p-value"] = p_value
 
     return results
+
+
+def merge_list_of_profiles(list_of_profiles):
+    """_summary_
+
+    Args:
+        list_of_profiles (_type_): _description_
+    """
+    raise NotImplementedError()

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -689,9 +689,14 @@ def perform_chi_squared_test_for_homogeneity(
 
 
 def merge_list_of_profiles(list_of_profiles):
-    """_summary_
+    """Using the profile object's `__add__` method,
 
-    Args:
-        list_of_profiles (_type_): _description_
+    :param list_of_profiles: List of Data Profiler profile objects.
+        Acceptable profile types are `StructuredProfiler` and
+        `UnstructuredProfiler`.
+    :type list_of_profiles: list
+    :return: Single profile that is the merging of all profile objects
+        provided in the parameter `list_of_profiles`.
+    :rtype: Profile
     """
     raise NotImplementedError()

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -702,3 +702,5 @@ def merge_list_of_profiles(list_of_profiles):
     :rtype: Profile
     """
     raise NotImplementedError()
+    # check all profile types in the list are the same type
+    # implement post order tree traversal DFS

--- a/dataprofiler/tests/profilers/test_utils.py
+++ b/dataprofiler/tests/profilers/test_utils.py
@@ -224,3 +224,9 @@ class TestShuffleInChunks(unittest.TestCase):
             33 / 1024**3,
             utils.get_memory_size(["This is test, a Test sentence.!!!"], unit="G"),
         )
+
+    def test_merge_list_of_profiles(self):
+        """
+        Test multiple scenarios of merging list of profiles
+        """
+        pass


### PR DESCRIPTION
Adding function to `utils.py` to take in a list of profile objects (assuming all same profile type) and merging them all together using their built in `__add__` method. 