### PR TITLE
adding pyupgrade & autoflake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,3 +55,16 @@ repos:
         'python-dateutil', 'pytz', 'six', 'pyarrow', 'chardet', 'fastavro',
         'python-snappy', 'charset-normalizer', 'psutil', 'scipy', 'requests',
         'networkx','typing-extensions']
+  # Pyupgrade - standardize and modernize Python syntax for newer versions of the language
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py37-plus"]
+  # Autoflake - cleanup unused variables and imports
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v2.0.0
+    hooks:
+      - id: autoflake
+        args:
+          - "--in-place"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,3 +68,4 @@ repos:
       - id: autoflake
         args:
           - "--in-place"
+          - "--ignore-pass-statements"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
     rev: v3.3.0
     hooks:
       - id: pyupgrade
-        args: ["--py37-plus"]
+        args: ["--py38-plus"]
   # Autoflake - cleanup unused variables and imports
   - repo: https://github.com/PyCQA/autoflake
     rev: v2.0.0

--- a/dataprofiler/data_readers/avro_data.py
+++ b/dataprofiler/data_readers/avro_data.py
@@ -58,7 +58,6 @@ class AVROData(JSONData, BaseData):
 
         Required by mypy because the inherited self.file_encoding is read-write.
         """
-        pass
 
     def _load_data_from_file(self, input_file_path: str) -> List:
         """Load data from file."""

--- a/dataprofiler/data_readers/avro_data.py
+++ b/dataprofiler/data_readers/avro_data.py
@@ -58,6 +58,7 @@ class AVROData(JSONData, BaseData):
 
         Required by mypy because the inherited self.file_encoding is read-write.
         """
+        pass
 
     def _load_data_from_file(self, input_file_path: str) -> List:
         """Load data from file."""

--- a/dataprofiler/data_readers/base_data.py
+++ b/dataprofiler/data_readers/base_data.py
@@ -14,7 +14,7 @@ from . import data_utils
 logger = dp_logging.get_child_logger(__name__)
 
 
-class BaseData(object):
+class BaseData:
     """Abstract class for data loading and saving."""
 
     data_type: str

--- a/dataprofiler/data_readers/csv_data.py
+++ b/dataprofiler/data_readers/csv_data.py
@@ -3,11 +3,11 @@ import csv
 import random
 import re
 from collections import Counter
+from io import StringIO
 from typing import Dict, List, Optional, Tuple, Union, cast
 
 import numpy as np
 import pandas as pd
-from six import StringIO
 
 from . import data_utils
 from .avro_data import AVROData
@@ -443,11 +443,9 @@ class CSVData(SpreadSheetDataMixin, BaseData):
             # Determine percent of string, uppercase string or none in row,
             # must be ABOVE threshold
             rstr = float(
-                (
-                    header_check_list[i].count("str")
-                    + header_check_list[i].count("upstr")
-                    + header_check_list[i].count("none")
-                )
+                header_check_list[i].count("str")
+                + header_check_list[i].count("upstr")
+                + header_check_list[i].count("none")
             )
             rstr /= float(len(header_check_list[i]))
 
@@ -611,7 +609,7 @@ class CSVData(SpreadSheetDataMixin, BaseData):
         quote = self.quotechar if self.quotechar else self._default_quotechar
         data = data.to_csv(sep=sep, quotechar=quote, index=False)
         data = data.splitlines()
-        return super(CSVData, self)._get_data_as_records(data)
+        return super()._get_data_as_records(data)
 
     @classmethod
     def is_match(cls, file_path: str, options: Optional[Dict] = None) -> bool:
@@ -759,5 +757,5 @@ class CSVData(SpreadSheetDataMixin, BaseData):
         options.update(
             header=self.header, delimiter=self.delimiter, quotechar=self.quotechar
         )
-        super(CSVData, self).reload(input_file_path, data, options)
+        super().reload(input_file_path, data, options)
         self.__init__(self.input_file_path, data, options)  # type: ignore

--- a/dataprofiler/data_readers/data.py
+++ b/dataprofiler/data_readers/data.py
@@ -1,5 +1,4 @@
 """Contains factory class reading various kinds of data."""
-from __future__ import absolute_import, division
 
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Union, cast
@@ -16,7 +15,7 @@ from .text_data import TextData
 logger = dp_logging.get_child_logger(__name__)
 
 
-class Data(object):
+class Data:
     """Factory class for reading various kinds of data."""
 
     data_classes: List[Dict] = [

--- a/dataprofiler/data_readers/data_utils.py
+++ b/dataprofiler/data_readers/data_utils.py
@@ -2,7 +2,6 @@
 import json
 import re
 import urllib
-from builtins import next
 from collections import OrderedDict
 from io import BytesIO, StringIO, TextIOWrapper
 from typing import (
@@ -41,8 +40,7 @@ def data_generator(data_list: List[str]) -> Generator[str, None, None]:
     :return: item from the list
     :rtype: generator
     """
-    for item in data_list:
-        yield item
+    yield from data_list
 
 
 def generator_on_file(

--- a/dataprofiler/data_readers/filepath_or_buffer.py
+++ b/dataprofiler/data_readers/filepath_or_buffer.py
@@ -1,5 +1,5 @@
 """Contains functions and classes for handling filepaths and buffers."""
-from io import BytesIO, StringIO, TextIOWrapper, open
+from io import BytesIO, StringIO, TextIOWrapper
 from typing import IO, Any, Optional, Type, Union, cast
 
 from typing_extensions import TypeGuard

--- a/dataprofiler/data_readers/json_data.py
+++ b/dataprofiler/data_readers/json_data.py
@@ -3,11 +3,11 @@ import json
 import re
 import warnings
 from collections import OrderedDict
+from io import StringIO
 from typing import Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
-from six import StringIO
 
 from .._typing import JSONType
 from . import data_utils
@@ -295,7 +295,7 @@ class JSONData(SpreadSheetDataMixin, BaseData):
             data[i] = json.dumps(
                 self._convert_flat_to_nested_cols(sample), ensure_ascii=False
             )
-        return super(JSONData, self)._get_data_as_records(data)
+        return super()._get_data_as_records(data)
 
     def _get_data_as_json(self, data: Union[pd.DataFrame, Dict, List]) -> List[str]:
         """
@@ -442,5 +442,5 @@ class JSONData(SpreadSheetDataMixin, BaseData):
         :return: None
         """
         self._selected_keys = None
-        super(JSONData, self).reload(input_file_path, data, options)
+        super().reload(input_file_path, data, options)
         self.__init__(self.input_file_path, data, options)  # type: ignore

--- a/dataprofiler/data_readers/parquet_data.py
+++ b/dataprofiler/data_readers/parquet_data.py
@@ -76,7 +76,6 @@ class ParquetData(SpreadSheetDataMixin, BaseData):
 
         Required by mypy because the inherited self.file_encoding is read-write).
         """
-        pass
 
     @property
     def selected_columns(self) -> List[str]:
@@ -110,7 +109,7 @@ class ParquetData(SpreadSheetDataMixin, BaseData):
         # split into row samples separate by `\n`
         data = data.to_json(orient="records", lines=True)
         data = data.splitlines()
-        return super(ParquetData, self)._get_data_as_records(data)
+        return super()._get_data_as_records(data)
 
     def _get_data_as_json(self, data: pd.DataFrame) -> List[str]:
         """Return json data."""
@@ -171,5 +170,5 @@ class ParquetData(SpreadSheetDataMixin, BaseData):
         :type options: dict
         :return: None
         """
-        super(ParquetData, self).reload(input_file_path, data, options)
+        super().reload(input_file_path, data, options)
         self.__init__(self.input_file_path, data, options)  # type: ignore

--- a/dataprofiler/data_readers/parquet_data.py
+++ b/dataprofiler/data_readers/parquet_data.py
@@ -76,6 +76,7 @@ class ParquetData(SpreadSheetDataMixin, BaseData):
 
         Required by mypy because the inherited self.file_encoding is read-write).
         """
+        pass
 
     @property
     def selected_columns(self) -> List[str]:

--- a/dataprofiler/data_readers/structured_mixins.py
+++ b/dataprofiler/data_readers/structured_mixins.py
@@ -9,7 +9,7 @@ from .. import dp_logging
 logger: Logger = dp_logging.get_child_logger(__name__)
 
 
-class SpreadSheetDataMixin(object):
+class SpreadSheetDataMixin:
     """
     Mixin data class for loading datasets of type SpreadSheet.
 

--- a/dataprofiler/data_readers/text_data.py
+++ b/dataprofiler/data_readers/text_data.py
@@ -1,6 +1,4 @@
 """Contains class for saving and loading text files."""
-from __future__ import unicode_literals  # at top of module
-from __future__ import print_function
 
 from io import StringIO
 from typing import Dict, List, Optional, Union, cast
@@ -51,7 +49,7 @@ class TextData(BaseData):
             raise ValueError("Input data type is not string.")
 
         options = self._check_and_return_options(options)
-        super(TextData, self).__init__(input_file_path, data, options)
+        super().__init__(input_file_path, data, options)
 
         # 'Private' properties
         #  _data_formats: dict containing data_formats (key) and function
@@ -152,5 +150,5 @@ class TextData(BaseData):
         :type options: dict
         :return: None
         """
-        super(TextData, self).reload(input_file_path, data, options)
+        super().reload(input_file_path, data, options)
         self.__init__(self.input_file_path, data, options)  # type: ignore

--- a/dataprofiler/labelers/base_data_labeler.py
+++ b/dataprofiler/labelers/base_data_labeler.py
@@ -5,7 +5,7 @@ import json
 import os
 import sys
 import warnings
-from typing import Dict, List, Optional, Type, Union, cast
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -20,12 +20,12 @@ from .base_model import BaseModel
 default_labeler_dir = pkg_resources.resource_filename("resources", "labelers")
 
 
-class BaseDataLabeler(object):
+class BaseDataLabeler:
     """Parent class for data labeler objects."""
 
     _default_model_loc: str = None  # type: ignore
 
-    def __init__(self, dirpath: str = None, load_options: Dict = None) -> None:
+    def __init__(self, dirpath: str = None, load_options: dict = None) -> None:
         """
         Initialize DataLabeler class.
 
@@ -99,7 +99,7 @@ class BaseDataLabeler(object):
         self._postprocessor.help()
 
     @property
-    def label_mapping(self) -> Dict:
+    def label_mapping(self) -> dict:
         """
         Retrieve the label encodings.
 
@@ -108,7 +108,7 @@ class BaseDataLabeler(object):
         return self._model.label_mapping
 
     @property
-    def reverse_label_mapping(self) -> Dict:
+    def reverse_label_mapping(self) -> dict:
         """
         Retrieve the index to label encoding.
 
@@ -117,7 +117,7 @@ class BaseDataLabeler(object):
         return self._model.reverse_label_mapping
 
     @property
-    def labels(self) -> List[str]:
+    def labels(self) -> list[str]:
         """
         Retrieve the label.
 
@@ -126,7 +126,7 @@ class BaseDataLabeler(object):
         return self._model.labels
 
     @property
-    def preprocessor(self) -> Optional[data_processing.BaseDataPreprocessor]:
+    def preprocessor(self) -> data_processing.BaseDataPreprocessor | None:
         """
         Retrieve the data preprocessor.
 
@@ -144,7 +144,7 @@ class BaseDataLabeler(object):
         return self._model
 
     @property
-    def postprocessor(self) -> Optional[data_processing.BaseDataPostprocessor]:
+    def postprocessor(self) -> data_processing.BaseDataPostprocessor | None:
         """
         Retrieve the data postprocessor.
 
@@ -187,7 +187,7 @@ class BaseDataLabeler(object):
         else:
             return np.reshape(data, -1)
 
-    def set_params(self, params: Dict) -> None:
+    def set_params(self, params: dict) -> None:
         """
         Allow user to set parameters of pipeline components.
 
@@ -262,7 +262,7 @@ class BaseDataLabeler(object):
         """
         self._model.add_label(label, same_as)
 
-    def set_labels(self, labels: Union[List, Dict]) -> None:
+    def set_labels(self, labels: list | dict) -> None:
         """
         Set the labels for the data labeler.
 
@@ -277,10 +277,10 @@ class BaseDataLabeler(object):
         self,
         data: DataArray,
         batch_size: int = 32,
-        predict_options: Dict[str, bool] = None,
+        predict_options: dict[str, bool] = None,
         error_on_mismatch: bool = False,
         verbose: bool = True,
-    ) -> Dict:
+    ) -> dict:
         """
         Predict labels of input data based with the data labeler model.
 
@@ -389,8 +389,8 @@ class BaseDataLabeler(object):
         messages = []
 
         def get_parameter_overlap_mismatches(
-            param_dict1: Dict, param_dict2: Dict
-        ) -> List[str]:
+            param_dict1: dict, param_dict2: dict
+        ) -> list[str]:
             """
             Get mismatching parameters in dictionary if same key exists.
 
@@ -447,7 +447,7 @@ class BaseDataLabeler(object):
             warnings.warn("\n".join(messages), category=RuntimeWarning)
 
     @staticmethod
-    def _load_parameters(dirpath: str, load_options: Dict = None) -> Dict[str, Dict]:
+    def _load_parameters(dirpath: str, load_options: dict = None) -> dict[str, dict]:
         """
         Load the data labeler parameters.
 
@@ -463,7 +463,7 @@ class BaseDataLabeler(object):
             load_options = {}
 
         with open(os.path.join(dirpath, "data_labeler_parameters.json")) as fp:
-            params: Dict[str, Dict] = json.load(fp)
+            params: dict[str, dict] = json.load(fp)
 
         if "model_class" in load_options:
             model_class = load_options.get("model_class")
@@ -512,7 +512,7 @@ class BaseDataLabeler(object):
         return params
 
     def _load_model(
-        self, model_class: Optional[Union[Type[BaseModel], str]], dirpath: str
+        self, model_class: type[BaseModel] | str | None, dirpath: str
     ) -> None:
         """
         Load the data labeler model.
@@ -539,7 +539,7 @@ class BaseDataLabeler(object):
 
     def _load_preprocessor(
         self,
-        processor_class: Optional[Union[Type[data_processing.BaseDataProcessor], str]],
+        processor_class: type[data_processing.BaseDataProcessor] | str | None,
         dirpath: str,
     ) -> None:
         """
@@ -570,7 +570,7 @@ class BaseDataLabeler(object):
 
     def _load_postprocessor(
         self,
-        processor_class: Optional[Union[Type[data_processing.BaseDataProcessor], str]],
+        processor_class: type[data_processing.BaseDataProcessor] | str | None,
         dirpath: str,
     ) -> None:
         """
@@ -601,7 +601,7 @@ class BaseDataLabeler(object):
             )
         )
 
-    def _load_data_labeler(self, dirpath: str, load_options: Dict = None) -> None:
+    def _load_data_labeler(self, dirpath: str, load_options: dict = None) -> None:
         """
         Load and initializes the data data labeler in the given path.
 
@@ -640,7 +640,7 @@ class BaseDataLabeler(object):
         return cls(os.path.join(default_labeler_dir, name))
 
     @classmethod
-    def load_from_disk(cls, dirpath: str, load_options: Dict = None) -> BaseDataLabeler:
+    def load_from_disk(cls, dirpath: str, load_options: dict = None) -> BaseDataLabeler:
         """
         Load the data labeler from a saved location on disk.
 
@@ -763,12 +763,12 @@ class TrainableDataLabeler(BaseDataLabeler):
         x: DataArray,
         y: DataArray,
         validation_split: float = 0.2,
-        labels: Union[List, Dict] = None,
+        labels: list | dict | None = None,
         reset_weights: bool = False,
         batch_size: int = 32,
         epochs: int = 1,
         error_on_mismatch: bool = False,
-    ) -> List:
+    ) -> list:
         """
         Fit the data labeler model for the dataset.
 

--- a/dataprofiler/labelers/base_model.py
+++ b/dataprofiler/labelers/base_model.py
@@ -5,7 +5,7 @@ import abc
 import copy
 import inspect
 import warnings
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union, cast
+from typing import Any, Type, TypeVar, cast
 
 from dataprofiler._typing import DataArray
 
@@ -16,27 +16,27 @@ class AutoSubRegistrationMeta(abc.ABCMeta):
     """For registering subclasses."""
 
     def __new__(
-        cls, clsname: str, bases: Tuple[type, ...], attrs: Dict[str, object]
+        cls, clsname: str, bases: tuple[type, ...], attrs: dict[str, object]
     ) -> type[T]:
         """Create auto registration object and return new class."""
         new_class = cast(
             Type[T],
-            super(AutoSubRegistrationMeta, cls).__new__(cls, clsname, bases, attrs),
+            super().__new__(cls, clsname, bases, attrs),
         )
         new_class._register_subclass()
         return new_class
 
 
-class BaseModel(object, metaclass=abc.ABCMeta):
+class BaseModel(metaclass=abc.ABCMeta):
     """For labeling data."""
 
-    _BaseModel__subclasses: Dict[str, Type[BaseModel]] = {}
+    _BaseModel__subclasses: dict[str, type[BaseModel]] = {}
     __metaclass__ = abc.ABCMeta
 
     # boolean if the label mapping requires the mapping for index 0 reserved
     requires_zero_mapping: bool = False
 
-    def __init__(self, label_mapping: Union[List, Dict], parameters: Dict) -> None:
+    def __init__(self, label_mapping: list | dict, parameters: dict) -> None:
         """
         Initialize Base Model.
 
@@ -52,8 +52,8 @@ class BaseModel(object, metaclass=abc.ABCMeta):
         # initialize class
         self._model: Any = None
         self._validate_parameters(parameters)
-        self._parameters: Dict = parameters
-        self._label_mapping: Dict[str, int] = None  # type: ignore
+        self._parameters: dict = parameters
+        self._label_mapping: dict[str, int] = None  # type: ignore
 
         self.set_label_mapping(label_mapping)
 
@@ -91,12 +91,12 @@ class BaseModel(object, metaclass=abc.ABCMeta):
             cls._BaseModel__subclasses[cls.__name__.lower()] = cls
 
     @property
-    def label_mapping(self) -> Dict[str, int]:
+    def label_mapping(self) -> dict[str, int]:
         """Return mapping of labels to their encoded values."""
         return copy.deepcopy(self._label_mapping)
 
     @property
-    def reverse_label_mapping(self) -> Dict[int, str]:
+    def reverse_label_mapping(self) -> dict[int, str]:
         """
         Return reversed order of current labels.
 
@@ -105,7 +105,7 @@ class BaseModel(object, metaclass=abc.ABCMeta):
         return {v: k for k, v in self.label_mapping.items()}
 
     @property
-    def labels(self) -> List[str]:
+    def labels(self) -> list[str]:
         """
         Retrieve the label.
 
@@ -120,8 +120,8 @@ class BaseModel(object, metaclass=abc.ABCMeta):
 
     @staticmethod
     def _convert_labels_to_label_mapping(
-        labels: Union[List[str], Dict[str, int]], requires_zero_mapping: bool
-    ) -> Dict:
+        labels: list[str] | dict[str, int], requires_zero_mapping: bool
+    ) -> dict:
         """
         Convert the new labels set to be in an encoding dict if not already.
 
@@ -145,7 +145,7 @@ class BaseModel(object, metaclass=abc.ABCMeta):
         return max(self.label_mapping.values()) + 1
 
     @classmethod
-    def get_class(cls, class_name: str) -> Optional[Type[BaseModel]]:
+    def get_class(cls, class_name: str) -> type[BaseModel] | None:
         """Get subclasses."""
         # Import possible internal models
         from .character_level_cnn_model import CharacterLevelCnnModel  # NOQA
@@ -154,7 +154,7 @@ class BaseModel(object, metaclass=abc.ABCMeta):
 
         return cls._BaseModel__subclasses.get(class_name.lower(), None)
 
-    def get_parameters(self, param_list: List[str] = None) -> Dict:
+    def get_parameters(self, param_list: list[str] = None) -> dict:
         """
         Return a dict of parameters from the model given a list.
 
@@ -224,9 +224,7 @@ class BaseModel(object, metaclass=abc.ABCMeta):
             same_as, max_label_ind + 1  # type: ignore
         )
 
-    def set_label_mapping(
-        self, label_mapping: Union[List[str], Dict[str, int]]
-    ) -> None:
+    def set_label_mapping(self, label_mapping: list[str] | dict[str, int]) -> None:
         """
         Set the labels for the model.
 
@@ -255,7 +253,7 @@ class BaseModel(object, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def _validate_parameters(self, parameters: Dict) -> None:
+    def _validate_parameters(self, parameters: dict) -> None:
         """
         Validate the parameters sent in.
 
@@ -322,7 +320,7 @@ class BaseModel(object, metaclass=abc.ABCMeta):
         batch_size: int,
         show_confidences: bool,
         verbose: bool,
-    ) -> Dict:
+    ) -> dict:
         """
         Predict the data with the current model.
 
@@ -374,10 +372,10 @@ class BaseTrainableModel(BaseModel, metaclass=abc.ABCMeta):
         val_data: DataArray,
         batch_size: int = None,
         epochs: int = None,
-        label_mapping: Dict[str, int] = None,
+        label_mapping: dict[str, int] = None,
         reset_weights: bool = False,
         verbose: bool = True,
-    ) -> Tuple[Dict, Optional[float], Dict]:
+    ) -> tuple[dict, float | None, dict]:
         """
         Train the current model with the training data and validation data.
 

--- a/dataprofiler/labelers/char_load_tf_model.py
+++ b/dataprofiler/labelers/char_load_tf_model.py
@@ -7,7 +7,7 @@ import os
 import sys
 import time
 from collections import defaultdict
-from typing import Dict, List, Optional, Tuple, Union, cast
+from typing import cast
 
 import numpy as np
 import tensorflow as tf
@@ -31,7 +31,7 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
     requires_zero_mapping = False
 
     def __init__(
-        self, model_path: str, label_mapping: Dict[str, int], parameters: Dict = None
+        self, model_path: str, label_mapping: dict[str, int], parameters: dict = None
     ) -> None:
         """
         Initialize Loadable TF Model.
@@ -82,7 +82,7 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
             return False
         return True
 
-    def _validate_parameters(self, parameters: Dict) -> None:
+    def _validate_parameters(self, parameters: dict) -> None:
         """
         Validate the parameters sent in.
 
@@ -118,9 +118,7 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
         if errors:
             raise ValueError("\n".join(errors))
 
-    def set_label_mapping(
-        self, label_mapping: Union[List[str], Dict[str, int]]
-    ) -> None:
+    def set_label_mapping(self, label_mapping: list[str] | dict[str, int]) -> None:
         """
         Set the labels for the model.
 
@@ -198,12 +196,12 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
         """
         # load parameters
         model_param_dirpath = os.path.join(dirpath, "model_parameters.json")
-        with open(model_param_dirpath, "r") as fp:
+        with open(model_param_dirpath) as fp:
             parameters = json.load(fp)
 
         # load label_mapping
         labels_dirpath = os.path.join(dirpath, "label_mapping.json")
-        with open(labels_dirpath, "r") as fp:
+        with open(labels_dirpath) as fp:
             label_mapping = json.load(fp)
 
         # use f1 score metric
@@ -333,10 +331,10 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
         val_data: DataArray = None,
         batch_size: int = None,
         epochs: int = None,
-        label_mapping: Dict[str, int] = None,
+        label_mapping: dict[str, int] = None,
         reset_weights: bool = False,
         verbose: bool = True,
-    ) -> Tuple[Dict, Optional[float], Dict]:
+    ) -> tuple[dict, float | None, dict]:
         """
         Train the current model with the training data and validation data.
 
@@ -367,9 +365,9 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
             if reset_weights:
                 self.reset_weights()
 
-        history: Dict = defaultdict()
-        f1: Optional[float] = None
-        f1_report: Dict = {}
+        history: dict = defaultdict()
+        f1: float | None = None
+        f1_report: dict = {}
 
         self._model.reset_metrics()
         softmax_output_layer_name = self._model.outputs[0].name.split("/")[0]
