### PR TITLE
Fix bug with loading data labeler from disk

### DIFF
--- a/dataprofiler/labelers/base_data_labeler.py
+++ b/dataprofiler/labelers/base_data_labeler.py
@@ -468,11 +468,11 @@ class BaseDataLabeler(object):
             if not isinstance(model_class, BaseModel):
                 raise TypeError("`model_class` must be a BaseModel")
             param_model_class = params.get("model", {}).get("class", None)
-            if param_model_class != model_class.__name__:
+            if param_model_class != model_class.__class__.__name__:
                 raise ValueError(
                     "The load_options model class does not match "
                     "the required DataLabeler model.\n {} != {}".format(
-                        model_class.__name__, param_model_class
+                        model_class.__class__.__name__, param_model_class
                     )
                 )
             params["model"]["class"] = model_class
@@ -483,11 +483,13 @@ class BaseDataLabeler(object):
                     "`preprocessor_class` must be a " "BaseDataPreprocessor"
                 )
             param_processor_class = params.get("preprocessor", {}).get("class", None)
-            if param_processor_class != processor_class:
+            if param_processor_class != processor_class.__class__.__name__:
                 raise ValueError(
                     "The load_options preprocessor class does not "
                     "match the required DataLabeler preprocessor."
-                    "\n {} != {}".format(processor_class, param_processor_class)
+                    "\n {} != {}".format(
+                        processor_class.__class__.__name__, param_processor_class
+                    )
                 )
             params["preprocessor"]["class"] = load_options.get("preprocessor_class")
         if "postprocessor_class" in load_options:
@@ -497,11 +499,11 @@ class BaseDataLabeler(object):
                     "`postprocessor_class` must be a " "BaseDataPostprocessor"
                 )
             param_processor_class = params.get("postprocessor", {}).get("class", None)
-            if param_processor_class != processor_class.__name__:
+            if param_processor_class != processor_class.__class__.__name__:
                 raise ValueError(
                     "The load_options postprocessor class does not match "
                     "the required DataLabeler postprocessor.\n {} != {}".format(
-                        processor_class.__name__, param_processor_class
+                        processor_class.__class__.__name__, param_processor_class
                     )
                 )
             params["postprocessor"]["class"] = load_options.get("postprocessor_class")

--- a/dataprofiler/tests/labelers/test_unstructured_data_labeler.py
+++ b/dataprofiler/tests/labelers/test_unstructured_data_labeler.py
@@ -128,7 +128,7 @@ class TestDataLabeler(unittest.TestCase):
             ".* != .*",
         ):
             mocked_model = mock.Mock(spec=CharacterLevelCnnModel)
-            mocked_model.__name__ = "FakeClassName"
+            mocked_model.__class__.__name__ = "FakeClassName"
             load_options = dict(model_class=mocked_model)
             UnstructuredDataLabeler._load_parameters("test/path", load_options)
 
@@ -147,7 +147,7 @@ class TestDataLabeler(unittest.TestCase):
             "preprocessor.\n .* != .*",
         ):
             mocked_preprocessor = mock.Mock(spec=data_processing.BaseDataPreprocessor)
-            mocked_preprocessor.__name__ = "FakeProcessorName"
+            mocked_preprocessor.__class__.__name__ = "FakeProcessorName"
             load_options = dict(preprocessor_class=mocked_preprocessor)
             UnstructuredDataLabeler._load_parameters("test/path", load_options)
 


### PR DESCRIPTION
When `DataLabeler` is passed in a `dirpath` parameter, it loads from the disk and calls `_load_parameters` in `base_data_labeler.py`. However, there is a bug when the code checks if the model, preprocessor, or postprocessor matches the one specified in the saved DataLabeler.

```Python
from dataprofiler.labelers import DataLabeler, CharPreprocessor, CharPostprocessor
from dataprofiler.labelers.character_level_cnn_model import CharacterLevelCnnModel

data_labeler = DataLabeler(labeler_type="unstructured")
data_labeler.save_to_disk("temp")

label_mapping = {"PAD": 0, "CITY": 1, "UNKNOWN": 1, "ADDRESS": 2}
load_options = {
    "model_class": CharacterLevelCnnModel(label_mapping=label_mapping),
    "preprocessor_class": CharPreprocessor(),
    "postprocessor_class": CharPostprocessor(),
}

new_data_labeler = DataLabeler(labeler_type='unstructured', dirpath="temp", load_options=load_options)
```

This code generates the error: `'CharacterLevelCNNModel' object has no attribute '__name__'`. This is because instances do not have this attribute. The class does however, so all occurrences in the code should be replaced with `__class__.__name__`. After changing this, the example code works.