### PR TITLE
Fix bug with null replication metrics when row is all null

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -2240,7 +2240,7 @@ class StructuredProfiler(BaseProfiler):
         :param clean_samples: input cleaned dataset
         :type clean_samples: dict
         """
-        data: pd.DataFrame = pd.DataFrame(clean_samples)
+        data = pd.DataFrame(clean_samples)
 
         # If the last row is all null, then add rows to the data DataFrame
         max_null_index = max(

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -2240,7 +2240,20 @@ class StructuredProfiler(BaseProfiler):
         :param clean_samples: input cleaned dataset
         :type clean_samples: dict
         """
-        data = pd.DataFrame(clean_samples).apply(pd.to_numeric, errors="coerce")
+        data: pd.DataFrame = pd.DataFrame(clean_samples)
+
+        # If the last row is all null, then add rows to the data DataFrame
+        max_null_index = max(
+            [max(i) for i in getattr(self._profile[0], "null_types_index").values()],
+            default=0,
+        )
+        if max_null_index > data.index.max():
+            data.loc[max_null_index] = {}
+
+        # Fill in missing rows with NaN and convert types to numeric
+        data = data.reindex(range(data.index.max() + 1), fill_value=np.nan).apply(
+            pd.to_numeric, errors="coerce"
+        )
 
         get_data_type = lambda profile: profile.profiles[  # NOQA: E731
             "data_type_profile"

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -2081,6 +2081,19 @@ class TestStructuredProfiler(unittest.TestCase):
         np.testing.assert_array_almost_equal([[np.nan], [18]], column["class_sum"])
         np.testing.assert_array_almost_equal([[np.nan], [9]], column["class_mean"])
 
+        # Test with all null in a row
+        data_4 = pd.DataFrame([[10, 10], [9999999, 9999999]])
+
+        profiler = dp.StructuredProfiler(data_4, options=profile_options)
+        report = profiler.report()
+
+        self.assertTrue("null_replication_metrics" in report["data_stats"][0])
+        column = report["data_stats"][0]["null_replication_metrics"]
+
+        np.testing.assert_array_almost_equal([0.5, 0.5], column["class_prior"])
+        np.testing.assert_array_almost_equal([[10], [0]], column["class_sum"])
+        np.testing.assert_array_almost_equal([[10], [0]], column["class_mean"])
+
     def test_column_level_invalid_values(self):
         data = pd.DataFrame([[1, 1], [9999999, 2], [3, 3]])
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -2082,7 +2082,9 @@ class TestStructuredProfiler(unittest.TestCase):
         np.testing.assert_array_almost_equal([[np.nan], [9]], column["class_mean"])
 
         # Test with all null in a row
-        data_4 = pd.DataFrame([[10, 10], [9999999, 9999999]])
+        data_4 = pd.DataFrame(
+            [[10, 20], [9999999, 9999999], [30, 9999999], [9999999, 9999999]]
+        )
 
         profiler = dp.StructuredProfiler(data_4, options=profile_options)
         report = profiler.report()
@@ -2091,7 +2093,7 @@ class TestStructuredProfiler(unittest.TestCase):
         column = report["data_stats"][0]["null_replication_metrics"]
 
         np.testing.assert_array_almost_equal([0.5, 0.5], column["class_prior"])
-        np.testing.assert_array_almost_equal([[10], [0]], column["class_sum"])
+        np.testing.assert_array_almost_equal([[20], [0]], column["class_sum"])
         np.testing.assert_array_almost_equal([[10], [0]], column["class_mean"])
 
     def test_column_level_invalid_values(self):


### PR DESCRIPTION
When `null_replication_metrics` is enabled and any row is all null, this errors:
```Python
import dataprofiler as dp
import pandas as pd
import re

profiler_options = dp.ProfilerOptions()

NO_FLAG = 0
profiler_options.set({
    '*.null_values': {
        "": NO_FLAG,
        "nan": re.IGNORECASE,
        "none": re.IGNORECASE,
        "null": re.IGNORECASE,
        "  *": NO_FLAG,
        "--*": NO_FLAG,
        "__*": NO_FLAG,
        "9"*7: NO_FLAG,
    }, 
    "*.null_replication_metrics.is_enabled": True,
    "data_labeler.is_enabled": False,
    "multiprocess.is_enabled": False,
})
profiler = dp.Profiler(pd.DataFrame([[10, 10], [9999999, 9999999]]), options=profiler_options)
```