@@ -424,7 +422,7 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
         batch_size_test: int = 32,
         verbose_log: bool = True,
         verbose_keras: bool = False,
-    ) -> Union[Tuple[float, Dict], Tuple[None, None]]:
+    ) -> tuple[float, dict] | tuple[None, None]:
         """
         Validate the model on the test set and return the evaluation metrics.
 
@@ -482,7 +480,7 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
         batch_size: int = 32,
         show_confidences: bool = False,
         verbose: bool = True,
-    ) -> Dict:
+    ) -> dict:
         """
         Run model and get predictions.
 
@@ -507,8 +505,8 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
                 "predict."
             )
         # Pre-allocate space for predictions
-        confidences: List = []
-        predictions: List = []
+        confidences: list = []
+        predictions: list = []
 
         # Run model with batching
         allocation_index = 0
@@ -556,7 +554,7 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
         self._model.summary()
         print("\nModel Parameters:")
         for key, value in self._parameters.items():
-            print("{}: {}".format(key, value))
+            print(f"{key}: {value}")
         print("\nModel Label Mapping:")
         for key, value in self.label_mapping.items():
-            print("{}: {}".format(key, value))
+            print(f"{key}: {value}")

--- a/dataprofiler/labelers/classification_report_utils.py
+++ b/dataprofiler/labelers/classification_report_utils.py
@@ -319,15 +319,14 @@ def classification_report(
     if target_names is not None and len(labels) != len(target_names):
         if labels_given:
             warnings.warn(
-                "labels size, {}, does not match size of target_names, {}".format(
-                    len(labels), len(target_names)
-                )
+                f"labels size, {len(labels)}, does not match size of "
+                f"target_names, {len(target_names)}"
             )
         else:
             raise ValueError(
-                "Number of classes, {}, does not match size of "
-                "target_names, {}. Try specifying the labels "
-                "parameter".format(len(labels), len(target_names))
+                f"Number of classes, {len(labels)}, does not match size of "
+                f"target_names, {len(target_names)}. Try specifying the labels "
+                "parameter"
             )
     if target_names is None:
         target_names = ["%s" % label for label in labels]

--- a/dataprofiler/labelers/classification_report_utils.py
+++ b/dataprofiler/labelers/classification_report_utils.py
@@ -319,14 +319,14 @@ def classification_report(
     if target_names is not None and len(labels) != len(target_names):
         if labels_given:
             warnings.warn(
-                "labels size, {0}, does not match size of target_names, {1}".format(
+                "labels size, {}, does not match size of target_names, {}".format(
                     len(labels), len(target_names)
                 )
             )
         else:
             raise ValueError(
-                "Number of classes, {0}, does not match size of "
-                "target_names, {1}. Try specifying the labels "
+                "Number of classes, {}, does not match size of "
+                "target_names, {}. Try specifying the labels "
                 "parameter".format(len(labels), len(target_names))
             )
     if target_names is None:

--- a/dataprofiler/labelers/column_name_model.py
+++ b/dataprofiler/labelers/column_name_model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable
 
 import numpy as np
 
@@ -27,7 +27,7 @@ logger = dp_logging.get_child_logger(__name__)
 class ColumnNameModel(BaseModel, metaclass=AutoSubRegistrationMeta):
     """Class for column name data labeling model."""
 
-    def __init__(self, label_mapping: Dict[str, int], parameters: Dict = None) -> None:
+    def __init__(self, label_mapping: dict[str, int], parameters: dict = None) -> None:
         """Initialize function for ColumnNameModel.
 
         :param parameters: Contains all the appropriate parameters for the model.
@@ -50,7 +50,7 @@ class ColumnNameModel(BaseModel, metaclass=AutoSubRegistrationMeta):
         self._validate_parameters(parameters)
         self._parameters = parameters
 
-    def _validate_parameters(self, parameters: Dict) -> None:
+    def _validate_parameters(self, parameters: dict) -> None:
         r"""
         Validate the parameters sent in.
 
@@ -120,7 +120,7 @@ class ColumnNameModel(BaseModel, metaclass=AutoSubRegistrationMeta):
                 )
             elif param == "include_label" and not isinstance(value, bool):
                 errors.append(
-                    "`{}` is a required parameter that must be a boolean.".format(param)
+                    f"`{param}` is a required parameter that must be a boolean."
                 )
             elif param == "negative_threshold_config" and (
                 not isinstance(value, int)
@@ -135,10 +135,10 @@ class ColumnNameModel(BaseModel, metaclass=AutoSubRegistrationMeta):
                 value is None or not isinstance(value, int)
             ):
                 errors.append(
-                    "`{}` is a required parameter that must be a boolean.".format(param)
+                    f"`{param}` is a required parameter that must be a boolean."
                 )
             elif param not in list_of_accepted_parameters:
-                errors.append("`{}` is not an accepted parameter.".format(param))
+                errors.append(f"`{param}` is not an accepted parameter.")
 
         if errors:
             raise ValueError("\n".join(errors))
@@ -150,7 +150,7 @@ class ColumnNameModel(BaseModel, metaclass=AutoSubRegistrationMeta):
     def _compare_negative(
         self,
         list_of_column_names: DataArray,
-        check_values_dict: Dict,
+        check_values_dict: dict,
         negative_threshold: float,
     ) -> DataArray:
         """Filter out column name examples that are false positives."""
@@ -179,17 +179,16 @@ class ColumnNameModel(BaseModel, metaclass=AutoSubRegistrationMeta):
 
     def reset_weights(self) -> None:
         """Reset weights function."""
-        pass
 
     @require_module(["rapidfuzz"])
     def _model(
         self,
-        list_of_column_names: List[str],
-        check_values_dict: List[Dict],
+        list_of_column_names: list[str],
+        check_values_dict: list[dict],
         processor: Callable,
         scorer: Callable,
         include_label: bool = False,
-    ) -> List:
+    ) -> list:
         scores = []
 
         check_values_list = [dict["attribute"] for dict in check_values_dict]
@@ -213,7 +212,7 @@ class ColumnNameModel(BaseModel, metaclass=AutoSubRegistrationMeta):
         batch_size: int = None,
         show_confidences: bool = False,
         verbose: bool = True,
-    ) -> Dict:
+    ) -> dict:
         """
         Apply the `process.cdist` for similarity score on input list of strings.
 
@@ -285,12 +284,12 @@ class ColumnNameModel(BaseModel, metaclass=AutoSubRegistrationMeta):
         """
         # load parameters
         model_param_dirpath = os.path.join(dirpath, "model_parameters.json")
-        with open(model_param_dirpath, "r") as fp:
+        with open(model_param_dirpath) as fp:
             parameters = json.load(fp)
 
         # load label_mapping
         labels_dirpath = os.path.join(dirpath, "label_mapping.json")
-        with open(labels_dirpath, "r") as fp:
+        with open(labels_dirpath) as fp:
             label_mapping = json.load(fp)
 
         loaded_model = cls(label_mapping, parameters)

--- a/dataprofiler/labelers/column_name_model.py
+++ b/dataprofiler/labelers/column_name_model.py
@@ -179,6 +179,7 @@ class ColumnNameModel(BaseModel, metaclass=AutoSubRegistrationMeta):
 
     def reset_weights(self) -> None:
         """Reset weights function."""
+        pass
 
     @require_module(["rapidfuzz"])
     def _model(

--- a/dataprofiler/labelers/data_labelers.py
+++ b/dataprofiler/labelers/data_labelers.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import os
-from typing import Dict, Union
 
 import pandas as pd
 import pkg_resources
@@ -16,7 +15,7 @@ default_labeler_dir = pkg_resources.resource_filename("resources", "labelers")
 
 
 def train_structured_labeler(
-    data: Union[None, pd.DataFrame],
+    data: None | pd.DataFrame,
     default_label: int = None,
     save_dirpath: str = None,
     epochs: int = 2,
@@ -87,7 +86,7 @@ class StructuredDataLabeler(BaseDataLabeler):
     _default_model_loc: str = "structured_model"
 
 
-class DataLabeler(object):
+class DataLabeler:
     """Wrapper class for choosing between structured and unstructured labeler."""
 
     labeler_classes = dict(
@@ -99,7 +98,7 @@ class DataLabeler(object):
         cls,
         labeler_type: str,
         dirpath: str = None,
-        load_options: Dict = None,
+        load_options: dict = None,
         trainable: bool = False,
     ) -> BaseDataLabeler:
         """
@@ -148,7 +147,7 @@ class DataLabeler(object):
 
     @classmethod
     def load_from_disk(
-        cls, dirpath: str, load_options: Dict = None, trainable: bool = False
+        cls, dirpath: str, load_options: dict = None, trainable: bool = False
     ) -> BaseDataLabeler:
         """
         Load the data labeler from a saved location on disk.

--- a/dataprofiler/labelers/regex_model.py
+++ b/dataprofiler/labelers/regex_model.py
@@ -6,7 +6,6 @@ import json
 import os
 import re
 import sys
-from typing import Dict
 
 import numpy as np
 
@@ -21,7 +20,7 @@ logger = dp_logging.get_child_logger(__name__)
 class RegexModel(BaseModel, metaclass=AutoSubRegistrationMeta):
     """Class for regex data labeling model."""
 
-    def __init__(self, label_mapping: Dict[str, int], parameters: Dict = None) -> None:
+    def __init__(self, label_mapping: dict[str, int], parameters: dict = None) -> None:
         r"""
         Initialize Regex Model.
 
@@ -68,7 +67,7 @@ class RegexModel(BaseModel, metaclass=AutoSubRegistrationMeta):
         self._validate_parameters(parameters)
         self._parameters = parameters
 
-    def _validate_parameters(self, parameters: Dict) -> None:
+    def _validate_parameters(self, parameters: dict) -> None:
         r"""
         Validate the parameters sent in.
 
@@ -120,14 +119,10 @@ class RegexModel(BaseModel, metaclass=AutoSubRegistrationMeta):
                 or "start" not in value
                 or "end" not in value
             ):
-                errors.append(
-                    "`{}` must be a dict with keys 'start' and 'end'".format(param)
-                )
+                errors.append(f"`{param}` must be a dict with keys 'start' and 'end'")
             elif param == "regex_patterns":
                 if not isinstance(value, dict):
-                    errors.append(
-                        "`{}` must be a dict of regex pattern lists.".format(param)
-                    )
+                    errors.append(f"`{param}` must be a dict of regex pattern lists.")
                     continue
                 for key in value:
                     if key not in self.label_mapping:
@@ -156,11 +151,11 @@ class RegexModel(BaseModel, metaclass=AutoSubRegistrationMeta):
                                         " pattern: {}".format(key, i, str(e))
                                     )
             elif param == "ignore_case" and not isinstance(parameters[param], bool):
-                errors.append("`{}` must be a bool.".format(param))
+                errors.append(f"`{param}` must be a bool.")
             elif param == "default_label" and not isinstance(parameters[param], str):
-                errors.append("`{}` must be a string.".format(param))
+                errors.append(f"`{param}` must be a string.")
             elif param not in list_of_necessary_params:
-                errors.append("`{}` is not an accepted parameter.".format(param))
+                errors.append(f"`{param}` is not an accepted parameter.")
         if errors:
             raise ValueError("\n".join(errors))
 
@@ -175,7 +170,6 @@ class RegexModel(BaseModel, metaclass=AutoSubRegistrationMeta):
 
     def reset_weights(self) -> None:
         """Reset weights."""
-        pass
 
     def predict(
         self,
@@ -183,7 +177,7 @@ class RegexModel(BaseModel, metaclass=AutoSubRegistrationMeta):
         batch_size: int = None,
         show_confidences: bool = False,
         verbose: bool = True,
-    ) -> Dict:
+    ) -> dict:
         """
         Apply the regex patterns (within regex_model) to the input_string.
 
@@ -250,11 +244,11 @@ class RegexModel(BaseModel, metaclass=AutoSubRegistrationMeta):
                         pred[indices[0] : indices[1], entity_id] = 1
             if verbose:
                 sys.stdout.flush()
-                sys.stdout.write("\rData Samples Processed: {:d}   ".format(i + 1))
+                sys.stdout.write(f"\rData Samples Processed: {i + 1:d}   ")
             predictions[i] = pred
 
         if verbose:
-            logger.info("\rData Samples Processed: {:d}   ".format(i + 1))
+            logger.info(f"\rData Samples Processed: {i + 1:d}   ")
 
         # Trim array size to number of samples
         if len(predictions) > i + 1:
@@ -280,12 +274,12 @@ class RegexModel(BaseModel, metaclass=AutoSubRegistrationMeta):
         """
         # load parameters
         model_param_dirpath = os.path.join(dirpath, "model_parameters.json")
-        with open(model_param_dirpath, "r") as fp:
+        with open(model_param_dirpath) as fp:
             parameters = json.load(fp)
 
         # load label_mapping
         labels_dirpath = os.path.join(dirpath, "label_mapping.json")
-        with open(labels_dirpath, "r") as fp:
+        with open(labels_dirpath) as fp:
             label_mapping = json.load(fp)
 
         loaded_model = cls(label_mapping, parameters)

--- a/dataprofiler/labelers/regex_model.py
+++ b/dataprofiler/labelers/regex_model.py
@@ -170,6 +170,7 @@ class RegexModel(BaseModel, metaclass=AutoSubRegistrationMeta):
 
     def reset_weights(self) -> None:
         """Reset weights."""
