### PR TITLE
Hot fix/notebook

### DIFF
--- a/examples/merge_profile_list.ipynb
+++ b/examples/merge_profile_list.ipynb
@@ -5,7 +5,7 @@
    "id": "60af5256",
    "metadata": {},
    "source": [
-    "# Overview\n",
+    "# Merge List of Profiles\n",
     "\n",
     "This is an example of a new utils in the dataprofiler for distributed merging of profile objects. This assumes the user is providing a list of profile objects to the utils function for merging all the profiles together."
    ]
@@ -15,7 +15,7 @@
    "id": "7eee37ff",
    "metadata": {},
    "source": [
-    "# Imports\n",
+    "## Imports\n",
     "\n",
     "Let's start by importing the necessary packages..."
    ]


### PR DESCRIPTION
Fixing `#` to `##` on a markdown cell formatting 