### PR TITLE
Fix bug

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -2244,7 +2244,10 @@ class StructuredProfiler(BaseProfiler):
         ]._profiles[get_data_type(profile)]
 
         total_row_sum = np.asarray(
-            [get_data_type_profiler(profile).sum for profile in self._profile]
+            [
+                get_data_type_profiler(profile).sum if get_data_type(profile) else 0
+                for profile in self._profile
+            ]
         )
 
         if not isinstance(self._null_replication_metrics, dict):
@@ -2290,7 +2293,11 @@ class StructuredProfiler(BaseProfiler):
             sum_not_null = np.delete(total_row_sum, col_id) - sum_null
 
             mean_null = sum_null / null_count
-            mean_not_null = sum_not_null / true_count
+
+            if true_count == 0:
+                mean_not_null = sum_not_null
+            else:
+                mean_not_null = sum_not_null / true_count
 
             # Convert numpy arrays to lists (serializable)
             sum_null = sum_null.tolist()


### PR DESCRIPTION
When `null_replication_metrics` is enabled and any columns is all null, this errors:
```Python
import dataprofiler as dp
import pandas as pd
import re

profiler_options = dp.ProfilerOptions()

NO_FLAG = 0
profiler_options.set({
    '*.null_values': {
        "": NO_FLAG,
        "nan": re.IGNORECASE,
        "none": re.IGNORECASE,
        "null": re.IGNORECASE,
        "  *": NO_FLAG,
        "--*": NO_FLAG,
        "__*": NO_FLAG,
        "9"*7: NO_FLAG,
    }, 
    "*.null_replication_metrics.is_enabled": True,
    "data_labeler.is_enabled": False,
    "multiprocess.is_enabled": False,
})
profiler = dp.Profiler(pd.DataFrame([[9999999,9], [9999999,9]]), options=profiler_options)
```