+        pass
 
     def predict(
         self,

--- a/dataprofiler/labelers/utils.py
+++ b/dataprofiler/labelers/utils.py
@@ -14,8 +14,8 @@ def warn_missing_module(labeler_function: str, module_name: str) -> None:
     :type module_name: str
     """
     warning_msg = "\n\n!!! WARNING Labeler Failure !!!\n\n"
-    warning_msg += "Labeler Function: {}".format(labeler_function)
-    warning_msg += "\nMissing Module: {}".format(module_name)
+    warning_msg += f"Labeler Function: {labeler_function}"
+    warning_msg += f"\nMissing Module: {module_name}"
     warning_msg += "\n\nFor labeler errors, try installing "
     warning_msg += "the extra labeler requirements via:\n\n"
     warning_msg += "$ pip install -r requirements-ml.txt\n\n"

--- a/dataprofiler/profilers/base_column_profilers.py
+++ b/dataprofiler/profilers/base_column_profilers.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 """Contains parent column profiler class."""
 
-from __future__ import annotations, division, print_function
+from __future__ import annotations
 
 import abc
 import warnings
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable
 
 import numpy as np
 import pandas as pd
@@ -29,23 +29,23 @@ class BaseColumnProfiler(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     _SAMPLING_RATIO = 0.20
     _MIN_SAMPLING_COUNT = 500
 
-    def __init__(self, name: Optional[str]) -> None:
+    def __init__(self, name: str | None) -> None:
         """
         Initialize base class properties for the subclass.
 
         :param name: Name of the dataset
         :type name: String
         """
-        self.name: Optional[str] = name
+        self.name: str | None = name
         self.col_index = np.nan
         self.sample_size: int = 0
-        self.metadata: Dict = dict()
-        self.times: Dict = defaultdict(float)
+        self.metadata: dict = dict()
+        self.times: dict = defaultdict(float)
         self.thread_safe: bool = True
 
     # TODO: Not needed for data labeling
     @staticmethod
-    def _combine_unique_sets(a: List, b: List) -> List:
+    def _combine_unique_sets(a: list, b: list) -> list:
         """
         Unify two lists.
 
@@ -53,7 +53,7 @@ class BaseColumnProfiler(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         :type b: list
         :rtype: list
         """
-        combined_list: Set = set()
+        combined_list: set = set()
         if not a and not b:
             combined_list = set()
         elif not a:
@@ -80,7 +80,7 @@ class BaseColumnProfiler(with_metaclass(abc.ABCMeta, object)):  # type: ignore
 
     @staticmethod
     def _filter_properties_w_options(
-        calculations: Dict, options: Optional[BaseInspectorOptions]
+        calculations: dict, options: BaseInspectorOptions | None
     ) -> None:
         """
         Cycle through the calculations and turns off the ones that are disabled.
@@ -96,10 +96,10 @@ class BaseColumnProfiler(with_metaclass(abc.ABCMeta, object)):  # type: ignore
 
     def _perform_property_calcs(
         self,
-        calculations: Dict,
+        calculations: dict,
         df_series: pd.DataFrame,
-        prev_dependent_properties: Dict,
-        subset_properties: Dict,
+        prev_dependent_properties: dict,
+        subset_properties: dict,
     ) -> None:
         """
         Cycle through the properties of the columns and calculate them.
@@ -123,7 +123,7 @@ class BaseColumnProfiler(with_metaclass(abc.ABCMeta, object)):  # type: ignore
 
     @staticmethod
     def _merge_calculations(
-        merged_profile_calcs: Dict, profile1_calcs: Dict, profile2_calcs: Dict
+        merged_profile_calcs: dict, profile1_calcs: dict, profile2_calcs: dict
     ) -> None:
         """
         Merge the calculations of two profiles to the lowest common denominator.
@@ -171,15 +171,13 @@ class BaseColumnProfiler(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         if other1.name == other2.name:
             self.name = other1.name
         else:
-            raise ValueError(
-                "Column names unmatched: {} != {}".format(other1.name, other2.name)
-            )
+            raise ValueError(f"Column names unmatched: {other1.name} != {other2.name}")
 
         self.times = utils.add_nested_dictionaries(other1.times, other2.times)
 
         self.sample_size = other1.sample_size + other2.sample_size
 
-    def diff(self, other_profile: BaseColumnProfiler, options: Dict = None) -> Dict:
+    def diff(self, other_profile: BaseColumnProfiler, options: dict = None) -> dict:
         """
         Find the differences for columns.
 
@@ -196,7 +194,7 @@ class BaseColumnProfiler(with_metaclass(abc.ABCMeta, object)):  # type: ignore
             )
         return {}
 
-    def _update_column_base_properties(self, profile: Dict) -> None:
+    def _update_column_base_properties(self, profile: dict) -> None:
         """
         Update the base properties with the base schema.
 
@@ -215,11 +213,11 @@ class BaseColumnProfiler(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         integrate with current setup.
         """
         if not hasattr(self, item):
-            raise ValueError("The property '{} does not exist.".format(item))
+            raise ValueError(f"The property '{item} does not exist.")
         return getattr(self, item)
 
     @abc.abstractmethod
-    def _update_helper(self, df_series_clean: pd.DataFrame, profile: Dict) -> None:
+    def _update_helper(self, df_series_clean: pd.DataFrame, profile: dict) -> None:
         """Help update the profile."""
         raise NotImplementedError()
 
@@ -235,12 +233,12 @@ class BaseColumnProfiler(with_metaclass(abc.ABCMeta, object)):  # type: ignore
 
     @property
     @abc.abstractmethod
-    def profile(self) -> Dict:
+    def profile(self) -> dict:
         """Return the profile of the column."""
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """
         Return report.
 
@@ -256,7 +254,7 @@ class BaseColumnPrimitiveTypeProfiler(
 ):
     """Abstract class for profiling primative data type for col of data."""
 
-    def __init__(self, name: Optional[str]) -> None:
+    def __init__(self, name: str | None) -> None:
         """
         Initialize base class properties for the subclass.
 
@@ -269,7 +267,7 @@ class BaseColumnPrimitiveTypeProfiler(
         self.match_count: int = 0
         self.sample_size: int  # inherited from BaseColumnProfiler
 
-    def _update_column_base_properties(self, profile: Dict) -> None:
+    def _update_column_base_properties(self, profile: dict) -> None:
         """
         Update the base properties with the base schema.
 

--- a/dataprofiler/profilers/categorical_column_profile.py
+++ b/dataprofiler/profilers/categorical_column_profile.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from collections import defaultdict
 from operator import itemgetter
-from typing import Dict, List, Optional
 
 from pandas import DataFrame, Series
 
@@ -27,7 +26,7 @@ class CategoricalColumn(BaseColumnProfiler):
     # Default value that determines if a given col is categorical or not.
     _CATEGORICAL_THRESHOLD_DEFAULT = 0.2
 
-    def __init__(self, name: Optional[str], options: CategoricalOptions = None) -> None:
+    def __init__(self, name: str | None, options: CategoricalOptions = None) -> None:
         """
         Initialize column base properties and itself.
 
@@ -39,11 +38,11 @@ class CategoricalColumn(BaseColumnProfiler):
                 "CategoricalColumn parameter 'options' must be of"
                 " type CategoricalOptions."
             )
-        super(CategoricalColumn, self).__init__(name)
-        self._categories: Dict[str, int] = defaultdict(int)
-        self.__calculations: Dict = {}
+        super().__init__(name)
+        self._categories: dict[str, int] = defaultdict(int)
+        self.__calculations: dict = {}
         self._filter_properties_w_options(self.__calculations, options)
-        self._top_k_categories: Optional[int] = None
+        self._top_k_categories: int | None = None
         if options:
             self._top_k_categories = options.top_k_categories
 
@@ -73,7 +72,7 @@ class CategoricalColumn(BaseColumnProfiler):
         )
         return merged_profile
 
-    def diff(self, other_profile: CategoricalColumn, options: Dict = None) -> Dict:
+    def diff(self, other_profile: CategoricalColumn, options: dict = None) -> dict:
         """
         Find the differences for CategoricalColumns.
 
@@ -82,7 +81,7 @@ class CategoricalColumn(BaseColumnProfiler):
         :return: the CategoricalColumn differences
         :rtype: dict
         """
-        differences: Dict = super().diff(other_profile, options)
+        differences: dict = super().diff(other_profile, options)
 
         differences["categorical"] = utils.find_diff_of_strings_and_bools(
             self.is_match, other_profile.is_match
@@ -137,7 +136,7 @@ class CategoricalColumn(BaseColumnProfiler):
 
         return differences
 
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """
         Return report.
 
@@ -150,14 +149,14 @@ class CategoricalColumn(BaseColumnProfiler):
         return self.profile
 
     @property
-    def profile(self) -> Dict:
+    def profile(self) -> dict:
         """
         Return the profile of the column.
 
         For categorical_count, it will display the top k categories most
         frequently occurred in descending order.
         """
-        profile: Dict = dict(
+        profile: dict = dict(
             categorical=self.is_match,
             statistics=dict(
                 [
@@ -179,12 +178,12 @@ class CategoricalColumn(BaseColumnProfiler):
         return profile
 
     @property
-    def categories(self) -> List[str]:
+    def categories(self) -> list[str]:
         """Return categories."""
         return list(self._categories.keys())
 
     @property
-    def categorical_counts(self) -> Dict[str, int]:
+    def categorical_counts(self) -> dict[str, int]:
         """Return counts of each category."""
         return self._categories.copy()
 
@@ -214,8 +213,8 @@ class CategoricalColumn(BaseColumnProfiler):
     def _update_categories(
         self,
         df_series: DataFrame,
-        prev_dependent_properties: Dict = None,
-        subset_properties: Dict = None,
+        prev_dependent_properties: dict = None,
+        subset_properties: dict = None,
     ) -> None:
         """
         Check whether column corresponds to category type.
@@ -237,7 +236,7 @@ class CategoricalColumn(BaseColumnProfiler):
             self._categories, category_count
         )
 
-    def _update_helper(self, df_series_clean: Series, profile: Dict) -> None:
+    def _update_helper(self, df_series_clean: Series, profile: dict) -> None:
         """
         Update col profile properties with clean dataset and its known profile.
 
@@ -276,7 +275,7 @@ class CategoricalColumn(BaseColumnProfiler):
         return self
 
     @property
-    def gini_impurity(self) -> Optional[float]:
+    def gini_impurity(self) -> float | None:
         """
         Return Gini Impurity.
 
@@ -299,7 +298,7 @@ class CategoricalColumn(BaseColumnProfiler):
         return gini_sum
 
     @property
-    def unalikeability(self) -> Optional[float]:
+    def unalikeability(self) -> float | None:
         """
         Return Unlikeability.
 

--- a/dataprofiler/profilers/column_profile_compilers.py
+++ b/dataprofiler/profilers/column_profile_compilers.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import abc
 from collections import OrderedDict
 from multiprocessing.pool import Pool
-from typing import Dict, List, Optional, Type
 
 from future.utils import with_metaclass
 from pandas import Series
@@ -26,9 +25,9 @@ class BaseCompiler(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     """Abstract class for generating a report."""
 
     # NOTE: these profilers are ordered. Test functionality if changed.
-    _profilers: List = list()
+    _profilers: list = list()
 
-    _option_class: Type[BaseOption] = None  # type: ignore[assignment]
+    _option_class: type[BaseOption] = None  # type: ignore[assignment]
 
     def __repr__(self) -> str:
         """Represent object as a string."""
@@ -47,13 +46,13 @@ class BaseCompiler(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         if self._option_class is None:
             raise NotImplementedError("Must set the expected OptionClass.")
 
-        self._profiles: Dict = OrderedDict()
+        self._profiles: dict = OrderedDict()
         if df_series is not None:
             self.name = df_series.name
             self._create_profile(df_series, options, pool)
 
     @abc.abstractmethod
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """
         Return report.
 
@@ -64,7 +63,7 @@ class BaseCompiler(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         raise NotImplementedError()
 
     @property
-    def profile(self) -> Dict:
+    def profile(self) -> dict:
         """Return the profile of the column."""
         return self.report(remove_disabled_flag=False)
 
@@ -84,7 +83,7 @@ class BaseCompiler(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         if not self._profilers:
             return
 
-        enabled_profiles: Optional[List[str]] = None
+        enabled_profiles: list[str] | None = None
         if options and isinstance(options, self._option_class):
             enabled_profiles = options.enabled_profiles
 
@@ -141,7 +140,7 @@ class BaseCompiler(with_metaclass(abc.ABCMeta, object)):  # type: ignore
             )
         return merged_profile_compiler
 
-    def diff(self, other: BaseCompiler, options: Dict = None) -> Dict:
+    def diff(self, other: BaseCompiler, options: dict = None) -> dict:
         """
         Find the difference between 2 compilers and returns the report.
 
@@ -159,7 +158,7 @@ class BaseCompiler(with_metaclass(abc.ABCMeta, object)):  # type: ignore
 
     def update_profile(
         self, df_series: Series, pool: Pool = None
-    ) -> Optional[BaseCompiler]:
+    ) -> BaseCompiler | None:
         """
         Update the profiles from the data frames.
 
@@ -231,7 +230,7 @@ class ColumnPrimitiveTypeProfileCompiler(BaseCompiler):
     ]
     _option_class = StructuredOptions
 
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """
         Return report.
 
@@ -239,7 +238,7 @@ class ColumnPrimitiveTypeProfileCompiler(BaseCompiler):
             flag to determine if disabled options should be excluded in report.
         :type remove_disabled_flag: boolean
         """
-        profile: Dict = {
+        profile: dict = {
             "data_type_representation": dict(),
             "data_type": None,
             "statistics": dict(),
@@ -261,19 +260,19 @@ class ColumnPrimitiveTypeProfileCompiler(BaseCompiler):
         return profile
 
     @property
-    def profile(self) -> Dict:
+    def profile(self) -> dict:
         """Return the profile of the column."""
         return self.report(remove_disabled_flag=False)
 
     @property
-    def selected_data_type(self) -> Optional[str]:
+    def selected_data_type(self) -> str | None:
         """
         Find the selected data_type in a primitive compiler.
 
         :return: name of the selected data type
         :rtype: str
         """
-        matched_profile: Optional[str] = None
+        matched_profile: str | None = None
         if self._profiles:
             for key, profiler in self._profiles.items():
                 if matched_profile is None and profiler.data_type_ratio == 1.0:
@@ -282,8 +281,8 @@ class ColumnPrimitiveTypeProfileCompiler(BaseCompiler):
         return matched_profile
 
     def diff(
-        self, other: ColumnPrimitiveTypeProfileCompiler, options: Dict = None
-    ) -> Dict:
+        self, other: ColumnPrimitiveTypeProfileCompiler, options: dict = None
+    ) -> dict:
         """
         Find the difference between 2 compilers and returns the report.
 
@@ -343,7 +342,7 @@ class ColumnStatsProfileCompiler(BaseCompiler):
     ]
     _option_class = StructuredOptions
 
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """
         Return report.
 
@@ -356,7 +355,7 @@ class ColumnStatsProfileCompiler(BaseCompiler):
             report.update(profiler.report(remove_disabled_flag))
         return report
 
-    def diff(self, other: ColumnStatsProfileCompiler, options: Dict = None) -> Dict:
+    def diff(self, other: ColumnStatsProfileCompiler, options: dict = None) -> dict:
         """
         Find the difference between 2 compilers and returns the report.
 
@@ -385,7 +384,7 @@ class ColumnDataLabelerCompiler(BaseCompiler):
     _profilers = [DataLabelerColumn]
     _option_class = StructuredOptions
 
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """
         Return report.
 
@@ -393,7 +392,7 @@ class ColumnDataLabelerCompiler(BaseCompiler):
             flag to determine if disabled options should be excluded in report.
         :type remove_disabled_flag: boolean
         """
-        report: Dict = {"data_label": None, "statistics": dict()}
+        report: dict = {"data_label": None, "statistics": dict()}
         # TODO: Only works for last profiler. Abstracted for now.
         for _, profiler in self._profiles.items():
             col_profile = profiler.report(remove_disabled_flag)
@@ -401,7 +400,7 @@ class ColumnDataLabelerCompiler(BaseCompiler):
             report["statistics"].update(col_profile)
         return report
 
-    def diff(self, other: ColumnDataLabelerCompiler, options: Dict = None) -> Dict:
+    def diff(self, other: ColumnDataLabelerCompiler, options: dict = None) -> dict:
         """
         Find the difference between 2 compilers and return the report.
 
@@ -440,9 +439,9 @@ class UnstructuredCompiler(BaseCompiler):
 
     _option_class = UnstructuredOptions
 
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """Report profile attrs of class and potentially pop val from self.profile."""
-        profile: Dict = {"data_label": dict(), "statistics": dict()}
+        profile: dict = {"data_label": dict(), "statistics": dict()}
         if UnstructuredLabelerProfile.type in self._profiles:
             profile["data_label"] = self._profiles[
                 UnstructuredLabelerProfile.type
@@ -453,7 +452,7 @@ class UnstructuredCompiler(BaseCompiler):
             )
         return profile
 
-    def diff(self, other: UnstructuredCompiler, options: Dict = None) -> Dict:
+    def diff(self, other: UnstructuredCompiler, options: dict = None) -> dict:
         """
         Find the difference between 2 compilers and return the report.
 

--- a/dataprofiler/profilers/data_labeler_column_profile.py
+++ b/dataprofiler/profilers/data_labeler_column_profile.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import operator
-from typing import Dict, List, Optional, cast
+from typing import Dict, cast
 
 import numpy as np
 from pandas import DataFrame, Series
@@ -18,7 +18,7 @@ class DataLabelerColumn(BaseColumnProfiler):
 
     type = "data_labeler"
 
-    def __init__(self, name: Optional[str], options: DataLabelerOptions = None) -> None:
+    def __init__(self, name: str | None, options: DataLabelerOptions = None) -> None:
         """
         Initialize Data Label profiling for structured datasets.
 
@@ -53,9 +53,9 @@ class DataLabelerColumn(BaseColumnProfiler):
                 load_options=None,
             )
 
-        self._reverse_label_mapping: Optional[Dict] = None
-        self._possible_data_labels: Optional[List[str]] = None
-        self._rank_distribution: Dict[str, int] = None  # type: ignore[assignment]
+        self._reverse_label_mapping: dict | None = None
+        self._possible_data_labels: list[str] | None = None
+        self._rank_distribution: dict[str, int] = None  # type: ignore[assignment]
         self._sum_predictions: np.ndarray = None  # type: ignore[assignment]
 
         # rank distribution variables
@@ -67,7 +67,7 @@ class DataLabelerColumn(BaseColumnProfiler):
         self._top_k_labels: int = 3
         self._min_top_label_prob: float = 0.35
 
-        self.__calculations: Dict = {}
+        self.__calculations: dict = {}
         self._filter_properties_w_options(self.__calculations, options)
 
         self.thread_safe = False
@@ -193,7 +193,7 @@ class DataLabelerColumn(BaseColumnProfiler):
         return merged_profile
 
     @property
-    def reverse_label_mapping(self) -> Dict:
+    def reverse_label_mapping(self) -> dict:
         """Return reverse label mapping."""
         if self._reverse_label_mapping is None:
             self._reverse_label_mapping = self.data_labeler.reverse_label_mapping
@@ -202,7 +202,7 @@ class DataLabelerColumn(BaseColumnProfiler):
         return self._reverse_label_mapping
 
     @property
-    def possible_data_labels(self) -> List[str]:
+    def possible_data_labels(self) -> list[str]:
         """Return possible data labels."""
         if self._possible_data_labels is None:
             self._possible_data_labels = list(self.reverse_label_mapping.values())
@@ -215,7 +215,7 @@ class DataLabelerColumn(BaseColumnProfiler):
         return self._possible_data_labels
 
     @property
-    def rank_distribution(self) -> Dict[str, int]:
+    def rank_distribution(self) -> dict[str, int]:
         """Return rank distribution."""
         if self._rank_distribution is None:
             self._rank_distribution = {key: 0 for key in self.possible_data_labels}
@@ -237,7 +237,7 @@ class DataLabelerColumn(BaseColumnProfiler):
         self._sum_predictions = value
 
     @property
-    def data_label(self) -> Optional[str]:
+    def data_label(self) -> str | None:
         """
         Return data labels which best fit data it has seen based on DataLabeler used.
 
@@ -268,7 +268,7 @@ class DataLabelerColumn(BaseColumnProfiler):
         return data_label
 
     @property
-    def avg_predictions(self) -> Optional[Dict[str, float]]:
+    def avg_predictions(self) -> dict[str, float] | None:
         """Average all sample predictions for each data label."""
         if not self.sample_size:
             return None
@@ -277,7 +277,7 @@ class DataLabelerColumn(BaseColumnProfiler):
         return dict(zip(self.possible_data_labels, avg_predictions))
 
     @property
-    def label_representation(self) -> Optional[Dict[str, float]]:
+    def label_representation(self) -> dict[str, float] | None:
         """
         Represent label found within the dataset based on ranked voting.
 
@@ -287,7 +287,7 @@ class DataLabelerColumn(BaseColumnProfiler):
         if not self.sample_size:
             return None
 
-        label_representation: Dict[str, float] = {
+        label_representation: dict[str, float] = {
             key: 0 for key in self.possible_data_labels
         }
         total_votes = max(1, sum(list(self.rank_distribution.values())))
@@ -296,7 +296,7 @@ class DataLabelerColumn(BaseColumnProfiler):
         return label_representation
 
     @property
-    def profile(self) -> Dict:
+    def profile(self) -> dict:
         """Return the profile of the column."""
         profile = {
             "data_label": self.data_label,
@@ -306,7 +306,7 @@ class DataLabelerColumn(BaseColumnProfiler):
         }
         return profile
 
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """
         Return report.
 
@@ -318,7 +318,7 @@ class DataLabelerColumn(BaseColumnProfiler):
         """
         return self.profile
 
-    def diff(self, other_profile: DataLabelerColumn, options: Dict = None) -> Dict:
+    def diff(self, other_profile: DataLabelerColumn, options: dict = None) -> dict:
         """
         Generate differences between the orders of two DataLabeler columns.
 
@@ -352,8 +352,8 @@ class DataLabelerColumn(BaseColumnProfiler):
     def _update_predictions(
         self,
         df_series: DataFrame,
-        prev_dependent_properties: Dict = None,
-        subset_properties: Dict = None,
+        prev_dependent_properties: dict = None,
+        subset_properties: dict = None,
     ) -> None:
         """
         Update col profile properties with clean dataset and its known profile.
@@ -393,7 +393,7 @@ class DataLabelerColumn(BaseColumnProfiler):
                         self.reverse_label_mapping[value + start_index]
                     ] += (rank_position + 1)
 
-    def _update_helper(self, df_series_clean: Series, profile: Dict) -> None:
+    def _update_helper(self, df_series_clean: Series, profile: dict) -> None:
         """
         Update the column profile properties.
 

--- a/dataprofiler/profilers/datetime_column_profile.py
+++ b/dataprofiler/profilers/datetime_column_profile.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import datetime
 import re
 import warnings
-from typing import Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -53,7 +52,7 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
         r"(\d{1,2})(" + "|".join(_day_suffixes) + ")"
     )
 
-    def __init__(self, name: Optional[str], options: DateTimeOptions = None) -> None:
+    def __init__(self, name: str | None, options: DateTimeOptions = None) -> None:
         """
         Initialize it and the column base properties.
 
@@ -67,13 +66,13 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
                 "DateTimeColumn parameter 'options' must be of " "type DateTimeOptions."
             )
         BaseColumnPrimitiveTypeProfiler.__init__(self, name)
-        self.date_formats: List[str] = []
+        self.date_formats: list[str] = []
         self.min = None
         self.max = None
         self._dt_obj_min = None  # datetime obj of min
         self._dt_obj_max = None  # datetime obj of max
 
-        self.__calculations: Dict = {}
+        self.__calculations: dict = {}
         self._filter_properties_w_options(self.__calculations, options)
 
     def __add__(self, other: DateTimeColumn) -> DateTimeColumn:
@@ -120,7 +119,7 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
         )
         return merged_profile
 
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """
         Return report.
 
@@ -133,7 +132,7 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
         return self.profile
 
     @property
-    def profile(self) -> Dict:
+    def profile(self) -> dict:
         """Return the profile of the column."""
         profile = dict(
             min=self.min,
@@ -145,7 +144,7 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
         return profile
 
     @property
-    def data_type_ratio(self) -> Optional[float]:
+    def data_type_ratio(self) -> float | None:
         """
         Calculate the ratio of samples which match this data type.
 
@@ -156,7 +155,7 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
             return float(self.match_count) / self.sample_size
         return None
 
-    def diff(self, other_profile: DateTimeColumn, options: Dict = None) -> Dict:
+    def diff(self, other_profile: DateTimeColumn, options: dict = None) -> dict:
         """
         Generate differences between max, min, and formats of two DateTime cols.
 
@@ -180,9 +179,7 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
         return differences
 
     @staticmethod
-    def _validate_datetime(
-        date: str, date_format: str
-    ) -> Union[datetime.datetime, float]:
+    def _validate_datetime(date: str, date_format: str) -> datetime.datetime | float:
         """
         Check to see if a string contains a certain date format.
 
@@ -193,16 +190,16 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
         :return: either the str converted into a date format, or Nan
         """
         try:
-            converted_date: Union[
-                datetime.datetime, float
-            ] = datetime.datetime.strptime(date, date_format)
+            converted_date: (datetime.datetime | float) = datetime.datetime.strptime(
+                date, date_format
+            )
         except (ValueError, TypeError):
             converted_date = np.nan
 
         return converted_date
 
     @staticmethod
-    def _replace_day_suffix(date: str, pattern: re.Pattern) -> Union[str, float]:
+    def _replace_day_suffix(date: str, pattern: re.Pattern) -> str | float:
         """
         Check the date for a suffix after the day. Remove suffix if present.
 
@@ -213,13 +210,13 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
         :return: either the date string passed in, or Nan
         """
         try:
-            new_date: Union[str, float] = pattern.sub(r"\1", date)
+            new_date: str | float = pattern.sub(r"\1", date)
         except (TypeError):
             new_date = np.nan
         return new_date
 
     @classmethod
-    def _get_datetime_profile(cls, df_series: pd.Series) -> Dict:
+    def _get_datetime_profile(cls, df_series: pd.Series) -> dict:
         """
         Determine for each val in a col its format and if it's a datetime.
 
@@ -230,8 +227,8 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
         :return: parameters for datetime columns
         :rtype: dict
         """
-        profile: Dict = dict()
-        activated_date_formats: List = list()
+        profile: dict = dict()
+        activated_date_formats: list = list()
         len_df = len(df_series)
 
         is_row_datetime = pd.Series(np.full((len(df_series)), False))
@@ -345,8 +342,8 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
     def _update_datetime(
         self,
         df_series: pd.DataFrame,
-        prev_dependent_properties: Dict,
-        subset_properties: Dict,
+        prev_dependent_properties: dict,
+        subset_properties: dict,
     ) -> None:
         """
         Calculate the datetime properties for the profile.
@@ -390,7 +387,7 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
 
         subset_properties.update(profile)
 
-    def _update_helper(self, df_series: pd.Series, profile: Dict) -> None:
+    def _update_helper(self, df_series: pd.Series, profile: dict) -> None:
         """
         Update the column profile properties.
 
@@ -417,7 +414,7 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
         profile = {"sample_size": len(df_series), "match_count": 0}
         if self._is_subset_datetime_column(df_series):
             self._update_datetime(df_series, {}, profile)
-            super(DateTimeColumn, self)._perform_property_calcs(
+            super()._perform_property_calcs(
                 self.__calculations,
                 df_series=df_series,
                 prev_dependent_properties={},

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import copy
 import re
-from typing import Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -23,7 +22,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
 
     type = "float"
 
-    def __init__(self, name: Optional[str], options: FloatOptions = None) -> None:
+    def __init__(self, name: str | None, options: FloatOptions = None) -> None:
         """
         Initialize column base properties and itself.
 
@@ -39,7 +38,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         NumericStatsMixin.__init__(self, options)
         BaseColumnPrimitiveTypeProfiler.__init__(self, name)
 
-        self._precision: Dict = {
+        self._precision: dict = {
             "min": None,
             "max": None,
             "sum": None,
@@ -121,7 +120,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
 
         return merged_profile
 
-    def diff(self, other_profile: FloatColumn, options: Dict = None) -> Dict:
+    def diff(self, other_profile: FloatColumn, options: dict = None) -> dict:
         """
         Find the differences for FloatColumns.
 
@@ -141,7 +140,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         differences["precision"] = precision_diff
         return differences
 
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """Report profile attribute of class; potentially pop val from self.profile."""
         calcs_dict_keys = self._FloatColumn__calculations.keys()
         profile = self.profile
@@ -157,7 +156,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         return profile
 
     @property
-    def profile(self) -> Dict:
+    def profile(self) -> dict:
         """
         Return the profile of the column.
 
@@ -185,7 +184,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         return profile
 
     @property
-    def precision(self) -> Dict[str, Optional[float]]:
+    def precision(self) -> dict[str, float | None]:
         """
         Report statistics on the significant figures of each element in the data.
 
@@ -225,7 +224,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         return precision
 
     @property
-    def data_type_ratio(self) -> Optional[float]:
+    def data_type_ratio(self) -> float | None:
         """
         Calculate the ratio of samples which match this data type.
 
@@ -239,7 +238,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
     @classmethod
     def _get_float_precision(
         cls, df_series_clean: pd.Series, sample_ratio: float = None
-    ) -> Optional[Dict]:
+    ) -> dict | None:
         """
         Determine the precision of the numeric value.
 
@@ -285,9 +284,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         return subset_precision
 
     @classmethod
-    def _is_each_row_float(
-        cls, df_series: pd.Series
-    ) -> Union[List[bool], pd.Series[bool]]:
+    def _is_each_row_float(cls, df_series: pd.Series) -> list[bool] | pd.Series[bool]:
         """
         Determine if each value in a dataframe is a float.
 
@@ -309,8 +306,8 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
     def _update_precision(
         self,
         df_series: pd.DataFrame,
-        prev_dependent_properties: Dict,
-        subset_properties: Dict,
+        prev_dependent_properties: dict,
+        subset_properties: dict,
     ) -> None:
         """
         Update the precision value of the column.
@@ -359,7 +356,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
                 self._precision["sum"] / self._precision["sample_size"]
             )
 
-    def _update_helper(self, df_series_clean: pd.Series, profile: Dict) -> None:
+    def _update_helper(self, df_series_clean: pd.Series, profile: dict) -> None:
         """
         Update column profile properties with cleaned dataset and its known profile.
 
@@ -376,8 +373,8 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
     def _update_numeric_stats(
         self,
         df_series: pd.DataFrame,
-        prev_dependent_properties: Dict,
-        subset_properties: Dict,
+        prev_dependent_properties: dict,
+        subset_properties: dict,
     ) -> None:
         """
         Call the numeric stats update function.
@@ -393,7 +390,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         :type df_series: Pandas Dataframe
         :return: None
         """
-        super(FloatColumn, self)._update_helper(df_series, subset_properties)
+        super()._update_helper(df_series, subset_properties)
 
     def update(self, df_series: pd.Series) -> FloatColumn:
         """

--- a/dataprofiler/profilers/graph_profiler.py
+++ b/dataprofiler/profilers/graph_profiler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import pickle
 from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List, Optional, Tuple, Union, cast
+from typing import cast
 
 import networkx as nx
 import numpy as np
@@ -16,7 +16,7 @@ from . import BaseColumnProfiler, utils
 from .profiler_options import ProfilerOptions
 
 
-class GraphProfiler(object):
+class GraphProfiler:
     """
     GraphProfiler class.
 
@@ -25,7 +25,7 @@ class GraphProfiler(object):
     """
 
     def __init__(
-        self, data: Union[nx.Graph, GraphData], options: ProfilerOptions = None
+        self, data: nx.Graph | GraphData, options: ProfilerOptions = None
     ) -> None:
         """
         Initialize Graph Profiler.
@@ -36,7 +36,7 @@ class GraphProfiler(object):
         :type options: GraphOptions
         """
         self.sample_size = 0
-        self.times: Dict[str, float] = defaultdict(float)
+        self.times: dict[str, float] = defaultdict(float)
 
         """
         Properties
@@ -50,7 +50,7 @@ class GraphProfiler(object):
         self._global_max_component_size = None
         self._continuous_distribution = None
         self._categorical_distribution = None
-        self.metadata: Dict = dict()
+        self.metadata: dict = dict()
 
         self.__calculations = {
             "num_nodes": GraphProfiler._update_num_nodes,
@@ -77,7 +77,7 @@ class GraphProfiler(object):
         )
 
     @property
-    def profile(self) -> Dict:
+    def profile(self) -> dict:
         """
         Return the profile of the graph.
 
@@ -96,7 +96,7 @@ class GraphProfiler(object):
         )
         return profile
 
-    def diff(self, other_profile: GraphProfiler, options: Dict = None) -> Dict:
+    def diff(self, other_profile: GraphProfiler, options: dict = None) -> dict:
         """
         Find the differences for two graph profiles.
 
@@ -147,7 +147,7 @@ class GraphProfiler(object):
 
         return diff_profile
 
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """
         Report on profile attribute of the class.
 
@@ -176,7 +176,7 @@ class GraphProfiler(object):
                 profile.pop(profile_key)
         return profile
 
-    def _update_helper(self, profile: Dict) -> None:
+    def _update_helper(self, profile: dict) -> None:
         """
         Update the graph profile properties with a cleaned dataset.
 
@@ -227,8 +227,8 @@ class GraphProfiler(object):
     def _update_num_nodes(
         self,
         graph: nx.Graph,
-        prev_dependent_properties: Dict = None,
-        subset_properties: Dict = None,
+        prev_dependent_properties: dict = None,
+        subset_properties: dict = None,
     ) -> None:
         """Update num_nodes for profile."""
         if subset_properties is None:
@@ -240,8 +240,8 @@ class GraphProfiler(object):
     def _update_num_edges(
         self,
         graph: nx.Graph,
-        prev_dependent_properties: Dict = None,
-        subset_properties: Dict = None,
+        prev_dependent_properties: dict = None,
+        subset_properties: dict = None,
     ) -> None:
         """Update num_edges for profile."""
         self._num_edges = self._get_num_edges(graph)
@@ -249,8 +249,8 @@ class GraphProfiler(object):
     def _update_avg_node_degree(
         self,
         graph: nx.Graph,
-        prev_dependent_properties: Dict = None,
-        subset_properties: Dict = None,
+        prev_dependent_properties: dict = None,
+        subset_properties: dict = None,
     ) -> None:
         """Update avg_node_degree for profile."""
         if subset_properties is None:
@@ -263,8 +263,8 @@ class GraphProfiler(object):
     def _update_global_max_comp_size(
         self,
         graph: nx.Graph,
-        prev_dependent_properties: Dict = None,
-        subset_properties: Dict = None,
+        prev_dependent_properties: dict = None,
+        subset_properties: dict = None,
     ) -> None:
         """Update global_max_component_size for profile."""
         self._global_max_component_size = self._get_global_max_component_size(graph)
@@ -272,8 +272,8 @@ class GraphProfiler(object):
     def _update_categorical_attributes(
         self,
         graph: nx.Graph,
-        prev_dependent_properties: Dict = None,
-        subset_properties: Dict = None,
+        prev_dependent_properties: dict = None,
+        subset_properties: dict = None,
     ) -> None:
         """Update categorical_attributes for profile."""
         if subset_properties is None:
@@ -285,8 +285,8 @@ class GraphProfiler(object):
     def _update_continuous_attributes(
         self,
         graph: nx.Graph,
-        prev_dependent_properties: Dict = None,
-        subset_properties: Dict = None,
+        prev_dependent_properties: dict = None,
+        subset_properties: dict = None,
     ) -> None:
         """Update continuous_attributes for profile."""
         if subset_properties is None:
@@ -298,8 +298,8 @@ class GraphProfiler(object):
     def _update_continuous_distribution(
         self,
         graph: nx.Graph,
-        prev_dependent_properties: Dict = None,
-        subset_properties: Dict = None,
+        prev_dependent_properties: dict = None,
+        subset_properties: dict = None,
     ) -> None:
         """Update continuous_distribution for profile."""
         if subset_properties is None:
@@ -312,8 +312,8 @@ class GraphProfiler(object):
     def _update_categorical_distribution(
         self,
         graph: nx.Graph,
-        prev_dependent_properties: Dict = None,
-        subset_properties: Dict = None,
+        prev_dependent_properties: dict = None,
+        subset_properties: dict = None,
     ) -> None:
         """Update categorical_distribution for profile."""
         if subset_properties is None:
@@ -338,12 +338,12 @@ class GraphProfiler(object):
         return cast(int, graph.number_of_edges())
 
     @BaseColumnProfiler._timeit(name="categorical_attributes")
-    def _get_categorical_attributes(self, graph: nx.Graph) -> List[str]:
+    def _get_categorical_attributes(self, graph: nx.Graph) -> list[str]:
         """Fetch list of categorical attributes."""
         return self._get_categorical_and_continuous_attributes(graph)[0]
 
     @BaseColumnProfiler._timeit(name="continuous_attributes")
-    def _get_continuous_attributes(self, graph: nx.Graph) -> List[str]:
+    def _get_continuous_attributes(self, graph: nx.Graph) -> list[str]:
         """Fetch list of continuous attributes."""
         return self._get_categorical_and_continuous_attributes(graph)[1]
 
@@ -366,8 +366,8 @@ class GraphProfiler(object):
 
     @BaseColumnProfiler._timeit(name="continuous_distribution")
     def _get_continuous_distribution(
-        self, graph: nx.Graph, continuous_attributes: List[str]
-    ) -> Dict:
+        self, graph: nx.Graph, continuous_attributes: list[str]
+    ) -> dict:
         """
         Compute the continuous distribution of graph edge continuous attributes.
 
@@ -380,9 +380,9 @@ class GraphProfiler(object):
             - lognorm: shape=s
         """
         attributes = self._find_all_attributes(graph)
-        continuous_distributions: Dict = dict()
+        continuous_distributions: dict = dict()
 
-        distribution_candidates: List[st.rv_continuous] = [
+        distribution_candidates: list[st.rv_continuous] = [
             st.norm,
             st.uniform,
             st.expon,
@@ -396,7 +396,7 @@ class GraphProfiler(object):
                 df = pd.Series(data_as_list)
                 best_fit: str = None  # type: ignore[assignment]
                 best_mle: float = 1000
-                best_fit_properties: Tuple = None  # type: ignore[assignment]
+                best_fit_properties: tuple = None  # type: ignore[assignment]
 
                 for distribution in distribution_candidates:
                     # compute fit, mle, kolmogorov-smirnov test to test fit, and pdf
@@ -412,7 +412,7 @@ class GraphProfiler(object):
                 mean, variance, skew, kurtosis = best_distrib.stats(
                     best_fit_properties, moments="mvsk"
                 )
-                properties: Dict[str, List[np.ndarray]] = {
+                properties: dict[str, list[np.ndarray]] = {
                     "best_fit_properties": list(best_fit_properties),
                     "mean": list(mean),
                     "variance": list(variance),
@@ -430,12 +430,12 @@ class GraphProfiler(object):
 
     @BaseColumnProfiler._timeit(name="categorical_distribution")
     def _get_categorical_distribution(
-        self, graph: nx.Graph, categorical_attributes: List[str]
-    ) -> Dict:
+        self, graph: nx.Graph, categorical_attributes: list[str]
+    ) -> dict:
         """Compute histogram of graph edge categorical attributes."""
         attributes = GraphProfiler._find_all_attributes(graph)
 
-        categorical_distributions: Dict = dict()
+        categorical_distributions: dict = dict()
 
         for attribute in attributes:
             if attribute in categorical_attributes:
@@ -452,7 +452,7 @@ class GraphProfiler(object):
     @staticmethod
     def _get_categorical_and_continuous_attributes(
         graph: nx.Graph,
-    ) -> Tuple[List[str], List[str]]:
+    ) -> tuple[list[str], list[str]]:
         """Find and list categorical and continuous attributes."""
         categorical_attributes = []
         continuous_attributes = []
@@ -475,14 +475,14 @@ class GraphProfiler(object):
     """
 
     @staticmethod
-    def _find_all_attributes(graph: nx.Graph) -> List[str]:
+    def _find_all_attributes(graph: nx.Graph) -> list[str]:
         """Compute the number of attributes for each edge."""
         attribute_list = set(
             np.array([list(graph.edges[n].keys()) for n in graph.edges()]).flatten()
         )
         return list(attribute_list)
 
-    def _attribute_data_as_list(self, graph: nx.Graph, attribute: str) -> List:
+    def _attribute_data_as_list(self, graph: nx.Graph, attribute: str) -> list:
         """Fetch graph attribute data and convert it to a readable list."""
         data_as_list = []
         for u, v in list(graph.edges):
@@ -490,7 +490,7 @@ class GraphProfiler(object):
             data_as_list.append(value)
         return data_as_list
 
-    def _save_helper(self, filepath: Optional[str], data_dict: Dict) -> None:
+    def _save_helper(self, filepath: str | None, data_dict: dict) -> None:
         """
         Save profiler to disk.
 

--- a/dataprofiler/profilers/histogram_utils.py
+++ b/dataprofiler/profilers/histogram_utils.py
@@ -48,9 +48,7 @@ def _get_bin_edges(
         # if `bins` is a string for an automatic method,
         # this will replace it with the number of bins calculated
         if bin_name not in _hist_bin_selectors:
-            raise ValueError(
-                "{!r} is not a valid estimator for `bins`".format(bin_name)
-            )
+            raise ValueError(f"{bin_name!r} is not a valid estimator for `bins`")
         if weights is not None:
             raise TypeError(
                 "Automated estimation of the number of "

--- a/dataprofiler/profilers/int_column_profile.py
+++ b/dataprofiler/profilers/int_column_profile.py
@@ -1,8 +1,6 @@
 """Int profile analysis for individual col within structured profiling."""
 from __future__ import annotations
 
-from typing import Dict, List, Optional
-
 import numpy as np
 import pandas as pd
 
@@ -20,7 +18,7 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
 
     type = "int"
 
-    def __init__(self, name: Optional[str], options: IntOptions = None) -> None:
+    def __init__(self, name: str | None, options: IntOptions = None) -> None:
         """
         Initialize column base properties and itself.
 
@@ -35,7 +33,7 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             )
         NumericStatsMixin.__init__(self, options)
         BaseColumnPrimitiveTypeProfiler.__init__(self, name)
-        self.__calculations: Dict = {}
+        self.__calculations: dict = {}
         self._filter_properties_w_options(self.__calculations, options)
 
     def __add__(self, other: IntColumn) -> IntColumn:
@@ -62,7 +60,7 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         )
         return merged_profile
 
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """
         Return the report.
 
@@ -73,7 +71,7 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         return self.profile
 
     @property
-    def profile(self) -> Dict:
+    def profile(self) -> dict:
         """
         Return the profile of the column.
 
@@ -82,7 +80,7 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         return NumericStatsMixin.profile(self)
 
     @property
-    def data_type_ratio(self) -> Optional[float]:
+    def data_type_ratio(self) -> float | None:
         """
         Calculate the ratio of samples which match this data type.
 
@@ -94,7 +92,7 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         return None
 
     @classmethod
-    def _is_each_row_int(cls, df_series: pd.Series) -> List[bool]:
+    def _is_each_row_int(cls, df_series: pd.Series) -> list[bool]:
         """
         Return true if given is numerical and int values.
 
@@ -115,7 +113,7 @@ class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
 
         return [NumericStatsMixin.is_int(x) for x in df_series]
 
-    def _update_helper(self, df_series_clean: pd.Series, profile: Dict) -> None:
+    def _update_helper(self, df_series_clean: pd.Series, profile: dict) -> None:
         """
         Update col profile properties with clean dataset and its known null params.
 

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 """Build model for dataset by identifying col type along with its respective params."""
-from __future__ import annotations, division, print_function
+from __future__ import annotations
 
 import abc
 import copy
 import itertools
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -26,7 +26,7 @@ class abstractstaticmethod(staticmethod):
 
     def __init__(self, function: Callable) -> None:
         """Initialize abstract static method."""
-        super(abstractstaticmethod, self).__init__(function)
+        super().__init__(function)
         function.__isabstractmethod__ = True  # type: ignore
 
     __isabstractmethod__ = True
@@ -40,7 +40,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     Has Subclasses itself.
     """
 
-    type: Optional[str] = None
+    type: str | None = None
 
     def __init__(self, options: NumericalOptions = None) -> None:
         """
@@ -54,18 +54,18 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
                 "NumericalStatsMixin parameter 'options' must be "
                 "of type NumericalOptions."
             )
-        self.min: Union[int, float, None] = None
-        self.max: Union[int, float, None] = None
+        self.min: int | float | None = None
+        self.max: int | float | None = None
         self._top_k_modes: int = 5  # By default, return at max 5 modes
-        self.sum: Union[int, float] = 0
+        self.sum: int | float = 0
         self._biased_variance: float = np.nan
-        self._biased_skewness: Union[float, np.float64] = np.nan
-        self._biased_kurtosis: Union[float, np.float64] = np.nan
+        self._biased_skewness: float | np.float64 = np.nan
+        self._biased_kurtosis: float | np.float64 = np.nan
         self._median_is_enabled: bool = True
         self._median_abs_dev_is_enabled: bool = True
         self.max_histogram_bin: int = 100000
         self.min_histogram_bin: int = 1000
-        self.histogram_bin_method_names: List[str] = [
+        self.histogram_bin_method_names: list[str] = [
             "auto",
             "fd",
             "doane",
@@ -74,8 +74,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
             "sturges",
             "sqrt",
         ]
-        self.histogram_selection: Optional[str] = None
-        self.user_set_histogram_bin: Optional[int] = None
+        self.histogram_selection: str | None = None
+        self.user_set_histogram_bin: int | None = None
         self.bias_correction: bool = True  # By default, we correct for bias
         self._mode_is_enabled: bool = True
         self.num_zeros: int = 0
@@ -94,14 +94,14 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
             elif isinstance(bin_count_or_method, int):
                 self.user_set_histogram_bin = bin_count_or_method
                 self.histogram_bin_method_names = ["custom"]
-        self.histogram_methods: Dict = {}
-        self._stored_histogram: Dict = {
+        self.histogram_methods: dict = {}
+        self._stored_histogram: dict = {
             "total_loss": 0,
             "current_loss": 0,
             "suggested_bin_count": self.min_histogram_bin,
             "histogram": {"bin_counts": None, "bin_edges": None},
         }
-        self._batch_history: List = []
+        self._batch_history: list = []
         for method in self.histogram_bin_method_names:
             self.histogram_methods[method] = {
                 "total_loss": 0,
@@ -110,7 +110,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
                 "histogram": {"bin_counts": None, "bin_edges": None},
             }
         num_quantiles: int = 1000  # TODO: add to options
-        self.quantiles: Union[List[float], Dict] = {
+        self.quantiles: list[float] | dict = {
             bin_num: None for bin_num in range(num_quantiles - 1)
         }
         self.__calculations = {
@@ -130,11 +130,11 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
 
     def __getattribute__(self, name: str) -> Any:
         """Return computed attribute value."""
-        return super(NumericStatsMixin, self).__getattribute__(name)
+        return super().__getattribute__(name)
 
     def __getitem__(self, item: str) -> Any:
         """Return indexed item."""
-        return super(NumericStatsMixin, self).__getitem__(item)
+        return super().__getitem__(item)
 
     @property
     def _has_histogram(self) -> bool:
@@ -295,7 +295,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
             other1._median_abs_dev_is_enabled and other2._median_abs_dev_is_enabled
         )
 
-    def profile(self) -> Dict:
+    def profile(self) -> dict:
         """
         Return profile of the column.
 
@@ -322,7 +322,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
 
         return profile
 
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """
         Call the profile and remove the disabled columns from profile's report.
 
@@ -355,7 +355,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
 
         return profile
 
-    def diff(self, other_profile: NumericStatsMixin, options: Dict = None) -> Dict:
+    def diff(self, other_profile: NumericStatsMixin, options: dict = None) -> dict:
         """
         Find the differences for several numerical stats.
 
@@ -411,7 +411,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         return float(self.sum) / self.match_count
 
     @property
-    def mode(self) -> List[float]:
+    def mode(self) -> list[float]:
         """
         Find an estimate for the mode[s] of the data.
 
@@ -444,14 +444,14 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         )
 
     @property
-    def stddev(self) -> Union[float, np.float64]:
+    def stddev(self) -> float | np.float64:
         """Return stddev value."""
         if self.match_count == 0:
             return np.nan
         return cast(np.float64, np.sqrt(self.variance))
 
     @property
-    def skewness(self) -> Union[float, np.float64]:
+    def skewness(self) -> float | np.float64:
         """Return skewness value."""
         return (
             self._biased_skewness
@@ -460,7 +460,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         )
 
     @property
-    def kurtosis(self) -> Union[float, np.float64]:
+    def kurtosis(self) -> float | np.float64:
         """Return kurtosis value."""
         return (
             self._biased_kurtosis
@@ -471,8 +471,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     @staticmethod
     def _perform_t_test(
         mean1: float, var1: float, n1: int, mean2: float, var2: float, n2: int
-    ) -> Dict:
-        results: Dict = {
+    ) -> dict:
+        results: dict = {
             "t-statistic": None,
             "conservative": {"df": None, "p-value": None},
             "welch": {"df": None, "p-value": None},
@@ -609,7 +609,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         self_histogram: np.ndarray,
         other_match_count: int,
         other_histogram: np.ndarray,
-    ) -> Optional[float]:
+    ) -> float | None:
         """
         Calculate PSI (Population Stability Index).
 
@@ -748,14 +748,14 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     @staticmethod
     def _merge_biased_skewness(
         match_count1: int,
-        biased_skewness1: Union[float, np.float64],
+        biased_skewness1: float | np.float64,
         biased_variance1: float,
         mean1: float,
         match_count2: int,
-        biased_skewness2: Union[float, np.float64],
+        biased_skewness2: float | np.float64,
         biased_variance2: float,
         mean2: float,
-    ) -> Union[float, np.float64]:
+    ) -> float | np.float64:
         """
         Calculate the combined skewness of two data chunks.
 
@@ -804,8 +804,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
 
     @staticmethod
     def _correct_bias_skewness(
-        match_count: int, biased_skewness: Union[float, np.float64]
-    ) -> Union[float, np.float64]:
+        match_count: int, biased_skewness: float | np.float64
+    ) -> float | np.float64:
         """
         Apply bias correction to skewness.
 
@@ -833,16 +833,16 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     @staticmethod
     def _merge_biased_kurtosis(
         match_count1: int,
-        biased_kurtosis1: Union[float, np.float64],
-        biased_skewness1: Union[float, np.float64],
+        biased_kurtosis1: float | np.float64,
+        biased_skewness1: float | np.float64,
         biased_variance1: float,
         mean1: float,
         match_count2: int,
-        biased_kurtosis2: Union[float, np.float64],
-        biased_skewness2: Union[float, np.float64],
+        biased_kurtosis2: float | np.float64,
+        biased_skewness2: float | np.float64,
         biased_variance2: float,
         mean2: float,
-    ) -> Union[float, np.float64]:
+    ) -> float | np.float64:
         """
         Calculate the combined kurtosis of two sets of data.
 
@@ -903,8 +903,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
 
     @staticmethod
     def _correct_bias_kurtosis(
-        match_count: int, biased_kurtosis: Union[float, np.float64]
-    ) -> Union[float, np.float64]:
+        match_count: int, biased_kurtosis: float | np.float64
+    ) -> float | np.float64:
         """
         Apply bias correction to kurtosis.
 
@@ -929,7 +929,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         )
         return kurtosis
 
-    def _estimate_mode_from_histogram(self) -> List[float]:
+    def _estimate_mode_from_histogram(self) -> list[float]:
         """
         Estimate the mode of the current data using the histogram.
 
@@ -973,7 +973,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         return var
 
     def _total_histogram_bin_variance(
-        self, input_array: Union[np.ndarray, pd.Series]
+        self, input_array: np.ndarray | pd.Series
     ) -> float:
         # calculate total variance over all bins of a histogram
         bin_counts = self._stored_histogram["histogram"]["bin_counts"]
@@ -992,7 +992,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
             sum_var += bin_var
         return sum_var
 
-    def _histogram_bin_error(self, input_array: Union[np.ndarray, pd.Series]) -> float:
+    def _histogram_bin_error(self, input_array: np.ndarray | pd.Series) -> float:
         """
         Calculate error of each value from bin of the histogram it falls within.
 
@@ -1102,11 +1102,9 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
             hist_to_array = [[]]
 
         array_flatten: np.ndarray = np.concatenate(
-            (
-                hist_to_array
-                + [[bin_edges[-2]] * int(bin_counts[-1] / 2)]
-                + [[bin_edges[-1]] * (bin_counts[-1] - int(bin_counts[-1] / 2))]
-            )
+            hist_to_array
+            + [[bin_edges[-2]] * int(bin_counts[-1] / 2)]
+            + [[bin_edges[-1]] * (bin_counts[-1] - int(bin_counts[-1] / 2))]
         )
 
         # If we know they are integers, we can limit the data to be as such
@@ -1117,8 +1115,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         return array_flatten
 
     def _get_histogram(
-        self, values: Union[np.ndarray, pd.Series]
-    ) -> Tuple[np.ndarray, np.ndarray]:
+        self, values: np.ndarray | pd.Series
+    ) -> tuple[np.ndarray, np.ndarray]:
         """
         Calculate stored histogram the suggested bin counts for each histogram method.
 
@@ -1171,7 +1169,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
             bin_counts, bin_edges = np.histogram(values, bins=n_equal_bins)
         return bin_counts, bin_edges
 
-    def _merge_histogram(self, values: Union[np.ndarray, pd.Series]) -> None:
+    def _merge_histogram(self, values: np.ndarray | pd.Series) -> None:
         # values is the current array of values,
         # that needs to be updated to the accumulated histogram
         combined_values = np.concatenate([values, self._histogram_to_array()])
@@ -1219,7 +1217,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
 
     def _regenerate_histogram(
         self, bin_counts, bin_edges, suggested_bin_count, options=None
-    ) -> Tuple[Dict[str, np.ndarray], float]:
+    ) -> tuple[dict[str, np.ndarray], float]:
 
         # create proper binning
         new_bin_counts = np.zeros((suggested_bin_count,))
@@ -1290,7 +1288,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
 
     def _histogram_for_profile(
         self, histogram_method: str
-    ) -> Tuple[Dict[str, np.ndarray], float]:
+    ) -> tuple[dict[str, np.ndarray], float]:
         """
         Convert the stored histogram into the presentable state.
 
@@ -1331,7 +1329,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
             suggested_bin_count=suggested_bin_count,
         )
 
-    def _get_best_histogram_for_profile(self) -> Dict:
+    def _get_best_histogram_for_profile(self) -> dict:
         """
         Convert the stored histogram into the presentable state.
 
@@ -1354,9 +1352,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
 
         return cast(Dict, self.histogram_methods[self.histogram_selection]["histogram"])
 
-    def _get_percentile(
-        self, percentiles: Union[np.ndarray, List[float]]
-    ) -> List[float]:
+    def _get_percentile(self, percentiles: np.ndarray | list[float]) -> list[float]:
         """
         Get value for the number where the given percentage of values fall below it.
 
@@ -1397,7 +1393,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     @staticmethod
     def _fold_histogram(
         bin_counts: np.ndarray, bin_edges: np.ndarray, value: float
-    ) -> Tuple[List[Union[np.ndarray, List]], List[Union[np.ndarray, List]]]:
+    ) -> tuple[list[np.ndarray | list], list[np.ndarray | list]]:
         """
         Offset histogram by given value, then fold the histogram at break point.
 
@@ -1453,7 +1449,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         return [bin_counts_pos, bin_edges_pos], [bin_counts_neg, bin_edges_neg]
 
     @property
-    def median_abs_deviation(self) -> Union[float, np.float64]:
+    def median_abs_deviation(self) -> float | np.float64:
         """
         Get median absolute deviation estimated from the histogram of the data.
 
