### PR TITLE
Fix numpy version and drop python 3.7 in checks

### DIFF
--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 h5py>=2.10.0
 wheel>=0.33.1
 future>=0.18.2
-numpy>=1.21.1
+numpy>=1.22.0
 pandas>=1.1.2
 python-dateutil>=2.7.5
 pytz>=2020.1

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ DESCRIPTION = (
 setup(
     name="DataProfiler",
     version=__version__,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- Resolving issue #516
- Bumping `numpy`
- Dropping python3.7 because numpy 1.22 does not support 3.7 anymore, per [this ](https://numpy.org/devdocs/release/1.22.0-notes.html#:~:text=The%20Python%20versions%20supported%20in%20this%20release%20are%203.8%2D3.10%2C%20Python%203.7%20has%20been%20dropped.)