### PR TITLE
Add property array to continuous distribution profile in GraphProfiler/ Integer Node ID identified as Integer in GraphData

### DIFF
--- a/dataprofiler/data_readers/graph_data.py
+++ b/dataprofiler/data_readers/graph_data.py
@@ -159,7 +159,7 @@ class GraphData(BaseData):
 
     def _format_data_networkx(self):
         """Format the input file into a networkX graph."""
-        networkx_graph = nx.DiGraph()
+        networkx_graph = nx.Graph()
 
         # read lines from csv
         csv_as_list = []
@@ -189,10 +189,12 @@ class GraphData(BaseData):
                         csv_as_list[line][column]
                     )
                 elif column is self._source_node or column is self._destination_node:
-                    networkx_graph.add_node(csv_as_list[line][column])
+                    networkx_graph.add_node(
+                        self.check_integer(csv_as_list[line][column])
+                    )
             networkx_graph.add_edge(
-                csv_as_list[line][self._source_node],
-                csv_as_list[line][self._destination_node],
+                self.check_integer(csv_as_list[line][self._source_node]),
+                self.check_integer(csv_as_list[line][self._destination_node]),
                 **attributes
             )
 
@@ -206,3 +208,13 @@ class GraphData(BaseData):
             self._data = data
         else:
             self._data = self._format_data_networkx()
+
+    def check_integer(self, string):
+        """Check whether string is integer and output integer."""
+        stringVal = string
+        if string[0] == ("-", "+"):
+            stringVal = string[1:]
+        if stringVal.isdigit():
+            return int(string)
+        else:
+            return string

--- a/dataprofiler/data_readers/graph_data.py
+++ b/dataprofiler/data_readers/graph_data.py
@@ -70,8 +70,7 @@ class GraphData(BaseData):
         self._quotechar = options.get("quotechar", None)
         self._header = options.get("header", "auto")
 
-        if data is not None:
-            self._load_data(data)
+        self._load_data(data)
 
     @classmethod
     def _find_target_string_in_column(self, column_names, keyword_list):

--- a/dataprofiler/profilers/graph_profiler.py
+++ b/dataprofiler/profilers/graph_profiler.py
@@ -277,8 +277,12 @@ class GraphProfile(object):
         Compute the continuous distribution of graph edge continuous attributes.
 
         Returns properties array in the profile:
+        [optional: shape, loc, scale, mean, variance, skew, kurtosis]
+
         - 6-property length: norm, uniform, expon, logistic
         - 7-property length: gamma, lognorm