@@ -1535,7 +1531,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         percentiles: np.ndarray = np.linspace(0, 100, len(self.quantiles) + 2)[1:-1]
         self.quantiles = self._get_percentile(percentiles=percentiles)
 
-    def _update_helper(self, df_series_clean: pd.Series, profile: Dict) -> None:
+    def _update_helper(self, df_series_clean: pd.Series, profile: dict) -> None:
         """
         Update base numerical profile properties w/ clean dataset and known null params.
 
@@ -1556,7 +1552,7 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
         }
         subset_properties = copy.deepcopy(profile)
         df_series_clean = df_series_clean.astype(float)
-        super(NumericStatsMixin, self)._perform_property_calcs(
+        super()._perform_property_calcs(
             self.__calculations,
             df_series=df_series_clean,
             prev_dependent_properties=prev_dependent_properties,
@@ -1570,8 +1566,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     def _get_min(
         self,
         df_series: pd.Series,
-        prev_dependent_properties: Dict,
-        subset_properties: Dict,
+        prev_dependent_properties: dict,
+        subset_properties: dict,
     ) -> None:
         min_value = df_series.min()
         self.min = min_value if not self.min else min(self.min, min_value)
@@ -1581,8 +1577,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     def _get_max(
         self,
         df_series: pd.Series,
-        prev_dependent_properties: Dict,
-        subset_properties: Dict,
+        prev_dependent_properties: dict,
+        subset_properties: dict,
     ) -> None:
         max_value = df_series.max()
         self.max = max_value if not self.max else max(self.max, max_value)
@@ -1592,8 +1588,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     def _get_sum(
         self,
         df_series: pd.Series,
-        prev_dependent_properties: Dict,
-        subset_properties: Dict,
+        prev_dependent_properties: dict,
+        subset_properties: dict,
     ) -> None:
         if np.isinf(self.sum) or (np.isnan(self.sum) and self.match_count > 0):
             return
@@ -1614,8 +1610,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     def _get_variance(
         self,
         df_series: pd.Series,
-        prev_dependent_properties: Dict,
-        subset_properties: Dict,
+        prev_dependent_properties: dict,
+        subset_properties: dict,
     ) -> None:
         if np.isinf(self._biased_variance) or (
             np.isnan(self._biased_variance) and self.match_count > 0
@@ -1644,8 +1640,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     def _get_skewness(
         self,
         df_series: pd.Series,
-        prev_dependent_properties: Dict,
-        subset_properties: Dict,
+        prev_dependent_properties: dict,
+        subset_properties: dict,
     ) -> None:
         """
         Compute and update skewness of current dataset given new chunk.
