### PR TITLE
Allow diff to set format options for prepare report

### DIFF
--- a/dataprofiler/data_readers/structured_mixins.py
+++ b/dataprofiler/data_readers/structured_mixins.py
@@ -1,6 +1,7 @@
 """Contains mixin data class for loading datasets of tye SpreadSheet."""
 from logging import Logger
 from typing import Any, Dict, List, Optional, Union
+
 import pandas as pd
 
 from .. import dp_logging
@@ -44,7 +45,7 @@ class SpreadSheetDataMixin(object):
         """Load the data into memory from the file."""
         raise NotImplementedError()
 
-    def _load_data(self, data: Optional[Union[pd.DataFrame, str]]=None) -> None:
+    def _load_data(self, data: Optional[Union[pd.DataFrame, str]] = None) -> None:
         """Load either the specified data or the input_file into memory."""
         if data is not None:
             if isinstance(data, pd.DataFrame):

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1177,7 +1177,7 @@ class UnstructuredProfiler(BaseProfiler):
         return merged_profile
 
     def diff(  # type: ignore[override]
-        self, other_profile: UnstructuredProfiler, options: Dict = None
+        self, other_profile: UnstructuredProfiler, options: Optional[Dict] = None
     ) -> Dict:
         """
         Find difference between 2 unstuctured profiles and return the report.
@@ -1189,6 +1189,9 @@ class UnstructuredProfiler(BaseProfiler):
         :return: difference of the profiles
         :rtype: dict
         """
+        if options is None:
+            options = {}
+
         report = super().diff(other_profile, options)
 
         report["global_stats"].update(
@@ -1208,7 +1211,11 @@ class UnstructuredProfiler(BaseProfiler):
         report["data_stats"] = self._profile.diff(
             other_profile._profile, options=options
         )
-        return _prepare_report(report)
+        return _prepare_report(
+            report,
+            output_format=options.get("output_format", None),
+            omit_keys=options.get("omit_keys", None),
+        )
 
     def _update_base_stats(self, base_stats: Dict) -> None:
         """
@@ -1593,7 +1600,7 @@ class StructuredProfiler(BaseProfiler):
         return merged_profile
 
     def diff(  # type: ignore[override]
-        self, other_profile: StructuredProfiler, options: Dict = None
+        self, other_profile: StructuredProfiler, options: Optional[Dict] = None
     ) -> Dict:
         """
         Find the difference between 2 Profiles and return the report.
@@ -1605,6 +1612,9 @@ class StructuredProfiler(BaseProfiler):
         :return: difference of the profiles
         :rtype: dict
         """
+        if options is None:
+            options = {}
+
         report = super().diff(other_profile, options)
         report["global_stats"].update(
             {
@@ -1666,7 +1676,11 @@ class StructuredProfiler(BaseProfiler):
                     self._profile[i].diff(other_profile._profile[i], options=options)
                 )
 
-        return _prepare_report(report)
+        return _prepare_report(
+            report,
+            output_format=options.get("output_format", None),
+            omit_keys=options.get("omit_keys", None),
+        )
 
     @property
     def _max_col_samples_used(self) -> int:

--- a/dataprofiler/tests/labelers/test_unstructured_data_labeler.py
+++ b/dataprofiler/tests/labelers/test_unstructured_data_labeler.py
@@ -68,6 +68,7 @@ class TestDataLabeler(unittest.TestCase):
     @staticmethod
     def _setup_mock_load_model(mock_load_model):
         model_mock = mock.Mock(spec=CharacterLevelCnnModel)
+        model_mock.__class__.__name__ = "CharacterLevelCnnModel"
         model_mock.set_num_labels = mock.Mock()
         mock_load_model.return_value = model_mock
         model_mock.requires_zero_mapping = True

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import json
 import logging
 import os
 import random
@@ -1847,6 +1848,10 @@ class TestStructuredProfiler(unittest.TestCase):
         np.testing.assert_array_almost_equal(expected_chi2_mat, diff_chi2_mat)
         self.assertDictEqual(expected_diff, diff)
 
+        diff = profile1.diff(profile2, options={"output_format": "serializable"})
+        # validate can serialize
+        json.dumps(diff)
+
     @mock.patch("dataprofiler.profilers.profile_builder.DataLabeler")
     @mock.patch(
         "dataprofiler.profilers.data_labeler_column_profile." "DataLabelerColumn.update"
@@ -2693,6 +2698,10 @@ class TestUnstructuredProfiler(unittest.TestCase):
             },
         }
         self.assertDictEqual(expected_diff, profiler1.diff(profiler2))
+
+        # validate can serialize
+        diff = profiler1.diff(profiler2, options=dict(output_format="serializable"))
+        json.dumps(diff)
 
     def test_get_sample_size(self, *mocks):
         data = pd.DataFrame([0] * int(50e3))


### PR DESCRIPTION
Now can use:
```python
profile1.diff(profile2, options=dict(output_format='pretty', omit_keys=[....])
```