### PR TITLE
loosening pin on typing-extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ psutil>=4.0.0
 scipy>=1.4.1
 requests==2.27.1
 networkx==2.5.1
-typing-extensions>=4.4.0
+typing-extensions>=3.10.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ psutil>=4.0.0
 scipy>=1.4.1
 requests==2.27.1
 networkx==2.5.1
-typing-extensions==3.10.0.2
+typing-extensions>=4.4.0


### PR DESCRIPTION
Dataprofiler is currently strictly depending on an old version of `typing-extensions`. This package is generally super safe to upgrade (and not pin tightly) since it's just backports to the `typing` module.