@@ -1688,8 +1684,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     def _get_kurtosis(
         self,
         df_series: pd.Series,
-        prev_dependent_properties: Dict,
-        subset_properties: Dict,
+        prev_dependent_properties: dict,
+        subset_properties: dict,
     ) -> None:
         """
         Compute and update kurtosis of current dataset given new chunk.
@@ -1735,8 +1731,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     def _get_histogram_and_quantiles(
         self,
         df_series: pd.Series,
-        prev_dependent_properties: Dict,
-        subset_properties: Dict,
+        prev_dependent_properties: dict,
+        subset_properties: dict,
     ) -> None:
         try:
             self._update_histogram(df_series)
@@ -1753,8 +1749,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     def _get_num_zeros(
         self,
         df_series: pd.Series,
-        prev_dependent_properties: Dict,
-        subset_properties: Dict,
+        prev_dependent_properties: dict,
+        subset_properties: dict,
     ) -> None:
         """
         Get the count of zeros in the numerical column.
@@ -1775,8 +1771,8 @@ class NumericStatsMixin(with_metaclass(abc.ABCMeta, object)):  # type: ignore
     def _get_num_negatives(
         self,
         df_series: pd.Series,
-        prev_dependent_properties: Dict,
-        subset_properties: Dict,
+        prev_dependent_properties: dict,
+        subset_properties: dict,
     ) -> None:
         """
         Get the count of negative numbers in the numerical column.

--- a/dataprofiler/profilers/order_column_profile.py
+++ b/dataprofiler/profilers/order_column_profile.py
@@ -1,7 +1,7 @@
 """Index profile analysis for individual col within structured profiling."""
 from __future__ import annotations
 
-from typing import Dict, Optional, Tuple, cast
+from typing import cast
 
 from pandas import DataFrame, Series
 
@@ -18,7 +18,7 @@ class OrderColumn(BaseColumnProfiler):
 
     type = "order"
 
-    def __init__(self, name: Optional[str], options: OrderOptions = None) -> None:
+    def __init__(self, name: str | None, options: OrderOptions = None) -> None:
         """
         Initialize column base properties and self.
 
@@ -31,13 +31,13 @@ class OrderColumn(BaseColumnProfiler):
             raise ValueError(
                 "OrderColumn parameter 'options' must be of type" " OrderOptions."
             )
-        self.order: Optional[str] = None
-        self._last_value: Optional[int] = None
-        self._first_value: Optional[int] = None
-        self._piecewise: Optional[bool] = False
-        self.__calculations: Dict = {}
+        self.order: str | None = None
+        self._last_value: int | None = None
+        self._first_value: int | None = None
+        self._piecewise: bool | None = False
+        self.__calculations: dict = {}
         self._filter_properties_w_options(self.__calculations, options)
-        super(OrderColumn, self).__init__(name)
+        super().__init__(name)
 
     @staticmethod
     def _is_intersecting(
@@ -115,7 +115,7 @@ class OrderColumn(BaseColumnProfiler):
         first_value2: int,
         last_value2: int,
         piecewise2: bool,
-    ) -> Tuple[str, int, int, bool]:
+    ) -> tuple[str, int, int, bool]:
         """
         Add the order of two datasets together.
 
@@ -156,8 +156,8 @@ class OrderColumn(BaseColumnProfiler):
 
         # Default initialization
         order = "random"
-        first_value: Optional[int] = None
-        last_value: Optional[int] = None
+        first_value: int | None = None
+        last_value: int | None = None
 
         if order1 == "random" or order2 == "random":
             order = "random"
@@ -260,7 +260,7 @@ class OrderColumn(BaseColumnProfiler):
         )
         return merged_profile
 
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """
         Private abstract method for returning report.
 
@@ -271,7 +271,7 @@ class OrderColumn(BaseColumnProfiler):
         return self.profile
 
     @property
-    def profile(self) -> Dict:
+    def profile(self) -> dict:
         """
         Property for profile. Returns the profile of the column.
 
@@ -279,7 +279,7 @@ class OrderColumn(BaseColumnProfiler):
         """
         return dict(order=self.order, times=self.times)
 
-    def diff(self, other_profile: OrderColumn, options: Dict = None) -> Dict:
+    def diff(self, other_profile: OrderColumn, options: dict = None) -> dict:
         """
         Generate the differences between the orders of two OrderColumns.
 
@@ -297,7 +297,7 @@ class OrderColumn(BaseColumnProfiler):
         return differences
 
     @BaseColumnProfiler._timeit(name="order")
-    def _get_data_order(self, df_series: Series) -> Tuple[str, float, float]:
+    def _get_data_order(self, df_series: Series) -> tuple[str, float, float]:
         """
         Retrieve the order profile of a given data series.
 
@@ -339,8 +339,8 @@ class OrderColumn(BaseColumnProfiler):
     def _update_order(
         self,
         df_series: DataFrame,
-        prev_dependent_properties: Dict = None,
-        subset_properties: Dict = None,
+        prev_dependent_properties: dict = None,
+        subset_properties: dict = None,
     ) -> None:
         """
         Update order profile with order info attained from new dataset.
@@ -380,7 +380,7 @@ class OrderColumn(BaseColumnProfiler):
             piecewise2=False,
         )
 
-    def _update_helper(self, df_series_clean: Series, profile: Dict) -> None:
+    def _update_helper(self, df_series_clean: Series, profile: dict) -> None:
         """
         Update col profile properties with clean dataset and its known null parameters.
 

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -6,16 +6,15 @@ import abc
 import copy
 import re
 import warnings
-from typing import Dict, List, Optional, Set, Union
 
 from ..labelers.base_data_labeler import BaseDataLabeler
 
 
-class BaseOption(object):
+class BaseOption:
     """For configuring options."""
 
     @property
-    def properties(self) -> Dict[str, BooleanOption]:
+    def properties(self) -> dict[str, BooleanOption]:
         """
         Return a copy of the option properties.
 
@@ -24,7 +23,7 @@ class BaseOption(object):
         """
         return copy.deepcopy(self.__dict__)
 
-    def _set_helper(self, options: Dict[str, bool], variable_path: str) -> None:
+    def _set_helper(self, options: dict[str, bool], variable_path: str) -> None:
         """
         Set all the options.
 
@@ -89,10 +88,10 @@ class BaseOption(object):
             else:
                 error_path = variable_path if variable_path else self.__class__.__name__
                 raise AttributeError(
-                    "type object '{}' has no attribute '{}'".format(error_path, option)
+                    f"type object '{error_path}' has no attribute '{option}'"
                 )
 
-    def set(self, options: Dict[str, bool]) -> None:
+    def set(self, options: dict[str, bool]) -> None:
         """
         Set all the options.
 
@@ -109,7 +108,7 @@ class BaseOption(object):
         self._set_helper(options, variable_path="")
 
     @abc.abstractmethod
-    def _validate_helper(self, variable_path: str = "") -> List[str]:
+    def _validate_helper(self, variable_path: str = "") -> list[str]:
         """
         Validate the options don't cause errors and return possible errors.
 
@@ -120,7 +119,7 @@ class BaseOption(object):
         """
         raise NotImplementedError()
 
-    def validate(self, raise_error: bool = True) -> Optional[List[str]]:
+    def validate(self, raise_error: bool = True) -> list[str] | None:
         """
         Validate the options do not conflict and cause errors.
 
@@ -163,7 +162,7 @@ class BooleanOption(BaseOption):
         """
         self.is_enabled = is_enabled
 
-    def _validate_helper(self, variable_path: str = "BooleanOption") -> List[str]:
+    def _validate_helper(self, variable_path: str = "BooleanOption") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -175,9 +174,9 @@ class BooleanOption(BaseOption):
         if not isinstance(variable_path, str):
             raise ValueError("The variable path must be a string.")
 
-        errors: List[str] = []
+        errors: list[str] = []
         if not isinstance(self.is_enabled, bool):
-            errors = ["{}.is_enabled must be a Boolean.".format(variable_path)]
+            errors = [f"{variable_path}.is_enabled must be a Boolean."]
         return errors
 
 
@@ -187,7 +186,7 @@ class HistogramOption(BooleanOption):
     def __init__(
         self,
         is_enabled: bool = True,
-        bin_count_or_method: Union[str, int, List[str]] = "auto",
+        bin_count_or_method: str | int | list[str] = "auto",
     ) -> None:
         """
         Initialize Options for histograms.
@@ -201,7 +200,7 @@ class HistogramOption(BooleanOption):
         self.bin_count_or_method = bin_count_or_method
         super().__init__(is_enabled=is_enabled)
 
-    def _validate_helper(self, variable_path: str = "HistogramOption") -> List[str]:
+    def _validate_helper(self, variable_path: str = "HistogramOption") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -248,7 +247,7 @@ class ModeOption(BooleanOption):
         self.top_k_modes = max_k_modes
         super().__init__(is_enabled=is_enabled)
 
-    def _validate_helper(self, variable_path: str = "ModeOption") -> List[str]:
+    def _validate_helper(self, variable_path: str = "ModeOption") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -283,7 +282,7 @@ class BaseInspectorOptions(BooleanOption):
 
     def _validate_helper(
         self, variable_path: str = "BaseInspectorOptions"
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -427,17 +426,17 @@ class NumericalOptions(BaseInspectorOptions):
         self.histogram_and_quantiles.is_enabled = value
 
     @property
-    def properties(self) -> Dict[str, BooleanOption]:
+    def properties(self) -> dict[str, BooleanOption]:
         """
         Include is_enabled.
 
             is_enabled: Turns on or off the column.
         """
-        props: Dict = super().properties
+        props: dict = super().properties
         props["is_numeric_stats_enabled"] = self.is_numeric_stats_enabled
         return props
 
-    def _validate_helper(self, variable_path: str = "NumericalOptions") -> List[str]:
+    def _validate_helper(self, variable_path: str = "NumericalOptions") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -466,9 +465,7 @@ class NumericalOptions(BaseInspectorOptions):
             "num_negatives",
         ]:
             if not isinstance(self.properties[item], BooleanOption):
-                errors.append(
-                    "{}.{} must be a BooleanOption.".format(variable_path, item)
-                )
+                errors.append(f"{variable_path}.{item} must be a BooleanOption.")
             else:
                 errors += self.properties[item]._validate_helper(
                     variable_path=variable_path + "." + item
@@ -577,7 +574,7 @@ class IntOptions(NumericalOptions):
         """
         NumericalOptions.__init__(self)
 
-    def _validate_helper(self, variable_path: str = "IntOptions") -> List[str]:
+    def _validate_helper(self, variable_path: str = "IntOptions") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -606,7 +603,7 @@ class PrecisionOptions(BooleanOption):
         self.sample_ratio = sample_ratio
         super().__init__(is_enabled=is_enabled)
 
-    def _validate_helper(self, variable_path: str = "PrecisionOptions") -> List[str]:
+    def _validate_helper(self, variable_path: str = "PrecisionOptions") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -620,7 +617,7 @@ class PrecisionOptions(BooleanOption):
             if not isinstance(self.sample_ratio, float) and not isinstance(
                 self.sample_ratio, int
             ):
-                errors.append("{}.sample_ratio must be a float.".format(variable_path))
+                errors.append(f"{variable_path}.sample_ratio must be a float.")
             if (
                 isinstance(self.sample_ratio, float)
                 or isinstance(self.sample_ratio, int)
@@ -675,7 +672,7 @@ class FloatOptions(NumericalOptions):
         NumericalOptions.__init__(self)
         self.precision = PrecisionOptions(is_enabled=True)
 
-    def _validate_helper(self, variable_path: str = "FloatOptions") -> List[str]:
+    def _validate_helper(self, variable_path: str = "FloatOptions") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -686,9 +683,7 @@ class FloatOptions(NumericalOptions):
         """
         errors = super()._validate_helper(variable_path=variable_path)
         if not isinstance(self.precision, PrecisionOptions):
-            errors.append(
-                "{}.precision must be a PrecisionOptions.".format(variable_path)
-            )
+            errors.append(f"{variable_path}.precision must be a PrecisionOptions.")
         errors += self.precision._validate_helper(variable_path + ".precision")
         return errors
 
@@ -738,7 +733,7 @@ class TextOptions(NumericalOptions):
         self.num_zeros = BooleanOption(is_enabled=False)
         self.num_negatives = BooleanOption(is_enabled=False)
 
-    def _validate_helper(self, variable_path: str = "TextOptions") -> List[str]:
+    def _validate_helper(self, variable_path: str = "TextOptions") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -752,7 +747,7 @@ class TextOptions(NumericalOptions):
         """
         errors = super()._validate_helper(variable_path=variable_path)
         if not isinstance(self.vocab, BooleanOption):
-            errors.append("{}.vocab must be a BooleanOption.".format(variable_path))
+            errors.append(f"{variable_path}.vocab must be a BooleanOption.")
         errors += self.vocab._validate_helper(variable_path + ".vocab")
 
         if self.properties["num_zeros"].is_enabled:
@@ -832,7 +827,7 @@ class DateTimeOptions(BaseInspectorOptions):
         """
         BaseInspectorOptions.__init__(self)
 
-    def _validate_helper(self, variable_path: str = "DateTimeOptions") -> List[str]:
+    def _validate_helper(self, variable_path: str = "DateTimeOptions") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -856,7 +851,7 @@ class OrderOptions(BaseInspectorOptions):
         """
         BaseInspectorOptions.__init__(self)
 
-    def _validate_helper(self, variable_path: str = "OrderOptions") -> List[str]:
+    def _validate_helper(self, variable_path: str = "OrderOptions") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -883,7 +878,7 @@ class CategoricalOptions(BaseInspectorOptions):
         BaseInspectorOptions.__init__(self, is_enabled=is_enabled)
         self.top_k_categories = top_k_categories
 
-    def _validate_helper(self, variable_path: str = "CategoricalOptions") -> List[str]:
+    def _validate_helper(self, variable_path: str = "CategoricalOptions") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -906,7 +901,7 @@ class CategoricalOptions(BaseInspectorOptions):
 class CorrelationOptions(BaseInspectorOptions):
     """For configuring options for Correlation between Columns."""
 
-    def __init__(self, is_enabled: bool = False, columns: List[str] = None) -> None:
+    def __init__(self, is_enabled: bool = False, columns: list[str] = None) -> None:
         """
         Initialize options for the Correlation between Columns.
 
@@ -918,7 +913,7 @@ class CorrelationOptions(BaseInspectorOptions):
         BaseInspectorOptions.__init__(self, is_enabled=is_enabled)
         self.columns = columns
 
-    def _validate_helper(self, variable_path: str = "CorrelationOptions") -> List[str]:
+    def _validate_helper(self, variable_path: str = "CorrelationOptions") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -959,11 +954,11 @@ class DataLabelerOptions(BaseInspectorOptions):
         :vartype max_sample_size: BaseDataLabeler
         """
         BaseInspectorOptions.__init__(self)
-        self.data_labeler_dirpath: Optional[str] = None
-        self.max_sample_size: Optional[int] = None
-        self.data_labeler_object: Optional[BaseDataLabeler] = None
+        self.data_labeler_dirpath: str | None = None
+        self.max_sample_size: int | None = None
+        self.data_labeler_object: BaseDataLabeler | None = None
 
-    def __deepcopy__(self, memo: Dict) -> DataLabelerOptions:
+    def __deepcopy__(self, memo: dict) -> DataLabelerOptions:
         """
         Override deepcopy for data labeler object.
 
@@ -983,7 +978,7 @@ class DataLabelerOptions(BaseInspectorOptions):
         return result
 
     @property
-    def properties(self) -> Dict:
+    def properties(self) -> dict:
         """
         Return a copy of the option properties.
 
@@ -998,7 +993,7 @@ class DataLabelerOptions(BaseInspectorOptions):
         props["data_labeler_object"] = self.data_labeler_object
         return props
 
-    def _validate_helper(self, variable_path: str = "DataLabelerOptions") -> List[str]:
+    def _validate_helper(self, variable_path: str = "DataLabelerOptions") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -1012,9 +1007,7 @@ class DataLabelerOptions(BaseInspectorOptions):
         if self.data_labeler_dirpath is not None and not isinstance(
             self.data_labeler_dirpath, str
         ):
-            errors.append(
-                "{}.data_labeler_dirpath must be a string.".format(variable_path)
-            )
+            errors.append(f"{variable_path}.data_labeler_dirpath must be a string.")
 
         if self.data_labeler_object is not None and not isinstance(
             self.data_labeler_object, BaseDataLabeler
@@ -1035,13 +1028,9 @@ class DataLabelerOptions(BaseInspectorOptions):
         if self.max_sample_size is not None and not isinstance(
             self.max_sample_size, int
         ):
-            errors.append(
-                "{}.max_sample_size must be an integer.".format(variable_path)
-            )
+            errors.append(f"{variable_path}.max_sample_size must be an integer.")
         elif self.max_sample_size is not None and self.max_sample_size <= 0:
-            errors.append(
-                "{}.max_sample_size must be greater than 0.".format(variable_path)
-            )
+            errors.append(f"{variable_path}.max_sample_size must be greater than 0.")
         return errors
 
 
@@ -1052,7 +1041,7 @@ class TextProfilerOptions(BaseInspectorOptions):
         self,
         is_enabled: bool = True,
         is_case_sensitive: bool = True,
-        stop_words: Set[str] = None,
+        stop_words: set[str] = None,
         top_k_chars: int = None,
         top_k_words: int = None,
     ) -> None:
@@ -1082,7 +1071,7 @@ class TextProfilerOptions(BaseInspectorOptions):
         self.vocab = BooleanOption(is_enabled=True)
         self.words = BooleanOption(is_enabled=True)
 
-    def _validate_helper(self, variable_path: str = "TextProfilerOptions") -> List[str]:
+    def _validate_helper(self, variable_path: str = "TextProfilerOptions") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -1097,9 +1086,7 @@ class TextProfilerOptions(BaseInspectorOptions):
         errors = super()._validate_helper(variable_path=variable_path)
 
         if not isinstance(self.is_case_sensitive, bool):
-            errors.append(
-                "{}.is_case_sensitive must be a Boolean.".format(variable_path)
-            )
+            errors.append(f"{variable_path}.is_case_sensitive must be a Boolean.")
 
         if self.stop_words is not None and (
             not isinstance(self.stop_words, list)
@@ -1144,8 +1131,8 @@ class StructuredOptions(BaseOption):
 
     def __init__(
         self,
-        null_values: Dict[str, Union[re.RegexFlag, int]] = None,
-        column_null_values: Dict[int, Dict[str, Union[re.RegexFlag, int]]] = None,
+        null_values: dict[str, re.RegexFlag | int] = None,
+        column_null_values: dict[int, dict[str, re.RegexFlag | int]] = None,
     ) -> None:
         """
         Construct the StructuredOptions object with default values.
@@ -1195,7 +1182,7 @@ class StructuredOptions(BaseOption):
         self.column_null_values = column_null_values
 
     @property
-    def enabled_profiles(self) -> List[str]:
+    def enabled_profiles(self) -> list[str]:
         """Return a list of the enabled profilers for columns."""
         enabled_profiles = list()
         # null_values and column_null_values do not have is_enabled
@@ -1207,7 +1194,7 @@ class StructuredOptions(BaseOption):
                 enabled_profiles.append(key)
         return enabled_profiles
 
-    def _validate_helper(self, variable_path: str = "StructuredOptions") -> List[str]:
+    def _validate_helper(self, variable_path: str = "StructuredOptions") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -1317,7 +1304,7 @@ class UnstructuredOptions(BaseOption):
         self.data_labeler = DataLabelerOptions()
 
     @property
-    def enabled_profiles(self) -> List[str]:
+    def enabled_profiles(self) -> list[str]:
         """Return a list of the enabled profilers."""
         enabled_profiles = list()
         for key, value in self.properties.items():
@@ -1325,7 +1312,7 @@ class UnstructuredOptions(BaseOption):
                 enabled_profiles.append(key)
         return enabled_profiles
 
-    def _validate_helper(self, variable_path: str = "UnstructuredOptions") -> List[str]:
+    def _validate_helper(self, variable_path: str = "UnstructuredOptions") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -1394,7 +1381,7 @@ class ProfilerOptions(BaseOption):
         self.set({"*.float.is_numeric_stats_enabled": False})
         self.set({"structured_options.text.is_numeric_stats_enabled": False})
 
-    def _validate_helper(self, variable_path: str = "ProfilerOptions") -> List[str]:
+    def _validate_helper(self, variable_path: str = "ProfilerOptions") -> list[str]:
         """
         Validate the options do not conflict and cause errors.
 
@@ -1431,7 +1418,7 @@ class ProfilerOptions(BaseOption):
 
         return errors
 
-    def set(self, options: Dict[str, bool]) -> None:
+    def set(self, options: dict[str, bool]) -> None:
         """
         Overwrite BaseOption.set.
 

--- a/dataprofiler/profilers/text_column_profile.py
+++ b/dataprofiler/profilers/text_column_profile.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import itertools
-from typing import Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -22,7 +21,7 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
 
     type = "text"
 
-    def __init__(self, name: Optional[str], options: TextOptions = None) -> None:
+    def __init__(self, name: str | None, options: TextOptions = None) -> None:
         """
         Initialize column base properties and itself.
 
@@ -37,7 +36,7 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             )
         NumericStatsMixin.__init__(self, options)
         BaseColumnPrimitiveTypeProfiler.__init__(self, name)
-        self.vocab: List = list()
+        self.vocab: list = list()
         self.__calculations = {"vocab": TextColumn._update_vocab}
         self._filter_properties_w_options(self.__calculations, options)
 
@@ -67,7 +66,7 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
             merged_profile._update_vocab(other.vocab)
         return merged_profile
 
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """Report profile attribute of class; potentially pop val from self.profile."""
         calcs_dict_keys = self._TextColumn__calculations.keys()
         profile = self.profile
@@ -83,7 +82,7 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         return profile
 
     @property
-    def profile(self) -> Dict:
+    def profile(self) -> dict:
         """
         Return the profile of the column.
 
@@ -97,7 +96,7 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         profile.update(dict(vocab=self.vocab))
         return profile
 
-    def diff(self, other_profile: TextColumn, options: Dict = None) -> Dict:
+    def diff(self, other_profile: TextColumn, options: dict = None) -> dict:
         """
         Find the differences for text columns.
 
@@ -113,7 +112,7 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         return differences
 
     @property
-    def data_type_ratio(self) -> Optional[float]:
+    def data_type_ratio(self) -> float | None:
         """
         Calculate the ratio of samples which match this data type.
 
@@ -128,9 +127,9 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
     @BaseColumnProfiler._timeit(name="vocab")
     def _update_vocab(
         self,
-        data: Union[List, np.ndarray, pd.DataFrame],
-        prev_dependent_properties: Dict = None,
-        subset_properties: Dict = None,
+        data: list | np.ndarray | pd.DataFrame,
+        prev_dependent_properties: dict = None,
+        subset_properties: dict = None,
     ) -> None:
         """
         Find the unique vocabulary used in the text column.
@@ -148,7 +147,7 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):
         data_flat = list(itertools.chain(*data))
         self.vocab = utils._combine_unique_sets(self.vocab, data_flat)
 
