### PR TITLE
Hot Fix: Typo in Graph Docstring

### DIFF
--- a/dataprofiler/profilers/graph_profiler.py
+++ b/dataprofiler/profilers/graph_profiler.py
@@ -77,7 +77,7 @@ class GraphProfiler(object):
 
     def diff(self, other_profile, options=None):
         """
-        Find the differences for two unstructured text profiles.
+        Find the differences for two graph profiles.
 
         :param other_profile: profile to find the difference with
         :type other_profile: GraphProfiler


### PR DESCRIPTION
typo in docstring in graph `diff()` method