### PR TITLE
[WIP] Spearman correlation calculation

### DIFF
--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -1123,6 +1123,7 @@ class StructuredOptions(BaseOption):
         self.category = CategoricalOptions()
         self.data_labeler = DataLabelerOptions()
         self.correlation = CorrelationOptions()
+        self.spearman_correlation = CorrelationOptions()
         self.chi2_homogeneity = BooleanOption(is_enabled=True)
         # Non-Option variables
         self.null_values = null_values
@@ -1164,6 +1165,7 @@ class StructuredOptions(BaseOption):
                 ("category", CategoricalOptions),
                 ("data_labeler", DataLabelerOptions),
                 ("correlation", CorrelationOptions),
+                ("spearman_correlation", CorrelationOptions),
                 ("chi2_homogeneity", BooleanOption),
             ]
         )


### PR DESCRIPTION
Enables DataProfiler to calculate Spearman correlation with the options to allow users to enable/disable calculations or specify columns for calculations.

When ran on `Iris` dataset, the Pearson correlation and the Spearman correlation are very similar (as it should be when correlations are linear),
`'correlation_matrix': array([[ 1.        , -0.11756978,  0.87175378,  0.81794113,  0.78256123],
         [-0.11756978,  1.        , -0.4284401 , -0.36612593, -0.42665756],
         [ 0.87175378, -0.4284401 ,  1.        ,  0.96286543,  0.9490347 ],
         [ 0.81794113, -0.36612593,  0.96286543,  1.        ,  0.95654733],
         [ 0.78256123, -0.42665756,  0.9490347 ,  0.95654733,  1.        ]]),
'spearman_correlation_matrix': array([[ 1.        , -0.16677766,  0.88189813,  0.83428878,  0.79807812],
         [-0.16677766,  1.        , -0.30963509, -0.28903175, -0.44028958],
         [ 0.88189813, -0.30963509,  1.        ,  0.93766682,  0.93543052],
         [ 0.83428878, -0.28903175,  0.93766682,  1.        ,  0.93817917],
         [ 0.79807812, -0.44028958,  0.93543052,  0.93817917,  1.        ]]),
` 

Spearman mainly has 2 advantages over Pearson:
1.  **Robustness to outliers**: When introduced an outlier in the 'petal length (cm)' column by `iris['petal length (cm)'][random_index] = 100`, Pearson correlation of the column changes drastically from,
 [ 0.87175378, -0.4284401 ,  1.        ,  0.96286543,  0.9490347 ] to  [ 0.23429883, -0.0503025 ,  1.        ,  0.34474503,  0.30366187]
Whereas Spearman correlation of the column changes from,
[ 0.88189813, -0.30963509,  1.        ,  0.93766682,  0.93543052] to [ 0.88048828, -0.30861155,  1.        ,  0.9383322 ,  0.93542968] 
2. **Detecting non-linear monotonic relationships**: When introduced a new column as a exponential function of an old column by `iris['exp'] = iris.apply(lambda row: row['petal length (cm)']**10, axis=1)`, the Pearson correlation between columns 'exp' and 'petal length (cm)' is 0.56452528 whereas Spearman correlation is 1.

_Todo_:
* Find out how/where to store ranked_mean and ranked_var for spearman correlation merging/updates
* Update ranked_mean and ranked_var on profile merging/updates
* Update Spearman correlation on profile merging/updates
* Write tests