-    def _update_helper(self, df_series_clean: pd.Series, profile: Dict) -> None:
+    def _update_helper(self, df_series_clean: pd.Series, profile: dict) -> None:
         """
         Update col profile properties with clean dataset and its known null parameters.
 

--- a/dataprofiler/profilers/unstructured_labeler_profile.py
+++ b/dataprofiler/profilers/unstructured_labeler_profile.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Dict, List, Optional
 
 from pandas import Series
 
@@ -14,7 +13,7 @@ from .base_column_profilers import BaseColumnProfiler
 from .profiler_options import DataLabelerOptions
 
 
-class UnstructuredLabelerProfile(object):
+class UnstructuredLabelerProfile:
     """Profiles and labels unstructured data."""
 
     type = "data_labeler"
@@ -47,12 +46,12 @@ class UnstructuredLabelerProfile(object):
                 load_options=None,
             )
 
-        self.entity_counts: Dict = dict(
+        self.entity_counts: dict = dict(
             word_level=defaultdict(int),
             true_char_level=defaultdict(int),
             postprocess_char_level=defaultdict(int),
         )
-        self.entity_percentages: Dict = dict(
+        self.entity_percentages: dict = dict(
             word_level=defaultdict(int),
             true_char_level=defaultdict(int),
             postprocess_char_level=defaultdict(int),
@@ -60,7 +59,7 @@ class UnstructuredLabelerProfile(object):
         self.char_sample_size: int = 0
         self.word_sample_size: int = 0
         self.separators = (" ", ",", ";", '"', ":", "\n", "\t", ".", "!", "'")
-        self.times: Dict = defaultdict(float)
+        self.times: dict = defaultdict(float)
 
     def __add__(self, other: UnstructuredLabelerProfile) -> UnstructuredLabelerProfile:
         """
@@ -101,7 +100,7 @@ class UnstructuredLabelerProfile(object):
 
         return merged_profile
 
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """
         Return profile object.
 
@@ -112,8 +111,8 @@ class UnstructuredLabelerProfile(object):
         return self.profile
 
     def diff(
-        self, other_profile: UnstructuredLabelerProfile, options: Dict = None
-    ) -> Dict:
+        self, other_profile: UnstructuredLabelerProfile, options: dict = None
+    ) -> dict:
         """
         Find the differences for two unstructured labeler profiles.
 
@@ -149,12 +148,12 @@ class UnstructuredLabelerProfile(object):
         return differences
 
     @property
-    def label_encoding(self) -> List[str]:
+    def label_encoding(self) -> list[str]:
         """Return list of labels."""
         return self.data_labeler.labels
 
     @BaseColumnProfiler._timeit(name="data_labeler_predict")
-    def _update_helper(self, df_series_clean: Series, profile: Dict) -> None:
+    def _update_helper(self, df_series_clean: Series, profile: dict) -> None:
         """
         Update col profile properties with clean dataset and its known profile.
 
@@ -198,7 +197,7 @@ class UnstructuredLabelerProfile(object):
         self._update_helper(df_series, profile)
 
     @property
-    def profile(self) -> Dict:
+    def profile(self) -> dict:
         """Return a profile."""
         profile = {
             "entity_counts": self.entity_counts,
@@ -207,7 +206,7 @@ class UnstructuredLabelerProfile(object):
         }
         return profile
 
-    def _update_column_base_properties(self, profile: Dict) -> None:
+    def _update_column_base_properties(self, profile: dict) -> None:
         """
         Update the base properties with the base schema.
 
@@ -217,7 +216,7 @@ class UnstructuredLabelerProfile(object):
         """
         self.metadata = profile
 
-    def _get_percentages(self, level: str) -> Optional[Dict]:
+    def _get_percentages(self, level: str) -> dict | None:
         """
         Create a sorted dictionary of each entity percentages.
 
@@ -258,7 +257,7 @@ class UnstructuredLabelerProfile(object):
             "postprocess_char_level"
         )
 
-    def _update_true_char_label_counts(self, predictions: List) -> None:
+    def _update_true_char_label_counts(self, predictions: list) -> None:
         """
         Update the true character label counts.
 
@@ -277,7 +276,7 @@ class UnstructuredLabelerProfile(object):
             self.char_sample_size += len(sample)
 
     def _update_postprocess_char_label_counts(
-        self, df_series_clean: Series, format_predictions: Dict
+        self, df_series_clean: Series, format_predictions: dict
     ) -> None:
         """
         Update the postprocess character label counts.
@@ -307,7 +306,7 @@ class UnstructuredLabelerProfile(object):
             char_label_counts["UNKNOWN"] += len(text) - index
 
     def _update_word_label_counts(
-        self, df_series_clean: Series, format_predictions: Dict
+        self, df_series_clean: Series, format_predictions: dict
     ) -> None:
         """
         Update the sorted dictionary of each entity count.

--- a/dataprofiler/profilers/unstructured_text_profile.py
+++ b/dataprofiler/profilers/unstructured_text_profile.py
@@ -5,7 +5,6 @@ import itertools
 import string
 import warnings
 from collections import Counter, defaultdict
-from typing import Dict, List, Optional, Union
 
 from numpy import ndarray
 from pandas import DataFrame, Series
@@ -14,14 +13,12 @@ from . import BaseColumnProfiler, utils
 from .profiler_options import TextProfilerOptions
 
 
-class TextProfiler(object):
+class TextProfiler:
     """Profiles text data."""
 
     type = "text"
 
-    def __init__(
-        self, name: Optional[str], options: TextProfilerOptions = None
-    ) -> None:
+    def __init__(self, name: str | None, options: TextProfilerOptions = None) -> None:
         """
         Initialize TextProfiler object.
 
@@ -30,12 +27,12 @@ class TextProfiler(object):
         :param options: Options for the Text Profiler
         :type options: TextProfilerOptions
         """
-        self.name: Optional[str] = name
+        self.name: str | None = name
         self.sample_size: int = 0
-        self.times: Dict = defaultdict(float)
+        self.times: dict = defaultdict(float)
         self.vocab_count: Counter = Counter()
         self.word_count: Counter = Counter()
-        self.metadata: Dict = dict()
+        self.metadata: dict = dict()
 
         # TODO: Add line length
         # self.line_length = {'max': None, 'min': None,...} #numeric stats mixin?
@@ -537,9 +534,7 @@ class TextProfiler(object):
         if self.name == other.name:
             merged_profile.name = self.name
         else:
-            raise ValueError(
-                "Text names unmatched: {} != {}".format(self.name, other.name)
-            )
+            raise ValueError(f"Text names unmatched: {self.name} != {other.name}")
 
         merged_profile.times = defaultdict(
             float,
@@ -582,7 +577,7 @@ class TextProfiler(object):
 
         return merged_profile
 
-    def diff(self, other_profile: TextProfiler, options: Dict = None) -> Dict:
+    def diff(self, other_profile: TextProfiler, options: dict = None) -> dict:
         """
         Find the differences for two unstructured text profiles.
 
@@ -613,7 +608,7 @@ class TextProfiler(object):
             other_words = [each_string.lower() for each_string in other_words]
             other_word_count = {k.lower(): v for k, v in other_word_count.items()}
 
-        diff: Dict = {}
+        diff: dict = {}
         diff["vocab"] = utils.find_diff_of_lists_and_sets(
             list(self.vocab_count.keys()), list(other_profile.vocab_count.keys())
         )
@@ -631,7 +626,7 @@ class TextProfiler(object):
 
         return diff
 
-    def report(self, remove_disabled_flag: bool = False) -> Dict:
+    def report(self, remove_disabled_flag: bool = False) -> dict:
         """Report profile attribute of class; potentially pop val from self.profile."""
         calcs_dict_keys = self._TextProfiler__calculations.keys()  # type: ignore
         profile = self.profile
@@ -650,7 +645,7 @@ class TextProfiler(object):
         return profile
 
     @property
-    def profile(self) -> Dict:
+    def profile(self) -> dict:
         """
         Return the profile of the column.
 
@@ -669,9 +664,9 @@ class TextProfiler(object):
     @BaseColumnProfiler._timeit(name="vocab")
     def _update_vocab(
         self,
-        data: Union[List, ndarray, DataFrame],
-        prev_dependent_properties: Dict = None,
-        subset_properties: Dict = None,
+        data: list | ndarray | DataFrame,
+        prev_dependent_properties: dict = None,
+        subset_properties: dict = None,
     ) -> None:
         """
         Find the vocabulary counts used in the text samples.
@@ -692,9 +687,9 @@ class TextProfiler(object):
     @BaseColumnProfiler._timeit(name="words")
     def _update_words(
         self,
-        data: Union[List, ndarray, DataFrame],
-        prev_dependent_properties: Dict = None,
-        subset_properties: Dict = None,
+        data: list | ndarray | DataFrame,
+        prev_dependent_properties: dict = None,
+        subset_properties: dict = None,
     ) -> None:
         """
         Find unique words and word count used in the text samples.
@@ -722,7 +717,7 @@ class TextProfiler(object):
             if w and w.lower() not in self._stop_words:
                 self.word_count.update({w: c})
 
-    def _update_helper(self, data: Series, profile: Dict) -> None:
+    def _update_helper(self, data: Series, profile: dict) -> None:
         """
         Update col profile properties with clean dataset and its known null parameters.
 

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -13,21 +13,7 @@ import warnings
 from abc import abstractmethod
 from itertools import islice
 from multiprocessing.pool import Pool
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generator,
-    Iterator,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
+from typing import Any, Callable, Dict, Generator, Iterator, TypeVar, cast, overload
 
 import numpy as np
 import psutil
@@ -38,7 +24,7 @@ from typing_extensions import Protocol
 from dataprofiler import profilers, settings
 
 
-def recursive_dict_update(d: Dict, update_d: Dict) -> Dict:
+def recursive_dict_update(d: dict, update_d: dict) -> dict:
     """
     Recursive updates nested dictionaries. Updating d with update_d.
 
@@ -70,7 +56,7 @@ class KeyDict(collections.defaultdict):
         return key
 
 
-def _combine_unique_sets(a: List, b: List) -> List:
+def _combine_unique_sets(a: list, b: list) -> list:
     """
     Unify two lists.
 
@@ -78,7 +64,7 @@ def _combine_unique_sets(a: List, b: List) -> List:
     :type b: list
     :rtype: list
     """
-    combined_list: Set = set()
+    combined_list: set = set()
     if not a and not b:
         combined_list = set()
     elif not a:
@@ -92,7 +78,7 @@ def _combine_unique_sets(a: List, b: List) -> List:
 
 def shuffle_in_chunks(
     data_length: int, chunk_size: int
-) -> Generator[List[int], None, Any]:
+) -> Generator[list[int], None, Any]:
     """
     Create shuffled indexes in chunks.
 
@@ -158,9 +144,9 @@ def warn_on_profile(col_profile: str, e: Exception) -> None:
     import warnings
 
     warning_msg = "\n\n!!! WARNING Partial Profiler Failure !!!\n\n"
-    warning_msg += "Profiling Type: {}".format(col_profile)
-    warning_msg += "\nException: {}".format(type(e).__name__)
-    warning_msg += "\nMessage: {}".format(e)
+    warning_msg += f"Profiling Type: {col_profile}"
+    warning_msg += f"\nException: {type(e).__name__}"
+    warning_msg += f"\nMessage: {e}"
     # This is considered a major error
     if type(e).__name__ == "ValueError":
         raise ValueError(e)
@@ -170,7 +156,7 @@ def warn_on_profile(col_profile: str, e: Exception) -> None:
     warnings.warn(warning_msg, RuntimeWarning, stacklevel=2)
 
 
-def partition(data: List, chunk_size: int) -> Generator[List, None, Any]:
+def partition(data: list, chunk_size: int) -> Generator[list, None, Any]:
     """
     Create a generator which returns data in specified chunk size.
 
@@ -183,7 +169,7 @@ def partition(data: List, chunk_size: int) -> Generator[List, None, Any]:
         yield data[idx : idx + chunk_size]
 
 
-def suggest_pool_size(data_size: int = None, cols: int = None) -> Optional[int]:
+def suggest_pool_size(data_size: int = None, cols: int = None) -> int | None:
     """
     Suggest the pool size based on resources.
 
@@ -224,7 +210,7 @@ def generate_pool(
     max_pool_size: int = None,
     data_size: int = None,
     cols: int = None,
-) -> Tuple[Optional[Pool], Optional[int]]:
+) -> tuple[Pool | None, int | None]:
     """
     Generate a multiprocessing pool to allocate functions too.
 
@@ -259,16 +245,14 @@ def generate_pool(
     return pool, max_pool_size
 
 
-def overlap(
-    x1: Union[int, Any], x2: Union[int, Any], y1: Union[int, Any], y2: Union[int, Any]
-) -> bool:
+def overlap(x1: int | Any, x2: int | Any, y1: int | Any, y2: int | Any) -> bool:
     """Return True iff [x1:x2] overlaps with [y1:y2]."""
     if not all(isinstance(i, int) for i in [x1, x2, y1, y2]):
         return False
     return (y1 <= x1 <= y2) or (y1 <= x2 <= y2) or (x1 <= y1 <= x2) or (x1 <= y2 <= x2)
 
 
-def add_nested_dictionaries(first_dict: Dict, second_dict: Dict) -> Dict:
+def add_nested_dictionaries(first_dict: dict, second_dict: dict) -> dict:
     """
     Merge two dictionaries together and add values together.
 
@@ -278,7 +262,7 @@ def add_nested_dictionaries(first_dict: Dict, second_dict: Dict) -> Dict:
     :type second_dict: dict
     :return: merged dictionary
     """
-    merged_dict: Dict = {}
+    merged_dict: dict = {}
     if isinstance(first_dict, collections.defaultdict):
         merged_dict = collections.defaultdict(first_dict.default_factory)
 
@@ -382,26 +366,22 @@ class Subtractable(Protocol):
     @abstractmethod
     def __eq__(self: object, other: object) -> bool:
         """Compare two objects."""
-        pass
 
     @abstractmethod
     def __sub__(self: T, other: T) -> Any:
         """Compare two subtractables."""
-        pass
 
 
 T = TypeVar("T", bound=Subtractable)
 
 
 @overload
-def find_diff_of_numbers(
-    stat1: Union[float, np.float64], stat2: Union[float, np.float64]
-) -> Any:
+def find_diff_of_numbers(stat1: float | np.float64, stat2: float | np.float64) -> Any:
     ...
 
 
 @overload
-def find_diff_of_numbers(stat1: Optional[T], stat2: Optional[T]) -> Any:
+def find_diff_of_numbers(stat1: T | None, stat2: T | None) -> Any:
     ...
 
 
@@ -428,8 +408,8 @@ def find_diff_of_numbers(stat1, stat2):
 
 
 def find_diff_of_strings_and_bools(
-    stat1: Union[str, bool, None], stat2: Union[str, bool, None]
-) -> Union[List[Union[str, bool, None]], str]:
+    stat1: str | bool | None, stat2: str | bool | None
+) -> list[str | bool | None] | str:
     """
     Find the difference between two stats.
 
@@ -448,8 +428,8 @@ def find_diff_of_strings_and_bools(
 
 
 def find_diff_of_lists_and_sets(
-    stat1: Union[List, Set, None], stat2: Union[List, Set, None]
-) -> Union[List[Union[List, Set, None]], str]:
+    stat1: list | set | None, stat2: list | set | None
+) -> list[list | set | None] | str:
     """
     Find the difference between two stats.
 
@@ -484,8 +464,8 @@ def find_diff_of_lists_and_sets(
 
 
 def find_diff_of_dates(
-    stat1: Optional[datetime.datetime], stat2: Optional[datetime.datetime]
-) -> Union[List, str, None]:
+    stat1: datetime.datetime | None, stat2: datetime.datetime | None
+) -> list | str | None:
     """
     Find the difference between two dates.
 
