### PR TITLE
Calculate correlation only between selected columns

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1844,7 +1844,7 @@ class StructuredProfiler(BaseProfiler):
         columns = self.options.correlation.columns
         column_ids = list(range(len(self._profile)))
         if columns is not None:
-            column_ids = [self._col_name_to_idx[col_name][0] for col_name in columns]
+            column_ids = [idx for col_name in columns for idx in self._col_name_to_idx[col_name]]
         clean_column_ids = []
         for idx in column_ids:
             data_type = (

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1842,21 +1842,23 @@ class StructuredProfiler(BaseProfiler):
         :type batch_properties: dict()
         """
         columns = self.options.correlation.columns
+        column_ids = list(range(len(self._profile)))
+        if columns is not None:
+            column_ids = [self._col_name_to_idx[col_name][0] for col_name in columns]
         clean_column_ids = []
-        if columns is None:
-            for idx in range(len(self._profile)):
-                data_type = (
-                    self._profile[idx].profiles["data_type_profile"].selected_data_type
-                )
-                if data_type not in ["int", "float"]:
-                    clean_samples.pop(idx)
-                else:
-                    clean_column_ids.append(idx)
-
+        for idx in column_ids:
+            data_type = (
+                self._profile[idx].profiles["data_type_profile"].selected_data_type
+            )
+            if data_type not in ["int", "float"]:
+                clean_samples.pop(idx)
+            else:
+                clean_column_ids.append(idx)
         data = pd.DataFrame(clean_samples).apply(pd.to_numeric, errors="coerce")
         means = {index: mean for index, mean in enumerate(batch_properties["mean"])}
         data = data.fillna(value=means)
-
+        data = data[clean_column_ids]
+        
         # Update the counts/std if needed (i.e. if null rows or exist)
         if (len(data) != batch_properties["count"]).any():
             adjusted_stds = np.sqrt(

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -707,6 +707,36 @@ class TestStructuredProfiler(unittest.TestCase):
     @mock.patch(
         "dataprofiler.profilers.profile_builder.DataLabeler", spec=StructuredDataLabeler
     )
+    def test_correlation_selected_columns(self, *mocks):
+        data = pd.DataFrame(
+            {
+                "a": [3, 2, 1, 7, 5, 9, 4, 10, 7, 2],
+                "b": [10, 11, 1, 4, 2, 5, 6, 3, 9, 8],
+                "c": [1, 5, 3, 5, 7, 2, 6, 8, 1, 2],
+                "d": [-2, 5, 1, 4, 5, 6, 0, 2, 3, 7],
+            }
+        )
+        profile_options = dp.ProfilerOptions()
+        profile_options.set(
+            {
+                "correlation.is_enabled": True,
+                "correlation.columns": ["a", "c"],
+                "structured_options.multiprocess.is_enabled": False,
+            }
+        )
+        profiler = dp.StructuredProfiler(data, options=profile_options)
+        expected_corr_mat = np.array(
+            [
+                [1.0, np.nan, 0.26594894270403086, np.nan],
+                [np.nan, np.nan, np.nan, np.nan],
+                [0.26594894270403086, np.nan, 1.0, np.nan],
+                [np.nan, np.nan, np.nan, np.nan],
+            ]
+        )
+        np.testing.assert_array_almost_equal(
+            expected_corr_mat, profiler.correlation_matrix
+        )
+
     def test_chi2(self, *mocks):
         # Empty
         data = pd.DataFrame([])

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -737,6 +737,28 @@ class TestStructuredProfiler(unittest.TestCase):
             expected_corr_mat, profiler.correlation_matrix
         )
 
+        data = data.rename(columns={"d": "b"})
+        profile_options = dp.ProfilerOptions()
+        profile_options.set(
+            {
+                "correlation.is_enabled": True,
+                "correlation.columns": ["a", "b"],
+                "structured_options.multiprocess.is_enabled": False,
+            }
+        )
+        profiler = dp.StructuredProfiler(data, options=profile_options)
+        expected_corr_mat = np.array(
+            [
+                [1.0, -0.26559389, np.nan, 0.14982219],
+                [-0.26559389, 1.0, np.nan, -0.02132435],
+                [np.nan, np.nan, np.nan, np.nan],
+                [0.14982219, -0.02132435, np.nan, 1.0],
+            ]
+        )
+        np.testing.assert_array_almost_equal(
+            expected_corr_mat, profiler.correlation_matrix
+        )
+
     def test_chi2(self, *mocks):
         # Empty
         data = pd.DataFrame([])


### PR DESCRIPTION
In the current implementation, correlation calculation between specific columns can be set with,
`profile_options = dp.ProfilerOptions()`
`profile_options.set({"correlation.columns": ["column name 1", "column name 2"]})`
But in the calculation ([Line 1834 in `profile_builder.py`](https://github.com/capitalone/DataProfiler/blob/main/dataprofiler/profilers/profile_builder.py#L1834)), correlation is correctly measured only if `correlation.columns` is not set (i.e. `correlation.columns` is `None`) and raises an error if `correlation.columns` is set. 
This PR fixes the issue and allows the user to calculate correlation between only the selected columns.

_Todo:_ Raise error if column name passed does not exist in the dataset 

_Test Coverage:_
`dataprofiler/tests/profilers/test_profile_builder.py                                              1572      2    99%`
Where the coverage is 99%