### PR TITLE
Fix typos, remove (unintended?) indentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -52,7 +52,7 @@ In short, when you submit code changes, your submissions are understood to be un
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/capitalone/DataProfiler/issues/new/choose); it's that easy!
 
 ## Write bug reports with detail, background, and sample code
-Detailed bug reports will make fixing the bug significatnly easier.
+Detailed bug reports will make fixing the bug significantly easier.
 
 **Great Bug Reports** tend to have:
 - General information of the working environment

--- a/examples/intro_data_profiler.ipynb
+++ b/examples/intro_data_profiler.ipynb
@@ -15,10 +15,10 @@
    "source": [
     "This introductory jupyter notebook demonstrates the basic usages of the Data Profiler. The library is designed to easily detect sensitive data and gather statistics on your datasets with just several lines of code. The Data Profiler can handle several different data types including: CSV (or any delimited file), JSON, Parquet, AVRO, and text. Additionally, there are a plethora of options to customize your profile. This library also has the ability to update profiles from multiple batches of large datasets, or merge multiple profiles. In particular, this example covers the followings:\n",
     "\n",
-    "    - Basic usage of the Data Profiler\n",
-    "    - The data reader class\n",
-    "    - Profiler options\n",
-    "    - Updating profiles and merging profiles\n",
+    "- Basic usage of the Data Profiler\n",
+    "- The data reader class\n",
+    "- Profiler options\n",
+    "- Updating profiles and merging profiles\n",
     "\n",
     "First, let's import the libraries needed for this example."
    ]

--- a/examples/structured_profilers.ipynb
+++ b/examples/structured_profilers.ipynb
@@ -375,7 +375,7 @@
    "metadata": {},
    "source": [
     "## Differences in Data\n",
-    "Can be appliied to both structured and unstructured datasets. \n",
+    "Can be applied to both structured and unstructured datasets. \n",
     "\n",
     "Such reports can provide details on the differences between training and validation data like in this pseudo example:\n",
     "```python\n",


### PR DESCRIPTION
This PR fixes #650. I hope that is okay with the people assigned to the issue.

This also updates the [Overview of Data Profiler](https://capitalone.github.io/DataProfiler/docs/0.8.1/html/overview.html) user guide, as I noticed that the list of sections was interpreted as a preformatted block. I removed the four spaces in front of that list.

Finally, I also fixed a typo in the Contribution guide.

(It's not a big PR, but if you accept it, I would very much appreciate if you could add the 'hacktoberfest-accepted' label to this PR to make it count.)