@@ -507,7 +487,7 @@ def find_diff_of_dates(
     """
     # We can use find_diff_of_numbers since datetime objects
     # can be compared and subtracted naturally
-    diff: Union[datetime.timedelta, List, str] = find_diff_of_numbers(stat1, stat2)
+    diff: datetime.timedelta | list | str = find_diff_of_numbers(stat1, stat2)
     if isinstance(diff, str):
         return diff
     if isinstance(diff, list):
@@ -519,9 +499,7 @@ def find_diff_of_dates(
     return "-" + str(abs(diff))
 
 
-def find_diff_of_dicts(
-    dict1: Optional[Dict], dict2: Optional[Dict]
-) -> Union[Dict, str]:
+def find_diff_of_dicts(dict1: dict | None, dict2: dict | None) -> dict | str:
     """
     Find the difference between two dicts.
 
@@ -540,7 +518,7 @@ def find_diff_of_dicts(
     dict1 = dict1 or {}
     dict2 = dict2 or {}
 
-    diff: Dict = {}
+    diff: dict = {}
     for key, value1 in dict1.items():
         value2 = dict2.get(key, None)
         if isinstance(value1, list):
@@ -567,8 +545,8 @@ def find_diff_of_dicts(
 
 
 def find_diff_of_matrices(
-    matrix1: Optional[np.ndarray], matrix2: Optional[np.ndarray]
-) -> Optional[Union[np.ndarray, str]]:
+    matrix1: np.ndarray | None, matrix2: np.ndarray | None
+) -> np.ndarray | str | None:
     """
     Find the difference between two matrices.
 
@@ -593,8 +571,8 @@ def find_diff_of_matrices(
 
 
 def find_diff_of_dicts_with_diff_keys(
-    dict1: Optional[Dict], dict2: Optional[Dict]
-) -> Union[List[Dict], str]:
+    dict1: dict | None, dict2: dict | None
+) -> list[dict] | str:
     """
     Find the difference between two dicts.
 
@@ -613,9 +591,9 @@ def find_diff_of_dicts_with_diff_keys(
     dict1 = dict1 or {}
     dict2 = dict2 or {}
 
-    diff_1: Dict = {}
-    diff_shared: Dict = {}
-    diff_2: Dict = {}
+    diff_1: dict = {}
+    diff_shared: dict = {}
+    diff_2: dict = {}
     for key, value1 in dict1.items():
         if key in dict2:
             value2 = dict2[key]
@@ -646,7 +624,7 @@ def find_diff_of_dicts_with_diff_keys(
     return diff
 
 
-def get_memory_size(data: Union[list, np.ndarray, DataFrame], unit: str = "M") -> float:
+def get_memory_size(data: list | np.ndarray | DataFrame, unit: str = "M") -> float:
     """
     Get memory size of the input data.
 
@@ -656,7 +634,7 @@ def get_memory_size(data: Union[list, np.ndarray, DataFrame], unit: str = "M") -
     :type unit: string
     :return: memory size of the input data
     """
-    unit_map: Dict = collections.defaultdict(B=0, K=1, M=2, G=3)
+    unit_map: dict = collections.defaultdict(B=0, K=1, M=2, G=3)
     if unit not in unit_map:
         raise ValueError(
             "Currently only supports the "
@@ -702,8 +680,8 @@ def method_timeit(method: Callable = None, name: str = None) -> Callable:
 
 
 def perform_chi_squared_test_for_homogeneity(
-    categories1: Dict, sample_size1: int, categories2: dict, sample_size2: int
-) -> Dict[str, Optional[Union[int, float]]]:
+    categories1: dict, sample_size1: int, categories2: dict, sample_size2: int
+) -> dict[str, int | float | None]:
     """
     Perform a Chi Squared test for homogeneity between two groups.
 
@@ -718,7 +696,7 @@ def perform_chi_squared_test_for_homogeneity(
     :return: Results of the chi squared test
     :rtype: dict
     """
-    results: Dict[str, Optional[Union[int, float]]] = {
+    results: dict[str, int | float | None] = {
         "chi2-statistic": None,
         "df": None,
         "p-value": None,
@@ -768,7 +746,7 @@ def perform_chi_squared_test_for_homogeneity(
     return results
 
 
-def chunk(lst: List, size: int) -> Iterator[Tuple]:
+def chunk(lst: list, size: int) -> Iterator[tuple]:
     """
     Chunk things out.
 
@@ -803,7 +781,7 @@ def merge(
 
 
 def merge_profile_list(
-    list_of_profiles: List[profilers.profile_builder.BaseProfiler],
+    list_of_profiles: list[profilers.profile_builder.BaseProfiler],
     pool_count: int = 5,
 ) -> profilers.profile_builder.BaseProfiler:
     """Merge list of profiles into a single profile.

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -366,10 +366,12 @@ class Subtractable(Protocol):
     @abstractmethod
     def __eq__(self: object, other: object) -> bool:
         """Compare two objects."""
+        pass
 
     @abstractmethod
     def __sub__(self: T, other: T) -> Any:
         """Compare two subtractables."""
+        pass
 
 
 T = TypeVar("T", bound=Subtractable)

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -13,13 +13,22 @@ import warnings
 from abc import abstractmethod
 from itertools import islice
 from multiprocessing.pool import Pool
-from typing import Any, Callable, Dict, Generator, Iterator, TypeVar, cast, overload
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    Iterator,
+    Protocol,
+    TypeVar,
+    cast,
+    overload,
+)
 
 import numpy as np
 import psutil
 import scipy
 from pandas import DataFrame, Series
-from typing_extensions import Protocol
 
 from dataprofiler import profilers, settings
 

--- a/dataprofiler/reports/graphs.py
+++ b/dataprofiler/reports/graphs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 import warnings
-from typing import TYPE_CHECKING, List, Optional, Union, cast
+from typing import TYPE_CHECKING, List, Union, cast
 
 if TYPE_CHECKING:
     from dataprofiler.profilers.float_column_profile import FloatColumn
@@ -33,8 +33,8 @@ from . import utils
 @utils.require_module(["matplotlib", "seaborn"])
 def plot_histograms(
     profiler: StructuredProfiler,
-    column_names: Optional[List[Union[int, str]]] = None,
-    column_inds: Optional[List[int]] = None,
+    column_names: list[int | str] | None = None,
+    column_inds: list[int] | None = None,
 ) -> matplotlib.pyplot.figure:
     """
     Plot the histograms of column names that are int or float columns.
@@ -148,9 +148,9 @@ def plot_histograms(
 
 @utils.require_module(["matplotlib", "seaborn"])
 def plot_col_histogram(
-    data_type_profiler: Union[IntColumn, FloatColumn],
-    ax: Optional[matplotlib.axes.Axes] = None,
-    title: Optional[str] = None,
+    data_type_profiler: IntColumn | FloatColumn,
+    ax: matplotlib.axes.Axes | None = None,
+    title: str | None = None,
 ) -> matplotlib.axes.Axes:
     """
     Take input of a Int or Float Column and plot the histogram.
@@ -187,8 +187,8 @@ def plot_col_histogram(
 @utils.require_module(["matplotlib", "seaborn"])
 def plot_missing_values_matrix(
     profiler: StructuredProfiler,
-    ax: Optional[matplotlib.axes.Axes] = None,
-    title: Optional[str] = None,
+    ax: matplotlib.axes.Axes | None = None,
+    title: str | None = None,
 ) -> matplotlib.pyplot.figure:
     """
     Generate matrix of bar graphs for missing value locations in cols of struct dataset.
@@ -210,9 +210,9 @@ def plot_missing_values_matrix(
 
 @utils.require_module(["matplotlib", "seaborn"])
 def plot_col_missing_values(
-    col_profiler_list: List[StructuredColProfiler],
-    ax: Optional[matplotlib.axes.Axes] = None,
-    title: Optional[str] = None,
+    col_profiler_list: list[StructuredColProfiler],
+    ax: matplotlib.axes.Axes | None = None,
+    title: str | None = None,
 ) -> matplotlib.pyplot.figure:
     """
     Generate bar graph of missing value locations within a col.

--- a/dataprofiler/reports/utils.py
+++ b/dataprofiler/reports/utils.py
@@ -17,8 +17,8 @@ def warn_missing_module(graph_func: str, module_name: str) -> None:
     :type module_name: str
     """
     warning_msg = "\n\n!!! WARNING Graphing Failure !!!\n\n"
-    warning_msg += "Graph Function: {}".format(graph_func)
-    warning_msg += "\nMissing Module: {}".format(module_name)
+    warning_msg += f"Graph Function: {graph_func}"
+    warning_msg += f"\nMissing Module: {module_name}"
     warning_msg += "\n\nFor report errors, try installing "
     warning_msg += "the extra reports requirements via:\n\n"
     warning_msg += "$ pip install dataprofiler[reports] --user\n\n"

--- a/dataprofiler/tests/data_readers/test_avro_data.py
+++ b/dataprofiler/tests/data_readers/test_avro_data.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import os
 import unittest
 from io import BytesIO

--- a/dataprofiler/tests/data_readers/test_base_data.py
+++ b/dataprofiler/tests/data_readers/test_base_data.py
@@ -1,11 +1,7 @@
-from __future__ import absolute_import, print_function
-
 import locale
 import os
-import sys
 import unittest
 from io import BytesIO, StringIO
-from unittest import mock
 
 from dataprofiler.data_readers.base_data import BaseData
 

--- a/dataprofiler/tests/data_readers/test_csv_data.py
+++ b/dataprofiler/tests/data_readers/test_csv_data.py
@@ -439,7 +439,7 @@ class TestCSVDataClass(unittest.TestCase):
         for input_file in cls.input_file_names:
             # add StringIO
             buffer_info = input_file.copy()
-            with open(input_file["path"], "r", encoding=input_file["encoding"]) as fp:
+            with open(input_file["path"], encoding=input_file["encoding"]) as fp:
                 buffer_info["path"] = StringIO(fp.read())
             cls.buffer_list.append(buffer_info)
 
@@ -560,7 +560,7 @@ class TestCSVDataClass(unittest.TestCase):
             "`header` must be one of following: auto, "
             "none for no header, or a non-negative "
             "integer for the row that represents the "
-            "header \(0 based index\)",
+            r"header \(0 based index\)",
         ):
             csv_data = CSVData(filename, options=options)
             first_value = csv_data.data.loc[0][0]
@@ -572,7 +572,7 @@ class TestCSVDataClass(unittest.TestCase):
             "`header` must be one of following: auto, "
             "none for no header, or a non-negative "
             "integer for the row that represents the "
-            "header \(0 based index\)",
+            r"header \(0 based index\)",
         ):
             csv_data = CSVData(filename, options=options)
             first_value = csv_data.data.loc[0][0]

--- a/dataprofiler/tests/data_readers/test_csv_graph_data.py
+++ b/dataprofiler/tests/data_readers/test_csv_graph_data.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from io import BytesIO, StringIO, TextIOWrapper
+from io import BytesIO, StringIO
 
 import networkx as nx
 
@@ -86,7 +86,7 @@ class TestGraphDataClass(unittest.TestCase):
         for input_file in cls.input_file_names_pos:
             # add StringIO
             buffer_info = input_file.copy()
-            with open(input_file["path"], "r", encoding=input_file["encoding"]) as fp:
+            with open(input_file["path"], encoding=input_file["encoding"]) as fp:
                 buffer_info["path"] = StringIO(fp.read())
             cls.buffer_list.append(buffer_info)
 

--- a/dataprofiler/tests/data_readers/test_filepath_or_buffer.py
+++ b/dataprofiler/tests/data_readers/test_filepath_or_buffer.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from io import BytesIO, StringIO, TextIOWrapper, open
+from io import BytesIO, StringIO, TextIOWrapper
 
 from dataprofiler.data_readers.filepath_or_buffer import FileOrBufferHandler
 
@@ -30,7 +30,7 @@ class TestFilepathOrBuffer(unittest.TestCase):
         for input_file in self.input_file_names:
             with FileOrBufferHandler(
                 input_file["path"], "r"
-            ) as filepath_or_buffer, open(input_file["path"], "r") as input_file_check:
+            ) as filepath_or_buffer, open(input_file["path"]) as input_file_check:
 
                 # check first 100 lines
                 for i in range(0, 100):
@@ -47,10 +47,10 @@ class TestFilepathOrBuffer(unittest.TestCase):
         to open()
         """
         for input_file in self.input_file_names:
-            with open(input_file["path"], "r") as fp:
+            with open(input_file["path"]) as fp:
                 stream = StringIO(fp.read())
             with FileOrBufferHandler(stream) as filepath_or_buffer, open(
-                input_file["path"], "r"
+                input_file["path"]
             ) as input_file_check:
 
                 # check first 100 lines
@@ -134,7 +134,7 @@ class TestFilepathOrBuffer(unittest.TestCase):
         with FileOrBufferHandler(
             file_name, "r", encoding=file_encoding
         ) as filepath_or_buffer, open(
-            file_name, "r", encoding=file_encoding
+            file_name, encoding=file_encoding
         ) as input_file_check:
 
             # check first 100 lines
@@ -157,7 +157,7 @@ class TestFilepathOrBuffer(unittest.TestCase):
         )
         with self.assertRaisesRegex(AttributeError, msg):
             with FileOrBufferHandler(file_name, "r") as filepath_or_buffer, open(
-                file_name, "r"
+                file_name
             ) as input_file_check:
                 filepath_or_buffer.readline(),
                 input_file_check.readline()

--- a/dataprofiler/tests/data_readers/test_json_data.py
+++ b/dataprofiler/tests/data_readers/test_json_data.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import os
 import unittest
 from io import BytesIO, StringIO
@@ -68,7 +66,7 @@ class TestJSONDataClass(unittest.TestCase):
         for input_file in cls.input_file_names:
             # add StringIO
             buffer_info = input_file.copy()
-            with open(input_file["path"], "r", encoding=input_file["encoding"]) as fp:
+            with open(input_file["path"], encoding=input_file["encoding"]) as fp:
                 buffer_info["path"] = StringIO(fp.read())
             cls.buffer_list.append(buffer_info)
 

--- a/dataprofiler/tests/data_readers/test_text_data.py
+++ b/dataprofiler/tests/data_readers/test_text_data.py
@@ -71,7 +71,7 @@ class TestTextDataClass(unittest.TestCase):
         for input_file in cls.input_file_names:
             # add StringIO
             buffer_info = input_file.copy()
-            with open(input_file["path"], "r", encoding=input_file["encoding"]) as fp:
+            with open(input_file["path"], encoding=input_file["encoding"]) as fp:
                 buffer_info["path"] = StringIO(fp.read())
             cls.buffer_list.append(buffer_info)
 

--- a/dataprofiler/tests/labelers/test_data_labelers.py
+++ b/dataprofiler/tests/labelers/test_data_labelers.py
@@ -428,7 +428,7 @@ class TestLoadedDataLabeler(unittest.TestCase):
         invalid_data = ["string", 1, None, dict()]
         print("\nInvalid Data Checks:")
         for data in invalid_data:
-            print("\tChecking data format: {}".format(str(type(data))))
+            print(f"\tChecking data format: {str(type(data))}")
             _invalid_check(data)
 
             # cannot predict dict
@@ -440,7 +440,7 @@ class TestLoadedDataLabeler(unittest.TestCase):
     def test_valid_fit_data_formats(self, mock_open, mock_load_model):
         def _valid_check(data):
             try:
-                print("\tChecking data format: {}".format(str(type(data))))
+                print(f"\tChecking data format: {str(type(data))}")
                 data = BaseDataLabeler._check_and_return_valid_data_format(
                     data, fit_or_predict="fit"
                 )
@@ -465,7 +465,7 @@ class TestLoadedDataLabeler(unittest.TestCase):
     def test_valid_predict_data_formats(self, mock_open, mock_load_model):
         def _valid_check(data):
             try:
-                print("\tChecking data format: {}".format(str(type(data))))
+                print(f"\tChecking data format: {str(type(data))}")
                 data = BaseDataLabeler._check_and_return_valid_data_format(
                     data, fit_or_predict="predict"
                 )

--- a/dataprofiler/tests/labelers/test_data_processing.py
+++ b/dataprofiler/tests/labelers/test_data_processing.py
@@ -4,7 +4,6 @@ import random
 import re
 import unittest
 from io import StringIO
-from typing import OrderedDict
 from unittest import mock
 
 import numpy as np
@@ -2995,7 +2994,7 @@ class TestColumnNameModelPostprocessor(unittest.TestCase):
 
         # assert parameters saved
         mock_open.assert_called_with("test/test_parameters.json", "w")
-        self.assertEquals(json.dumps(test_parameters), mock_file.getvalue())
+        self.assertEqual(json.dumps(test_parameters), mock_file.getvalue())
 
         # close mocks
         StringIO.close(mock_file)

--- a/dataprofiler/tests/labelers/test_integration_column_name_data_labeler.py
+++ b/dataprofiler/tests/labelers/test_integration_column_name_data_labeler.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 
 import numpy as np

--- a/dataprofiler/tests/labelers/test_regex_model.py
+++ b/dataprofiler/tests/labelers/test_regex_model.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import unittest
 from io import StringIO

--- a/dataprofiler/tests/labelers/test_unstructured_data_labeler.py
+++ b/dataprofiler/tests/labelers/test_unstructured_data_labeler.py
@@ -277,7 +277,7 @@ class TestDataLabeler(unittest.TestCase):
         invalid_data = ["string", 1, None, dict()]
         print("\nInvalid Data Checks:")
         for data in invalid_data:
-            print("\tChecking data format: {}".format(str(type(data))))
+            print(f"\tChecking data format: {str(type(data))}")
             _invalid_check(data)
 
         # cannot predict dict
@@ -289,7 +289,7 @@ class TestDataLabeler(unittest.TestCase):
     def test_valid_fit_data_formats(self, *mocks):
         def _valid_check(data):
             try:
-                print("\tChecking data format: {}".format(str(type(data))))
+                print(f"\tChecking data format: {str(type(data))}")
                 data = UnstructuredDataLabeler._check_and_return_valid_data_format(
                     data, fit_or_predict="fit"
                 )
@@ -314,7 +314,7 @@ class TestDataLabeler(unittest.TestCase):
     def test_valid_predict_data_formats(self, *mocks):
         def _valid_check(data):
             try:
-                print("\tChecking data format: {}".format(str(type(data))))
+                print(f"\tChecking data format: {str(type(data))}")
                 data = UnstructuredDataLabeler._check_and_return_valid_data_format(
                     data, fit_or_predict="predict"
                 )

--- a/dataprofiler/tests/profilers/profiler_options/test_base_inspector_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_base_inspector_options.py
@@ -41,7 +41,7 @@ class TestBaseInspectorOptions(TestBooleanOption):
         self.assertFalse(options.is_prop_enabled("is_enabled"))
 
         # Check is prop enabled for invalid property
-        expected_error = 'Property "Hello World" does not exist in {}.'.format(optpth)
+        expected_error = f'Property "Hello World" does not exist in {optpth}.'
         with self.assertRaisesRegex(AttributeError, expected_error):
             options.is_prop_enabled("Hello World")
 

--- a/dataprofiler/tests/profilers/profiler_options/test_boolean_option.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_boolean_option.py
@@ -57,7 +57,7 @@ class TestBooleanOption(TestBaseOption):
 
         # Option is_enabled is not a boolean
         option = self.get_options(is_enabled="Hello World")
-        expected_error = ["{}.is_enabled must be a Boolean.".format(optpth)]
+        expected_error = [f"{optpth}.is_enabled must be a Boolean."]
         self.assertSetEqual(set(expected_error), set(option._validate_helper()))
 
     def test_validate(self):
@@ -69,7 +69,7 @@ class TestBooleanOption(TestBaseOption):
 
         # Option is_enabled is not a boolean
         option = self.get_options(is_enabled="Hello World")
-        expected_error = "{}.is_enabled must be a Boolean.".format(optpth)
+        expected_error = f"{optpth}.is_enabled must be a Boolean."
         with self.assertRaisesRegex(ValueError, expected_error):
             option.validate(raise_error=True)
 

--- a/dataprofiler/tests/profilers/profiler_options/test_datalabeler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_datalabeler_options.py
@@ -52,18 +52,18 @@ class TestDataLabelerOptions(TestBaseInspectorOptions):
         # Test invalid dirpath
         options = self.get_options()
         options.set({"data_labeler_dirpath": 0})
-        expected_error = "{}.data_labeler_dirpath must be a string.".format(optpth)
+        expected_error = f"{optpth}.data_labeler_dirpath must be a string."
         self.assertEqual([expected_error], options._validate_helper())
 
         # Test invalid sample size
         options = self.get_options()
         options.set({"max_sample_size": ""})
-        expected_error = "{}.max_sample_size must be an integer.".format(optpth)
+        expected_error = f"{optpth}.max_sample_size must be an integer."
         self.assertEqual([expected_error], options._validate_helper())
 
         # Test max sample size less than or equal to 0
         options = self.get_options()
-        expected_error = "{}.max_sample_size must be greater than 0.".format(optpth)
+        expected_error = f"{optpth}.max_sample_size must be greater than 0."
         options.set({"max_sample_size": 0})
         self.assertEqual([expected_error], options._validate_helper())
         options.set({"max_sample_size": -1})
@@ -102,7 +102,7 @@ class TestDataLabelerOptions(TestBaseInspectorOptions):
         # Test invalid dirpath
         options = self.get_options()
         options.set({"data_labeler_dirpath": 0})
-        expected_error = "{}.data_labeler_dirpath must be a string.".format(optpth)
+        expected_error = f"{optpth}.data_labeler_dirpath must be a string."
         self.assertEqual([expected_error], options.validate(raise_error=False))
         with self.assertRaisesRegex(ValueError, expected_error):
             options.validate(raise_error=True)
@@ -110,14 +110,14 @@ class TestDataLabelerOptions(TestBaseInspectorOptions):
         # Test invalid sample size
         options = self.get_options()
         options.set({"max_sample_size": ""})
-        expected_error = "{}.max_sample_size must be an integer.".format(optpth)
+        expected_error = f"{optpth}.max_sample_size must be an integer."
         self.assertEqual([expected_error], options.validate(raise_error=False))
         with self.assertRaisesRegex(ValueError, expected_error):
             options.validate(raise_error=True)
 
         # Test max sample size less than or equal to 0
         options = self.get_options()
-        expected_error = "{}.max_sample_size must be greater than 0.".format(optpth)
+        expected_error = f"{optpth}.max_sample_size must be greater than 0."
         options.set({"max_sample_size": 0})
         self.assertEqual([expected_error], options.validate(raise_error=False))
         with self.assertRaisesRegex(ValueError, expected_error):

--- a/dataprofiler/tests/profilers/profiler_options/test_histogram_option.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_histogram_option.py
@@ -1,5 +1,3 @@
-import re
-
 from dataprofiler.profilers.profiler_options import HistogramOption
 
 from .test_boolean_option import TestBooleanOption
@@ -71,11 +69,11 @@ class TestHistogramOption(TestBooleanOption):
             option.set({"bin_count_or_method.is_enabled": True})
 
     def test_validate_helper(self):
-        super(TestHistogramOption, self).test_validate_helper()
+        super().test_validate_helper()
 
     def test_validate(self):
 
-        super(TestHistogramOption, self).test_validate()
+        super().test_validate()
 
         params_to_check = [
             # non errors
@@ -143,12 +141,12 @@ class TestHistogramOption(TestBooleanOption):
                     self.assertListEqual(
                         expected_errors,
                         validate_errors,
-                        msg="Errored for prop: {}, value: {}.".format(prop, value),
+                        msg=f"Errored for prop: {prop}, value: {value}.",
                     )
                 else:
                     self.assertIsNone(
                         validate_errors,
-                        msg="Errored for prop: {}, value: {}.".format(prop, value),
+                        msg=f"Errored for prop: {prop}, value: {value}.",
                     )
 
         # this time testing raising an error

--- a/dataprofiler/tests/profilers/profiler_options/test_numerical_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_numerical_options.py
@@ -48,7 +48,7 @@ class TestNumericalOptions(TestBaseInspectorOptions):
 
         # Enable and Disable Options
         for key in self.keys:
-            skey = "{}.is_enabled".format(key)
+            skey = f"{key}.is_enabled"
             for enabled in [True, False]:
                 options._set_helper({skey: enabled}, "")
                 self.assertEqual(enabled, options.properties[key].is_enabled)
@@ -59,7 +59,7 @@ class TestNumericalOptions(TestBaseInspectorOptions):
 
         # Enable and Disable Options
         for key in self.keys:
-            skey = "{}.is_enabled".format(key)
+            skey = f"{key}.is_enabled"
             for enabled in [True, False]:
                 options.set({skey: enabled})
                 self.assertEqual(enabled, options.properties[key].is_enabled)
@@ -71,8 +71,8 @@ class TestNumericalOptions(TestBaseInspectorOptions):
 
         # Set BooleanOptions' is_enabled to a non-boolean value
         for key in self.keys:
-            skey = "{}.is_enabled".format(key)
-            expected_error = "{}.{}.is_enabled must be a Boolean.".format(optpth, key)
+            skey = f"{key}.is_enabled"
+            expected_error = f"{optpth}.{key}.is_enabled must be a Boolean."
             default_bool = options.properties[key].is_enabled
             options.set({skey: "Hello World"})
             self.assertIn(expected_error, options._validate_helper())
@@ -207,8 +207,8 @@ class TestNumericalOptions(TestBaseInspectorOptions):
 
         # Set BooleanOptions' is_enabled to a non-boolean value
         for key in self.keys:
-            skey = "{}.is_enabled".format(key)
-            expected_error = "{}.{}.is_enabled must be a Boolean.".format(optpth, key)
+            skey = f"{key}.is_enabled"
+            expected_error = f"{optpth}.{key}.is_enabled must be a Boolean."
             default_bool = options.properties[key].is_enabled
             options.set({skey: "Hello World"})
             with self.assertRaisesRegex(ValueError, expected_error):
@@ -335,12 +335,12 @@ class TestNumericalOptions(TestBaseInspectorOptions):
         options = self.get_options()
 
         # Disable All Numeric Stats
-        options.set({"{}.is_enabled".format(key): False for key in self.numeric_keys})
+        options.set({f"{key}.is_enabled": False for key in self.numeric_keys})
         self.assertFalse(options.is_numeric_stats_enabled)
 
         # Enable Only One Numeric Stat
         for key in self.numeric_keys:
-            skey = "{}.is_enabled".format(key)
+            skey = f"{key}.is_enabled"
             options.set({skey: True})
             self.assertTrue(options.is_numeric_stats_enabled)
             options.set({skey: False})

--- a/dataprofiler/tests/profilers/profiler_options/test_precision_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_precision_options.py
@@ -52,21 +52,17 @@ class TestPrecisionOptions(TestBooleanOption):
 
         # Option sample_ratio cannot be a string, must be a float
         option = self.get_options(sample_ratio="Hello World")
-        expected_error = ["{}.sample_ratio must be a float.".format(optpth)]
+        expected_error = [f"{optpth}.sample_ratio must be a float."]
         self.assertSetEqual(set(expected_error), set(option._validate_helper()))
 
         # Option sample_ratio must be between 0 and 1
         option = self.get_options(sample_ratio=1.1)
-        expected_error = [
-            "{}.sample_ratio must be a float between 0 and 1.".format(optpth)
-        ]
+        expected_error = [f"{optpth}.sample_ratio must be a float between 0 and 1."]
         self.assertSetEqual(set(expected_error), set(option._validate_helper()))
 
         # Option sample_ratio must be between 0 and 1
         option = self.get_options(sample_ratio=-0.1)
-        expected_error = [
-            "{}.sample_ratio must be a float between 0 and 1.".format(optpth)
-        ]
+        expected_error = [f"{optpth}.sample_ratio must be a float between 0 and 1."]
         self.assertSetEqual(set(expected_error), set(option._validate_helper()))
 
     def test_validate(self):

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_class_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_class_options.py
@@ -77,7 +77,7 @@ class TestProfilerOptions(TestBaseOption):
                 "has no attribute 'is_enabled'".format(key)
             )
             with self.assertRaisesRegex(AttributeError, expected_error):
-                option.set({"{}.text.is_enabled.is_enabled".format(key): True})
+                option.set({f"{key}.text.is_enabled.is_enabled": True})
 
     def test_validate_helper(self):
         # Valid cases should return [] while invalid cases
@@ -95,7 +95,7 @@ class TestProfilerOptions(TestBaseOption):
 
         # Option is_enabled is not a boolean
         for key in self.keys:
-            option.set({"{}.text.is_enabled".format(key): "Hello World"})
+            option.set({f"{key}.text.is_enabled": "Hello World"})
         expected_error = [
             "{}.{}.text.is_enabled must be a " "Boolean.".format(optpth, key)
             for key in self.keys
@@ -112,8 +112,8 @@ class TestProfilerOptions(TestBaseOption):
         option.structured_options = ProfilerOptions()
         option.unstructured_options = ProfilerOptions()
         expected_error = [
-            "{}.structured_options must be a StructuredOptions.".format(optpth),
-            "{}.unstructured_options must be an UnstructuredOptions.".format(optpth),
+            f"{optpth}.structured_options must be a StructuredOptions.",
+            f"{optpth}.unstructured_options must be an UnstructuredOptions.",
         ]
         self.assertEqual(expected_error, option._validate_helper())
 
@@ -128,7 +128,7 @@ class TestProfilerOptions(TestBaseOption):
 
         # Option is_enabled is not a boolean
         for key in self.keys:
-            option.set({"{}.text.is_enabled".format(key): "Hello World"})
+            option.set({f"{key}.text.is_enabled": "Hello World"})
         expected_error = [
             "{}.{}.text.is_enabled must be a " "Boolean.".format(optpth, key)
             for key in self.keys
@@ -150,8 +150,8 @@ class TestProfilerOptions(TestBaseOption):
         option.structured_options = ProfilerOptions()
         option.unstructured_options = ProfilerOptions()
         expected_error = [
-            "{}.structured_options must be a StructuredOptions.".format(optpth),
-            "{}.unstructured_options must be an UnstructuredOptions.".format(optpth),
+            f"{optpth}.structured_options must be a StructuredOptions.",
+            f"{optpth}.unstructured_options must be an UnstructuredOptions.",
         ]
         with self.assertRaisesRegex(ValueError, "\n".join(expected_error)):
             option.validate()

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from unittest import mock
 

--- a/dataprofiler/tests/profilers/profiler_options/test_structured_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_structured_options.py
@@ -41,9 +41,9 @@ class TestStructuredOptions(TestBaseOption):
         optpth = self.get_options_path()
         # Enable and Disable Option
         for key in self.boolean_keys:
-            option._set_helper({"{}.is_enabled".format(key): False}, "")
+            option._set_helper({f"{key}.is_enabled": False}, "")
             self.assertFalse(option.properties[key].is_enabled)
-            option._set_helper({"{}.is_enabled".format(key): True}, "")
+            option._set_helper({f"{key}.is_enabled": True}, "")
             self.assertTrue(option.properties[key].is_enabled)
 
         # Treat is_enabled as a BooleanOption
@@ -53,7 +53,7 @@ class TestStructuredOptions(TestBaseOption):
                 "'is_enabled'".format(key)
             )
             with self.assertRaisesRegex(AttributeError, expected_error):
-                option._set_helper({"{}.is_enabled.is_enabled".format(key): True}, "")
+                option._set_helper({f"{key}.is_enabled.is_enabled": True}, "")
 
     def test_set(self):
         super().test_set()
@@ -62,9 +62,9 @@ class TestStructuredOptions(TestBaseOption):
 
         # Enable and Disable Options
         for key in self.boolean_keys:
-            option.set({"{}.is_enabled".format(key): False})
+            option.set({f"{key}.is_enabled": False})
             self.assertFalse(option.properties[key].is_enabled)
-            option.set({"{}.is_enabled".format(key): True})
+            option.set({f"{key}.is_enabled": True})
             self.assertTrue(option.properties[key].is_enabled)
 
         # Treat is_enabled as a BooleanOption
@@ -74,14 +74,14 @@ class TestStructuredOptions(TestBaseOption):
                 "'is_enabled'".format(key)
             )
             with self.assertRaisesRegex(AttributeError, expected_error):
-                option.set({"{}.is_enabled.is_enabled".format(key): True})
+                option.set({f"{key}.is_enabled.is_enabled": True})
 
         for key in self.other_keys:
             expected_error = "type object '{}' has no attribute " "'is_enabled'".format(
                 key
             )
             with self.assertRaisesRegex(AttributeError, expected_error):
-                option.set({"{}.is_enabled".format(key): True})
+                option.set({f"{key}.is_enabled": True})
 
         for test_dict in ({"a": 0}, {"a": re.IGNORECASE}, None):
             option.set({"null_values": test_dict})
@@ -115,10 +115,9 @@ class TestStructuredOptions(TestBaseOption):
 
         # Option is_enabled is not a boolean
         for key in self.boolean_keys:
-            option.set({"{}.is_enabled".format(key): "Hello World"})
+            option.set({f"{key}.is_enabled": "Hello World"})
         expected_error = [
-            "{}.{}.is_enabled must be a Boolean.".format(optpth, key)
-            for key in self.boolean_keys
+            f"{optpth}.{key}.is_enabled must be a Boolean." for key in self.boolean_keys
         ]
         expected_error = set(expected_error)
         # Verify expected errors are a subset of all errors
@@ -149,13 +148,9 @@ class TestStructuredOptions(TestBaseOption):
             elif key == "datetime":
                 ckey = "DateTime"
             if key == "multiprocess" or key == "chi2_homogeneity":
-                expected_error.add(
-                    "{}.{} must be a(n) BooleanOption.".format(optpth, key, ckey)
-                )
+                expected_error.add(f"{optpth}.{key} must be a(n) BooleanOption.")
             else:
-                expected_error.add(
-                    "{}.{} must be a(n) {}Options.".format(optpth, key, ckey)
-                )
+                expected_error.add(f"{optpth}.{key} must be a(n) {ckey}Options.")
         self.assertSetEqual(expected_error, set(option._validate_helper()))
 
     def test_validate(self):
@@ -178,11 +173,10 @@ class TestStructuredOptions(TestBaseOption):
 
         # Option is_enabled is not a boolean
         for key in self.boolean_keys:
-            option.set({"{}.is_enabled".format(key): "Hello World"})
+            option.set({f"{key}.is_enabled": "Hello World"})
 
         expected_error = [
-            "{}.{}.is_enabled must be a Boolean.".format(optpth, key)
-            for key in self.boolean_keys
+            f"{optpth}.{key}.is_enabled must be a Boolean." for key in self.boolean_keys
         ]
         expected_error = set(expected_error)
         # Verify expected errors are a subset of all errors
@@ -218,13 +212,9 @@ class TestStructuredOptions(TestBaseOption):
             elif key == "datetime":
                 ckey = "DateTime"
             if key == "multiprocess" or key == "chi2_homogeneity":
-                expected_error.add(
-                    "{}.{} must be a(n) BooleanOption.".format(optpth, key, ckey)
-                )
+                expected_error.add(f"{optpth}.{key} must be a(n) BooleanOption.")
             else:
-                expected_error.add(
-                    "{}.{} must be a(n) {}Options.".format(optpth, key, ckey)
-                )
+                expected_error.add(f"{optpth}.{key} must be a(n) {ckey}Options.")
         # Verify expected errors are a subset of all errors
         self.assertSetEqual(expected_error, set(option.validate(raise_error=False)))
         with self.assertRaises(ValueError) as cm:
@@ -293,19 +283,19 @@ class TestStructuredOptions(TestBaseOption):
 
         # All Columns Enabled
         for key in self.boolean_keys:
-            options.set({"{}.is_enabled".format(key): True})
+            options.set({f"{key}.is_enabled": True})
         self.assertSetEqual(set(self.boolean_keys), set(options.enabled_profiles))
 
         # No Columns Enabled
         for key in self.boolean_keys:
-            options.set({"{}.is_enabled".format(key): False})
+            options.set({f"{key}.is_enabled": False})
         self.assertEqual([], options.enabled_profiles)
 
         # One Column Enabled
         for key in self.boolean_keys:
-            options.set({"{}.is_enabled".format(key): True})
-            self.assertSetEqual(set([key]), set(options.enabled_profiles))
-            options.set({"{}.is_enabled".format(key): False})
+            options.set({f"{key}.is_enabled": True})
+            self.assertSetEqual({key}, set(options.enabled_profiles))
+            options.set({f"{key}.is_enabled": False})
 
     def test_eq(self):
         super().test_eq()

--- a/dataprofiler/tests/profilers/profiler_options/test_text_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_text_options.py
@@ -28,7 +28,7 @@ class TestTextOptions(TestNumericalOptions):
 
         # Check to make sure num_zeros/num_negatives is False as a TextOption
         for key in ["num_zeros", "num_negatives"]:
-            skey = "{}.is_enabled".format(key)
+            skey = f"{key}.is_enabled"
             expected_error = (
                 "{}.{} should always be disabled, "
                 "{}.is_enabled = False".format(optpth, key, key)
@@ -48,7 +48,7 @@ class TestTextOptions(TestNumericalOptions):
 
         # Disable All Numeric Stats but cheeck num_zeros and num_negatives
         # will not affect is_numeric_stats_enabled
-        options.set({"{}.is_enabled".format(key): False for key in self.numeric_keys})
+        options.set({f"{key}.is_enabled": False for key in self.numeric_keys})
         options.set({"num_zeros.is_enabled": True})
         self.assertFalse(options.is_numeric_stats_enabled)
         options.set({"num_negatives.is_enabled": True})

--- a/dataprofiler/tests/profilers/profiler_options/test_unstructured_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_unstructured_options.py
@@ -54,9 +54,9 @@ class TestUnstructuredOptions(TestBaseOption):
 
         # Enable and Disable Options
         for key in self.keys:
-            option.set({"{}.is_enabled".format(key): False})
+            option.set({f"{key}.is_enabled": False})
             self.assertFalse(option.properties[key].is_enabled)
-            option.set({"{}.is_enabled".format(key): True})
+            option.set({f"{key}.is_enabled": True})
             self.assertTrue(option.properties[key].is_enabled)
 
         # Set text options

--- a/dataprofiler/tests/profilers/profiler_options/test_unstructured_text_profile_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_unstructured_text_profile_options.py
@@ -79,7 +79,7 @@ class TestTextProfilerOptions(TestBaseInspectorOptions):
                 option.set({prop: value})
                 self.assertEqual(value, getattr(option, prop), msg=prop)
             else:
-                prop_enable = "{}.is_enabled".format(prop)
+                prop_enable = f"{prop}.is_enabled"
                 option.set({prop_enable: value})
                 self.assertEqual(value, option.properties[prop].is_enabled, msg=prop)
 
@@ -120,11 +120,11 @@ class TestTextProfilerOptions(TestBaseInspectorOptions):
             option.set({"vocab.is_enabled.other_props": True})
 
     def test_validate_helper(self):
-        super(TestTextProfilerOptions, self).test_validate_helper()
+        super().test_validate_helper()
 
     def test_validate(self):
 
-        super(TestTextProfilerOptions, self).test_validate()
+        super().test_validate()
 
         params_to_check = [
             # non errors
@@ -213,12 +213,12 @@ class TestTextProfilerOptions(TestBaseInspectorOptions):
                     self.assertListEqual(
                         expected_errors,
                         validate_errors,
-                        msg="Errored for prop: {}, value: {}.".format(prop, value),
+                        msg=f"Errored for prop: {prop}, value: {value}.",
                     )
                 else:
                     self.assertIsNone(
                         validate_errors,
-                        msg="Errored for prop: {}, value: {}.".format(prop, value),
+                        msg=f"Errored for prop: {prop}, value: {value}.",
                     )
 
         # this time testing raising an error

--- a/dataprofiler/tests/profilers/test_base_column_profilers.py
+++ b/dataprofiler/tests/profilers/test_base_column_profilers.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import unittest
 from unittest.mock import MagicMock, patch
@@ -100,7 +98,7 @@ class TestBaseColumnProfileClass(unittest.TestCase):
 
         self.assertEqual(
             str(exc.exception),
-            "Column names unmatched: {} != {}".format(profile1.name, profile2.name),
+            f"Column names unmatched: {profile1.name} != {profile2.name}",
         )
 
     def test_time_it(self):
@@ -165,7 +163,7 @@ class TestBaseColumnPrimitiveTypeProfileClass(unittest.TestCase):
         a = [1, 2, 3]
         b = [3, 1, 4, -1]
         c = utils._combine_unique_sets(a, b)
-        six.assertCountEqual(self, [1, 2, 3, 4, -1], c)
+        self.assertCountEqual([1, 2, 3, 4, -1], c)
 
     def test__init__(self):
         self.assertEqual(0, self.b_profile.name)
@@ -184,8 +182,7 @@ class TestBaseColumnPrimitiveTypeProfileClass(unittest.TestCase):
         self.assertDictEqual(metadata, self.b_profile.metadata)
 
     def test_update_match_are_abstract(self):
-        six.assertCountEqual(
-            self,
+        self.assertCountEqual(
             {"_update_helper", "update", "report", "profile"},
             BaseColumnPrimitiveTypeProfiler.__abstractmethods__,
         )
@@ -229,7 +226,7 @@ def get_object_path(obj):
     return ".".join(["data_profiler.profilers.profile_builder", obj.__name__])
 
 
-class AbstractTestColumnProfiler(object):
+class AbstractTestColumnProfiler:
 
     column_profiler = None
 
@@ -309,5 +306,5 @@ class AbstractTestColumnProfiler(object):
         profile = self.column_profiler(self.aws_dataset["datetime"])
         report = profile.profile
 
-        six.assertCountEqual(self, self.profile_types, report.keys())
+        self.assertCountEqual(self.profile_types, report.keys())
         self._delete_profiler_mocks()

--- a/dataprofiler/tests/profilers/test_categorical_column_profile.py
+++ b/dataprofiler/tests/profilers/test_categorical_column_profile.py
@@ -46,7 +46,7 @@ class TestCategoricalColumn(unittest.TestCase):
             "groucho-eu",
             "groucho-sydney",
         }
-        six.assertCountEqual(self, categories, profile.categories)
+        self.assertCountEqual(categories, profile.categories)
 
     def test_timeit_profile(self):
         dataset = self.aws_dataset["host"].dropna()
@@ -228,7 +228,7 @@ class TestCategoricalColumn(unittest.TestCase):
         }
 
         self.assertEqual(2120, profile.sample_size)
-        six.assertCountEqual(self, categories, profile.categories)
+        self.assertCountEqual(categories, profile.categories)
 
     def test_categorical_mapping(self):
 
@@ -279,8 +279,8 @@ class TestCategoricalColumn(unittest.TestCase):
         num_null_types = 1
         num_nan_count = 1
         categories = df1.apply(str).unique().tolist()
-        six.assertCountEqual(
-            self, categories, cat_profiler.categories + column_profile.null_types
+        self.assertCountEqual(
+            categories, cat_profiler.categories + column_profile.null_types
         )
         self.assertEqual(num_null_types, len(column_profile.null_types))
         self.assertEqual(num_nan_count, len(column_profile.null_types_index["nan"]))
@@ -293,8 +293,8 @@ class TestCategoricalColumn(unittest.TestCase):
         cat_profiler = column_profile.profiles["data_stats_profile"]._profiles[
             "category"
         ]
-        six.assertCountEqual(
-            self, categories, cat_profiler.categories + column_profile.null_types
+        self.assertCountEqual(
+            categories, cat_profiler.categories + column_profile.null_types
         )
         self.assertEqual(num_null_types, len(column_profile.null_types))
         self.assertEqual(num_nan_count, len(column_profile.null_types_index["nan"]))
@@ -320,8 +320,8 @@ class TestCategoricalColumn(unittest.TestCase):
         cat_profiler = column_profile.profiles["data_stats_profile"]._profiles[
             "category"
         ]
-        six.assertCountEqual(
-            self, categories, cat_profiler.categories + column_profile.null_types
+        self.assertCountEqual(
+            categories, cat_profiler.categories + column_profile.null_types
         )
         self.assertEqual(num_null_types, len(column_profile.null_types))
         self.assertEqual(num_nan_count, len(column_profile.null_types_index["nan"]))

--- a/dataprofiler/tests/profilers/test_column_profile_compilers.py
+++ b/dataprofiler/tests/profilers/test_column_profile_compilers.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 from unittest import mock
 
@@ -444,8 +442,8 @@ class TestBaseProfileCompilerClass(unittest.TestCase):
             col_pro_compilers.BaseCompiler()
 
     def test_update_match_are_abstract(self):
-        six.assertCountEqual(
-            self, {"report"}, col_pro_compilers.BaseCompiler.__abstractmethods__
+        self.assertCountEqual(
+            {"report"}, col_pro_compilers.BaseCompiler.__abstractmethods__
         )
 
 

--- a/dataprofiler/tests/profilers/test_data_labeler_column_profile.py
+++ b/dataprofiler/tests/profilers/test_data_labeler_column_profile.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 from collections import defaultdict
 from unittest import mock
@@ -50,8 +48,7 @@ class TestDataLabelerColumnProfiler(unittest.TestCase):
             self.assertEqual(["a", "b"], profiler.possible_data_labels)
             self.assertEqual(None, profiler.data_label)
             self.assertEqual(None, profiler.avg_predictions)
-            six.assertCountEqual(
-                self,
+            self.assertCountEqual(
                 ["data_label", "avg_predictions", "data_label_representation", "times"],
                 list(profiler.profile.keys()),
             )

--- a/dataprofiler/tests/profilers/test_datatype_column_profiler.py
+++ b/dataprofiler/tests/profilers/test_datatype_column_profiler.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import unittest
 
@@ -22,7 +20,7 @@ class TestColumnDataTypeProfiler(AbstractTestColumnProfiler, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestColumnDataTypeProfiler, cls).setUpClass()
+        super().setUpClass()
 
 
 if __name__ == "__main__":

--- a/dataprofiler/tests/profilers/test_datetime_column_profile.py
+++ b/dataprofiler/tests/profilers/test_datetime_column_profile.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import datetime
 import unittest
 import warnings
@@ -103,16 +101,16 @@ class TestDateTimeColumnProfiler(unittest.TestCase):
         datetime_profile = DateTimeColumn(df_all.name)
         datetime_profile.update(df_all)
 
-        six.assertCountEqual(self, date_formats_all, set(datetime_profile.date_formats))
+        self.assertCountEqual(date_formats_all, set(datetime_profile.date_formats))
 
         # Test chunks
         datetime_profile = DateTimeColumn(df_1.name)
         datetime_profile.update(df_1)
 
-        six.assertCountEqual(self, date_formats_1, set(datetime_profile.date_formats))
+        self.assertCountEqual(date_formats_1, set(datetime_profile.date_formats))
 
         datetime_profile.update(df_2)
-        six.assertCountEqual(self, date_formats_all, datetime_profile.date_formats)
+        self.assertCountEqual(date_formats_all, datetime_profile.date_formats)
 
     def test_profiled_min(self):
         def date_linspace(start, end, steps):

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -203,7 +203,7 @@ class TestFloatColumn(unittest.TestCase):
             self.assertEqual(
                 min_expected_precision,
                 precision["min"],
-                msg="Errored for: {}".format(sample[0]),
+                msg=f"Errored for: {sample[0]}",
             )
 
     def test_profiled_min(self):

--- a/dataprofiler/tests/profilers/test_graph_profiler.py
+++ b/dataprofiler/tests/profilers/test_graph_profiler.py
@@ -1,8 +1,5 @@
-from __future__ import print_function
-
 import os
 import unittest
-from cgi import test
 from collections import defaultdict
 from io import BytesIO
 from unittest import mock

--- a/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
+++ b/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
@@ -1028,7 +1028,7 @@ class TestNumericStatsMixin(unittest.TestCase):
             other_match_count=other2.match_count,
             other_histogram=other2._stored_histogram["histogram"],
         )
-        self.assertEquals(expected_psi_value, psi_value)
+        self.assertEqual(expected_psi_value, psi_value)
 
         # PSI min_min_edge == max_max_edge
         other1, other2 = TestColumnWProps(), TestColumnWProps()
@@ -1055,7 +1055,7 @@ class TestNumericStatsMixin(unittest.TestCase):
             other_match_count=other2.match_count,
             other_histogram=other2._stored_histogram["histogram"],
         )
-        self.assertEquals(expected_psi_value, psi_value)
+        self.assertEqual(expected_psi_value, psi_value)
 
         # PSI regen other / not self
         other1, other2 = TestColumnWProps(), TestColumnWProps()
@@ -1088,7 +1088,7 @@ class TestNumericStatsMixin(unittest.TestCase):
             other_match_count=other2.match_count,
             other_histogram=other2._stored_histogram["histogram"],
         )
-        self.assertEquals(expected_psi_value, psi_value)
+        self.assertEqual(expected_psi_value, psi_value)
 
         # PSI regen self / not other
         expected_psi_value = 0.6617899380349177
@@ -1098,4 +1098,4 @@ class TestNumericStatsMixin(unittest.TestCase):
             other_match_count=other1.match_count,
             other_histogram=other1._stored_histogram["histogram"],
         )
-        self.assertEquals(expected_psi_value, psi_value)
+        self.assertEqual(expected_psi_value, psi_value)

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import json
 import logging
 import os
@@ -971,7 +969,7 @@ class TestStructuredProfiler(unittest.TestCase):
         self.assertEqual(2999, profile.sample_size)
         self.assertEqual(col_schema_info.sample_size, col_schema_info.match_count)
         self.assertEqual(2, profile.null_count)
-        six.assertCountEqual(self, ["nan"], profile.null_types)
+        self.assertCountEqual(["nan"], profile.null_types)
         self.assertEqual(["%m/%d/%y %H:%M"], col_schema_info["date_formats"])
 
     def test_correct_integer_column_detection_src(self):
@@ -2160,15 +2158,13 @@ class TestStructuredColProfilerClass(unittest.TestCase):
         )
 
         data_types = ["int", "float", "datetime", "text"]
-        six.assertCountEqual(
-            self,
+        self.assertCountEqual(
             data_types,
             list(src_profile.profiles["data_type_profile"]._profiles.keys()),
         )
 
         stats_types = ["category", "order"]
-        six.assertCountEqual(
-            self,
+        self.assertCountEqual(
             stats_types,
             list(src_profile.profiles["data_stats_profile"]._profiles.keys()),
         )
@@ -2372,8 +2368,7 @@ class TestStructuredColProfilerClass(unittest.TestCase):
         )
 
     def test_update_match_are_abstract(self):
-        six.assertCountEqual(
-            self,
+        self.assertCountEqual(
             {"profile", "_update_helper", "report", "update"},
             dp.profilers.BaseColumnProfiler.__abstractmethods__,
         )

--- a/dataprofiler/tests/profilers/test_stats_column_profiler.py
+++ b/dataprofiler/tests/profilers/test_stats_column_profiler.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import unittest
 
@@ -21,7 +19,7 @@ class TestColumnStatsProfiler(AbstractTestColumnProfiler, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestColumnStatsProfiler, cls).setUpClass()
+        super().setUpClass()
 
 
 if __name__ == "__main__":

--- a/dataprofiler/tests/profilers/test_text_column_profile.py
+++ b/dataprofiler/tests/profilers/test_text_column_profile.py
@@ -54,19 +54,19 @@ class TestTextColumnProfiler(unittest.TestCase):
         text_profiler.update(df1)
 
         unique_vocab = dict.fromkeys("".join(df1.tolist())).keys()
-        six.assertCountEqual(self, unique_vocab, text_profiler.vocab)
-        six.assertCountEqual(self, set(text_profiler.vocab), text_profiler.vocab)
+        self.assertCountEqual(unique_vocab, text_profiler.vocab)
+        self.assertCountEqual(set(text_profiler.vocab), text_profiler.vocab)
 
         text_profiler.update(df2)
         df = pd.concat([df1, df2])
         unique_vocab = dict.fromkeys("".join(df.tolist())).keys()
-        six.assertCountEqual(self, unique_vocab, text_profiler.vocab)
-        six.assertCountEqual(self, set(text_profiler.vocab), text_profiler.vocab)
+        self.assertCountEqual(unique_vocab, text_profiler.vocab)
+        self.assertCountEqual(set(text_profiler.vocab), text_profiler.vocab)
 
         text_profiler.update(df3)
         df = pd.concat([df1, df2, df3])
         unique_vocab = dict.fromkeys("".join(df.tolist())).keys()
-        six.assertCountEqual(self, unique_vocab, text_profiler.vocab)
+        self.assertCountEqual(unique_vocab, text_profiler.vocab)
 
     def test_profiled_str_numerics(self):
         """

--- a/dataprofiler/tests/profilers/test_utils.py
+++ b/dataprofiler/tests/profilers/test_utils.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from datetime import datetime
 from unittest import mock
@@ -331,7 +330,8 @@ class TestShuffleInChunks(unittest.TestCase):
         # wrong unit input
         with self.assertRaisesRegex(
             ValueError,
-            "Currently only supports the memory size unit " "in \['B', 'K', 'M', 'G'\]",
+            "Currently only supports the memory size unit "
+            r"in \['B', 'K', 'M', 'G'\]",
         ):
             utils.get_memory_size([], unit="wrong_unit")
 

--- a/dataprofiler/tests/profilers/utils.py
+++ b/dataprofiler/tests/profilers/utils.py
@@ -1,4 +1,3 @@
-import json
 import os
 import random
 import shutil

--- a/dataprofiler/tests/test_data_profiler.py
+++ b/dataprofiler/tests/test_data_profiler.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import unittest
 from unittest import mock

--- a/dataprofiler/tests/validators/test_base_validators.py
+++ b/dataprofiler/tests/validators/test_base_validators.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import unittest
 

--- a/dataprofiler/validators/base_validators.py
+++ b/dataprofiler/validators/base_validators.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 """Build model for dataset by identifying col type along with its respective params."""
-from __future__ import annotations, division, print_function
+from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import dask as dd
     import pandas as pd
 
 
-def is_in_range(x: Union[float, int], config: dict) -> bool:
+def is_in_range(x: float | int, config: dict) -> bool:
     """
     Check to see x is in the range of the config.
 
@@ -43,12 +43,12 @@ class Validator:
 
     def __init__(self) -> None:
         """Initialize Validator object."""
-        self.config: Optional[Dict] = None
-        self.report: Optional[Dict] = None
+        self.config: dict | None = None
+        self.report: dict | None = None
         self.validation_run: bool = False
-        self.validation_report: Dict = dict()
+        self.validation_report: dict = dict()
 
-    def validate(self, data: Union[pd.DataFrame, dd.DataFrame], config: dict) -> None:
+    def validate(self, data: pd.DataFrame | dd.DataFrame, config: dict) -> None:
         """
         Validate a data set.
 


### PR DESCRIPTION
Adding [pyupgrade](https://github.com/asottile/pyupgrade) and [autoflake](https://github.com/PyCQA/autoflake) to the linting in `pre-commit`.

Pyupgrade cleans up a lot of syntax, some of it legacy Python 2. Because many files use `from __future__ import annotations` it also converts the typehints to a more modern 3.10 syntax using `|` instead of `Optional` and names for types like `list` or `dict` so that `List` and `Dict` no longer need to be imported.

`autoflake` then automatically cleans up the no longer used imports.

This PR is almost entirely mechanical:
```
pre-commit run pyupgrade -a
pre-commit run autoflake -a
```

There were just a few typehint issues that this revealed that `mypy` then caught that had to be fixed manually:
```
dataprofiler/labelers/data_processing.py:1540: error: Incompatible default for argument "random_state" (default has type "None", argument has type "Union[Random, int, List[Any], Tuple[Any, ...]]")
dataprofiler/labelers/data_processing.py:1882: error: Incompatible default for argument "priority_order" (default has type "None", argument has type "Union[List[Any], ndarray[Any, Any]]")
dataprofiler/labelers/data_processing.py:1883: error: Incompatible default for argument "random_state" (default has type "None", argument has type "Union[Random, int, List[Any], Tuple[Any, ...]]")
dataprofiler/labelers/data_processing.py:2089: error: Incompatible default for argument "random_state" (default has type "None", argument has type "Union[Random, int, List[Any], Tuple[Any, ...]]")
dataprofiler/labelers/base_data_labeler.py:766: error: Incompatible default for argument "labels" (default has type "None", argument has type "Union[List[Any], Dict[Any, Any]]")
Found 5 errors in 2 files (checked 39 source files)
```