+            - gamma: shape=a
+            - lognorm: shape=s
         """
         attributes = self._find_all_attributes(graph)
         continuous_distributions = dict()

--- a/dataprofiler/profilers/graph_profiler.py
+++ b/dataprofiler/profilers/graph_profiler.py
@@ -310,19 +310,8 @@ class GraphProfile(object):
                         best_fit = distribution.name
                         best_mle = mle
 
-                properties = []
-
                 mean, variance, skew, kurtosis = distribution.stats(fit, moments="mvsk")
-
-                if best_fit == "lognorm":
-                    shape, loc, scale = fit
-                    properties = [shape, loc, scale, mean, variance, skew, kurtosis]
-                elif best_fit == "gamma":
-                    a, loc, scale = fit
-                    properties = [a, loc, scale, mean, variance, skew, kurtosis]
-                else:
-                    loc, scale = fit
-                    properties = [loc, scale, mean, variance, skew, kurtosis]
+                properties = list(fit) + [mean, variance, skew, kurtosis]
 
                 continuous_distributions[attribute] = {
                     "name": best_fit,

--- a/dataprofiler/profilers/graph_profiler.py
+++ b/dataprofiler/profilers/graph_profiler.py
@@ -301,6 +301,8 @@ class GraphProfile(object):
                 df = pd.Series(data_as_list)
                 best_fit = None
                 best_mle = 1000
+                best_fit_properties = None
+
                 for distribution in distribution_candidates:
                     # compute fit, mle, kolmogorov-smirnov test to test fit, and pdf
                     fit = distribution.fit(df)
@@ -309,9 +311,17 @@ class GraphProfile(object):
                     if mle <= best_mle:
                         best_fit = distribution.name
                         best_mle = mle
+                        best_fit_properties = fit
 
-                mean, variance, skew, kurtosis = distribution.stats(fit, moments="mvsk")
-                properties = list(fit) + [mean, variance, skew, kurtosis]
+                mean, variance, skew, kurtosis = distribution.stats(
+                    best_fit_properties, moments="mvsk"
+                )
+                properties = list(best_fit_properties) + [
+                    mean,
+                    variance,
+                    skew,
+                    kurtosis,
+                ]
 
                 continuous_distributions[attribute] = {
                     "name": best_fit,

--- a/dataprofiler/tests/data_readers/test_csv_graph_data.py
+++ b/dataprofiler/tests/data_readers/test_csv_graph_data.py
@@ -20,16 +20,16 @@ class TestGraphDataClass(unittest.TestCase):
                 path=os.path.join(
                     test_dir, "csv/graph-differentiator-input-positive.csv"
                 ),
-                list_nodes=["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+                list_nodes=[1, 2, 3, 4, 5, 6, 7, 8, 9],
                 list_edges=[
-                    ("2", "1"),
-                    ("3", "2"),
-                    ("4", "2"),
-                    ("5", "2"),
-                    ("6", "2"),
-                    ("7", "2"),
-                    ("8", "2"),
-                    ("9", "2"),
+                    (2, 1),
+                    (3, 2),
+                    (4, 2),
+                    (5, 2),
+                    (6, 2),
+                    (7, 2),
+                    (8, 2),
+                    (9, 2),
                 ],
                 options={"header": 0, "delimiter": ","},
                 encoding="utf-8",
@@ -38,23 +38,23 @@ class TestGraphDataClass(unittest.TestCase):
                 path=os.path.join(
                     test_dir, "csv/graph-differentiator-input-standard-positive.csv"
                 ),
-                list_nodes=["1", "2", "3", "4"],
-                list_edges=[("2", "1"), ("1", "3"), ("2", "4")],
+                list_nodes=[1, 2, 3, 4],
+                list_edges=[(2, 1), (1, 3), (2, 4)],
                 options={"header": 0, "delimiter": ","},
                 encoding="utf-8",
             ),
             dict(
                 path=os.path.join(test_dir, "csv/graph-data-input-positive-header.csv"),
-                list_nodes=["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+                list_nodes=[1, 2, 3, 4, 5, 6, 7, 8, 9],
                 list_edges=[
-                    ("2", "1"),
-                    ("3", "2"),
-                    ("4", "2"),
-                    ("5", "2"),
-                    ("6", "2"),
-                    ("7", "2"),
-                    ("8", "2"),
-                    ("9", "2"),
+                    (2, 1),
+                    (3, 2),
+                    (4, 2),
+                    (5, 2),
+                    (6, 2),
+                    (7, 2),
+                    (8, 2),
+                    (9, 2),
                 ],
                 options={"header": 2, "delimiter": ","},
                 encoding="utf-8",
@@ -188,7 +188,7 @@ class TestGraphDataClass(unittest.TestCase):
             data_edges = list(data.edges)
 
             for edge in input_file["list_edges"]:
-                if edge not in data_edges:
+                if edge not in data_edges and (edge[1], edge[0]) not in data_edges:
                     all_edges_present = False
             self.assertTrue(all_edges_present)
 

--- a/dataprofiler/tests/profilers/test_graph_profiler.py
+++ b/dataprofiler/tests/profilers/test_graph_profiler.py
@@ -74,6 +74,16 @@ class TestGraphProfiler(unittest.TestCase):
             np.array([6.40046067, 3.52941176, 12.24828996]),
         ]
 
+    def check_properties(self, properties):
+        """Tests the properties array for continuous distribution"""
+        for index, property in enumerate(properties):
+            if isinstance(property, np.ndarray):
+                np.testing.assert_array_almost_equal(
+                    self.expected_props[index], property
+                )
+            else:
+                self.assertAlmostEqual(self.expected_props[index], property)
+
     def test_profile(self):
         graph_profile = GraphProfile("test_update")
         with utils.mock_timeit():
@@ -82,22 +92,8 @@ class TestGraphProfiler(unittest.TestCase):
         properties = profile.profile["continuous_distribution"]["weight"].pop(
             "properties"
         )
-
         self.assertAlmostEqual(scale, -15.250985118262854)
-        index = 0
-        for item in properties:
-            if isinstance(item, np.ndarray):
-                item = list(item)
-                np_index = 0
-                for np_item in item:
-                    self.assertAlmostEqual(
-                        np_item, self.expected_props[index][np_index]
-                    )
-                    np_index += 1
-            else:
-                self.assertAlmostEqual(self.expected_props[index], item)
-            index += 1
-
+        self.check_properties(properties)
         self.assertDictEqual(self.expected_profile, profile.profile)
 
     def test_report(self):
@@ -109,21 +105,7 @@ class TestGraphProfiler(unittest.TestCase):
             "properties"
         )
         self.assertAlmostEqual(scale, -15.250985118262854)
-
-        index = 0
-        for item in properties:
-            if isinstance(item, np.ndarray):
-                item = list(item)
-                np_index = 0
-                for np_item in item:
-                    self.assertAlmostEqual(
-                        np_item, self.expected_props[index][np_index]
-                    )
-                    np_index += 1
-            else:
-                self.assertAlmostEqual(self.expected_props[index], item)
-            index += 1
-
+        self.check_properties(properties)
         self.assertDictEqual(self.expected_profile, graph_profile.report())
 
     def test_graph_data_object(self):
@@ -136,21 +118,7 @@ class TestGraphProfiler(unittest.TestCase):
             "properties"
         )
         self.assertAlmostEqual(scale, -15.250985118262854)
-
-        index = 0
-        for item in properties:
-            if isinstance(item, np.ndarray):
-                item = list(item)
-                np_index = 0
-                for np_item in item:
-                    self.assertAlmostEqual(
-                        np_item, self.expected_props[index][np_index]
-                    )
-                    np_index += 1
-            else:
-                self.assertAlmostEqual(self.expected_props[index], item)
-            index += 1
-
+        self.check_properties(properties)
         self.assertDictEqual(self.expected_profile, profile.profile)
 
 

--- a/dataprofiler/tests/profilers/test_graph_profiler.py
+++ b/dataprofiler/tests/profilers/test_graph_profiler.py
@@ -74,9 +74,9 @@ class TestGraphProfiler(unittest.TestCase):
             np.array([6.40046067, 3.52941176, 12.24828996]),
         ]
 
-    def check_properties(self, properties):
+    def check_continuous_properties(self, continuous_distribution_props):
         """Tests the properties array for continuous distribution"""
-        for index, property in enumerate(properties):
+        for index, property in enumerate(continuous_distribution_props):
             if isinstance(property, np.ndarray):
                 np.testing.assert_array_almost_equal(
                     self.expected_props[index], property
@@ -89,11 +89,11 @@ class TestGraphProfiler(unittest.TestCase):
         with utils.mock_timeit():
             profile = graph_profile.update(self.graph)
         scale = profile.profile["continuous_distribution"]["weight"].pop("scale")
-        properties = profile.profile["continuous_distribution"]["weight"].pop(
-            "properties"
-        )
+        continuous_distribution_props = profile.profile["continuous_distribution"][
+            "weight"
+        ].pop("properties")
         self.assertAlmostEqual(scale, -15.250985118262854)
-        self.check_properties(properties)
+        self.check_continuous_properties(continuous_distribution_props)
         self.assertDictEqual(self.expected_profile, profile.profile)
 
     def test_report(self):
@@ -101,11 +101,11 @@ class TestGraphProfiler(unittest.TestCase):
         with utils.mock_timeit():
             profile = graph_profile.update(self.graph)
         scale = profile.profile["continuous_distribution"]["weight"].pop("scale")
-        properties = profile.profile["continuous_distribution"]["weight"].pop(
-            "properties"
-        )
+        continuous_distribution_props = profile.profile["continuous_distribution"][
+            "weight"
+        ].pop("properties")
         self.assertAlmostEqual(scale, -15.250985118262854)
-        self.check_properties(properties)
+        self.check_continuous_properties(continuous_distribution_props)
         self.assertDictEqual(self.expected_profile, graph_profile.report())
 
     def test_graph_data_object(self):
@@ -114,11 +114,11 @@ class TestGraphProfiler(unittest.TestCase):
         with utils.mock_timeit():
             profile = graph_profile.update(data)
         scale = profile.profile["continuous_distribution"]["weight"].pop("scale")
-        properties = profile.profile["continuous_distribution"]["weight"].pop(
-            "properties"
-        )
+        continuous_distribution_props = profile.profile["continuous_distribution"][
+            "weight"
+        ].pop("properties")
         self.assertAlmostEqual(scale, -15.250985118262854)
-        self.check_properties(properties)
+        self.check_continuous_properties(continuous_distribution_props)
         self.assertDictEqual(self.expected_profile, profile.profile)
 
 

--- a/dataprofiler/tests/profilers/test_graph_profiler.py
+++ b/dataprofiler/tests/profilers/test_graph_profiler.py
@@ -6,6 +6,7 @@ from cgi import test
 from collections import defaultdict
 
 import networkx as nx
+import numpy as np
 
 from dataprofiler.data_readers.graph_data import GraphData
 from dataprofiler.profilers.graph_profiler import GraphProfile
@@ -63,12 +64,40 @@ class TestGraphProfiler(unittest.TestCase):
             ),
         )
 
+        cls.expected_props = [
+            0.9374325237312068,
+            1.6999999999999997,
+            0.4898643008759932,
+            np.array([0.93743252, 1.7, 0.4898643]),
+            np.array([0.93743252, 1.7, 0.4898643]),
+            np.array([2.06566546, 1.53392998, 2.85753856]),
+            np.array([6.40046067, 3.52941176, 12.24828996]),
+        ]
+
     def test_profile(self):
         graph_profile = GraphProfile("test_update")
         with utils.mock_timeit():
             profile = graph_profile.update(self.graph)
         scale = profile.profile["continuous_distribution"]["weight"].pop("scale")
+        properties = profile.profile["continuous_distribution"]["weight"].pop(
+            "properties"
+        )
+
         self.assertAlmostEqual(scale, -15.250985118262854)
+        index = 0
+        for item in properties:
+            if isinstance(item, np.ndarray):
+                item = list(item)
+                np_index = 0
+                for np_item in item:
+                    self.assertAlmostEqual(
+                        np_item, self.expected_props[index][np_index]
+                    )
+                    np_index += 1
+            else:
+                self.assertAlmostEqual(self.expected_props[index], item)
+            index += 1
+
         self.assertDictEqual(self.expected_profile, profile.profile)
 
     def test_report(self):
@@ -76,7 +105,25 @@ class TestGraphProfiler(unittest.TestCase):
         with utils.mock_timeit():
             profile = graph_profile.update(self.graph)
         scale = profile.profile["continuous_distribution"]["weight"].pop("scale")
+        properties = profile.profile["continuous_distribution"]["weight"].pop(
+            "properties"
+        )
         self.assertAlmostEqual(scale, -15.250985118262854)
+
+        index = 0
+        for item in properties:
+            if isinstance(item, np.ndarray):
+                item = list(item)
+                np_index = 0
+                for np_item in item:
+                    self.assertAlmostEqual(
+                        np_item, self.expected_props[index][np_index]
+                    )
+                    np_index += 1
+            else:
+                self.assertAlmostEqual(self.expected_props[index], item)
+            index += 1
+
         self.assertDictEqual(self.expected_profile, graph_profile.report())
 
     def test_graph_data_object(self):
@@ -85,7 +132,25 @@ class TestGraphProfiler(unittest.TestCase):
         with utils.mock_timeit():
             profile = graph_profile.update(data)
         scale = profile.profile["continuous_distribution"]["weight"].pop("scale")
+        properties = profile.profile["continuous_distribution"]["weight"].pop(
+            "properties"
+        )
         self.assertAlmostEqual(scale, -15.250985118262854)
+
+        index = 0
+        for item in properties:
+            if isinstance(item, np.ndarray):
+                item = list(item)
+                np_index = 0
+                for np_item in item:
+                    self.assertAlmostEqual(
+                        np_item, self.expected_props[index][np_index]
+                    )
+                    np_index += 1
+            else:
+                self.assertAlmostEqual(self.expected_props[index], item)
+            index += 1
+
         self.assertDictEqual(self.expected_profile, profile.profile)
 
 

--- a/dataprofiler/tests/profilers/test_graph_profiler.py
+++ b/dataprofiler/tests/profilers/test_graph_profiler.py
@@ -65,13 +65,13 @@ class TestGraphProfiler(unittest.TestCase):
         )
 
         cls.expected_props = [
-            0.9374325237312068,
+            8.646041719759628,
             1.6999999999999997,
-            0.4898643008759932,
-            np.array([0.93743252, 1.7, 0.4898643]),
-            np.array([0.93743252, 1.7, 0.4898643]),
-            np.array([2.06566546, 1.53392998, 2.85753856]),
-            np.array([6.40046067, 3.52941176, 12.24828996]),
+            0.19403886939727638,
+            np.array([8.64604172, 1.7, 0.19403887]),
+            np.array([8.64604172, 1.7, 0.19403887]),
+            np.array([0.68017604, 1.53392998, 4.54031127]),
+            np.array([0.69395918, 3.52941176, 30.92163966]),
         ]
 
     def check_continuous_properties(self, continuous_distribution_props):
@@ -93,6 +93,7 @@ class TestGraphProfiler(unittest.TestCase):
             "weight"
         ].pop("properties")
         self.assertAlmostEqual(scale, -15.250985118262854)
+        print(continuous_distribution_props)
         self.check_continuous_properties(continuous_distribution_props)
         self.assertDictEqual(self.expected_profile, profile.profile)
 


### PR DESCRIPTION
Add property array to continuous distribution profile in GraphProfiler, necessary for tasks requiring replication of distribution.