### PR TITLE
formatting issue for 0.7.11 docs

### DIFF
--- a/examples/graph_data_demo.ipynb
+++ b/examples/graph_data_demo.ipynb
@@ -73,7 +73,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Profile"
+    "## Profile"
    ]
   },
   {
@@ -141,7 +141,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Conclusion"
+    "## Conclusion"
    ]
   },
   {


### PR DESCRIPTION
fixing markdown cell formatting for hyperlinking in the sphinx Table of contents bar in the sphinx documentation for 0.7.11