### PR TITLE
Presets for ProfilerOptions

### DIFF
--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -1323,7 +1323,7 @@ class UnstructuredOptions(BaseOption):
 class ProfilerOptions(BaseOption):
     """For configuring options for profiler."""
 
-    def __init__(self):
+    def __init__(self, presets=None):
         """
         Initialize the ProfilerOptions object.
 
@@ -1334,6 +1334,26 @@ class ProfilerOptions(BaseOption):
         """
         self.structured_options = StructuredOptions()
         self.unstructured_options = UnstructuredOptions()
+        self.presets = presets
+        if self.presets:
+            if self.presets=="complete":
+                self._complete_presets()
+            elif self.presets=="data_types":
+                self._data_types_presets()
+            elif self.presets=="numeric_stats_disabled":
+                self._numeric_stats_disabled_presets()
+
+    def _complete_presets(self):
+        self.set({"*.is_enabled":True})
+
+    def _data_types_presets(self):
+        self.set({"*.is_enabled":False})
+        self.set({"*.data_labeler.is_enabled":True})
+
+    def _numeric_stats_disabled_presets(self):
+        self.set({"*.int.is_numeric_stats_enabled": False})
+        self.set({"*.float.is_numeric_stats_enabled": False})
+        self.set({"structured_options.text.is_numeric_stats_enabled": False})
 
     def _validate_helper(self, variable_path="ProfilerOptions"):
         """

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_preset.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_preset.py
@@ -1,0 +1,44 @@
+import os
+import unittest
+from unittest import mock
+
+import numpy as np
+import pandas as pd
+
+from dataprofiler import Data, Profiler, ProfilerOptions
+from dataprofiler.labelers.base_data_labeler import BaseDataLabeler
+from dataprofiler.profilers.profiler_options import FloatOptions, IntOptions
+
+
+@mock.patch(
+    "dataprofiler.profilers.data_labeler_column_profile." "DataLabelerColumn.update",
+    return_value=None,
+)
+@mock.patch("dataprofiler.profilers.profile_builder.DataLabeler", spec=BaseDataLabeler)
+class TestProfilerPreset(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = Data(data=pd.DataFrame([1, 2]), data_type="csv")
+
+    def test_profiler_preset_complete(self, *mocks):
+        options = ProfilerOptions(presets="complete")
+        self.assertTrue(options.structured_options.correlation)
+        self.assertTrue(options.structured_options.null_replication_metrics.is_enabled)
+
+    def test_profiler_preset_data_types(self, *mocks):
+        options = ProfilerOptions(presets="data_types")
+        self.assertTrue(options.structured_options.data_labeler.is_enabled)
+        self.assertFalse(options.structured_options.correlation.is_enabled)
+        self.assertFalse(options.structured_options.null_replication_metrics.is_enabled)
+
+    def test_profiler_preset_numeric_stats_disabled(self, *mocks):
+        options = ProfilerOptions(presets="numeric_stats_disabled")
+        self.assertTrue(options.structured_options.data_labeler.is_enabled)
+        self.assertFalse(options.structured_options.int.is_numeric_stats_enabled)
+        self.assertFalse(options.structured_options.text.is_numeric_stats_enabled)
+        self.assertFalse(options.structured_options.float.is_numeric_stats_enabled)
+        self.assertFalse(options.structured_options.correlation.is_enabled)
+        self.assertFalse(options.structured_options.null_replication_metrics.is_enabled)
+        self.assertTrue(options.structured_options.category.is_enabled)
+        self.assertTrue(options.structured_options.order.is_enabled)
+

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_preset.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_preset.py
@@ -2,12 +2,10 @@ import os
 import unittest
 from unittest import mock
 
-import numpy as np
 import pandas as pd
 
 from dataprofiler import Data, Profiler, ProfilerOptions
 from dataprofiler.labelers.base_data_labeler import BaseDataLabeler
-from dataprofiler.profilers.profiler_options import FloatOptions, IntOptions
 
 
 @mock.patch(
@@ -16,9 +14,6 @@ from dataprofiler.profilers.profiler_options import FloatOptions, IntOptions
 )
 @mock.patch("dataprofiler.profilers.profile_builder.DataLabeler", spec=BaseDataLabeler)
 class TestProfilerPreset(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.data = Data(data=pd.DataFrame([1, 2]), data_type="csv")
 
     def test_profiler_preset_complete(self, *mocks):
         options = ProfilerOptions(presets="complete")
@@ -27,6 +22,7 @@ class TestProfilerPreset(unittest.TestCase):
 
     def test_profiler_preset_data_types(self, *mocks):
         options = ProfilerOptions(presets="data_types")
+        self.assertTrue(options.unstructured_options.data_labeler.is_enabled)
         self.assertTrue(options.structured_options.data_labeler.is_enabled)
         self.assertFalse(options.structured_options.correlation.is_enabled)
         self.assertFalse(options.structured_options.null_replication_metrics.is_enabled)


### PR DESCRIPTION
Added the following presets:
1. complete
2. data_types
3. numeric_stats_disabled

The test cases are also added in dataprofiler/tests/profilers/profiler_options/test_profiler_preset.py