### PR TITLE
SyntheticDataOptions and metrics calculations for NaN replication

### DIFF
--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -932,6 +932,34 @@ class CorrelationOptions(BaseInspectorOptions):
         return errors
 
 
+class SyntheticDataOptions(BaseInspectorOptions):
+    """For configuring options for synthetic data generation"""
+
+    def __init__(self):
+        """
+        Initialize options for synthetic data generation
+        :ivar is_enabled: boolean option to enable/disable synthetic data generation options
+        :vartype is_enabled: BooleanOption
+        :ivar replicate_nan: boolean option to enable/disable calculating metrics needed for
+        replicating nan values in synthetic data generator
+        :vartype replicate_nan: BooleanOption
+        """
+
+        self.replicate_nan = BooleanOption(is_enabled=True)
+        super().__init__(is_enabled=False)
+
+    def _validate_helper(self, variable_path="SyntheticDataOptions"):
+        """
+        Validate the options do not conflict and cause errors.
+
+        :param variable_path: current path to variable set.
+        :type variable_path: str
+        :return: list of errors (if raise_error is false)
+        :rtype: list(str)
+        """
+        return super()._validate_helper(variable_path)
+
+
 class DataLabelerOptions(BaseInspectorOptions):
     """For configuring options for Data Labeler Column."""
 
@@ -1156,6 +1184,8 @@ class StructuredOptions(BaseOption):
         :vartype correlation: CorrelationOptions
         :ivar chi2_homogeneity: option set for chi2_homogeneity matrix
         :vartype chi2_homogeneity: BooleanOption()
+        :ivar synthetic_data: option set for metrics calculation for synthetic data gen
+        :vartype synthetic_data: SyntheticDataOptions
         :ivar null_values: option set for defined null values
         :vartype null_values: Union[None, dict]
         """
@@ -1170,6 +1200,7 @@ class StructuredOptions(BaseOption):
         self.data_labeler = DataLabelerOptions()
         self.correlation = CorrelationOptions()
         self.chi2_homogeneity = BooleanOption(is_enabled=True)
+        self.synthetic_data = SyntheticDataOptions()
         # Non-Option variables
         self.null_values = null_values
 
@@ -1211,6 +1242,7 @@ class StructuredOptions(BaseOption):
                 ("data_labeler", DataLabelerOptions),
                 ("correlation", CorrelationOptions),
                 ("chi2_homogeneity", BooleanOption),
+                ("synthetic_data", SyntheticDataOptions),
             ]
         )
         properties = self.properties

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -759,3 +759,20 @@ def merge_profile_list(list_of_profiles, pool_count=5):
 
     list_of_profiles[0]._restore_data_labelers(data_labeler)
     return list_of_profiles[0]
+
+
+def combine_means(mean1, mean2, n1, n2):
+    """Combine two mean vectors
+
+    :param mean1: First mean vector
+    :type mean1: np.ndarray
+    :param mean2: Second mean vector
+    :type mean2: np.ndarray
+    :param n1: Number of samples mean1 was calculated from
+    :type n1: int
+    :param n2: Number of samples mean2 was calculated from
+    :type n2: int
+    :return: Combined mean vector
+    :rtype: np.ndarray
+    """
+    return (mean1 * n1 + mean2 * n2) / (n1 + n2)

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -27,7 +27,7 @@ class TestProfilerOptions(unittest.TestCase):
         self.assertTrue(profile.options.data_labeler.is_enabled)
         for column in profile.options.properties:
             # TODO: remove the check for correlation option once it's updated to True
-            if column == "correlation":
+            if column == "correlation" or column == "synthetic_data":
                 self.assertFalse(profile.options.properties[column].is_enabled)
             elif column == "null_values":
                 self.assertIsNone(profile.options.properties[column])


### PR DESCRIPTION
Added `SyntheticDataOptions` which can be set using `profile_options.set({"synthetic_data.is_enabled": True})`. This enables calculation of metrics specifically needed for `capitalone/synthetic-data`.

Added calculation of metrics needed by `capitalone/synthetic-data` for replicating NaN values in the generated dataset.