### PR TITLE
removing six

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
     hooks:
       - id: check-manifest
         additional_dependencies: ['h5py', 'wheel', 'future', 'numpy', 'pandas',
-        'python-dateutil', 'pytz', 'six', 'pyarrow', 'chardet', 'fastavro',
+        'python-dateutil', 'pytz', 'pyarrow', 'chardet', 'fastavro',
         'python-snappy', 'charset-normalizer', 'psutil', 'scipy', 'requests',
         'networkx','typing-extensions']
   # Pyupgrade - standardize and modernize Python syntax for newer versions of the language

--- a/dataprofiler/tests/profilers/test_base_column_profilers.py
+++ b/dataprofiler/tests/profilers/test_base_column_profilers.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
-import six
 
 from dataprofiler.profilers import utils
 from dataprofiler.profilers.base_column_profilers import (

--- a/dataprofiler/tests/profilers/test_categorical_column_profile.py
+++ b/dataprofiler/tests/profilers/test_categorical_column_profile.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
-import six
 
 from dataprofiler.profilers import CategoricalColumn
 from dataprofiler.profilers.profile_builder import StructuredColProfiler

--- a/dataprofiler/tests/profilers/test_column_profile_compilers.py
+++ b/dataprofiler/tests/profilers/test_column_profile_compilers.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import numpy as np
 import pandas as pd
-import six
 
 from dataprofiler.profilers import column_profile_compilers as col_pro_compilers
 from dataprofiler.profilers.profiler_options import (

--- a/dataprofiler/tests/profilers/test_data_labeler_column_profile.py
+++ b/dataprofiler/tests/profilers/test_data_labeler_column_profile.py
@@ -4,7 +4,6 @@ from unittest import mock
 
 import numpy as np
 import pandas as pd
-import six
 
 from dataprofiler.profilers import utils
 from dataprofiler.profilers.data_labeler_column_profile import DataLabelerColumn

--- a/dataprofiler/tests/profilers/test_datetime_column_profile.py
+++ b/dataprofiler/tests/profilers/test_datetime_column_profile.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import numpy as np
 import pandas as pd
-import six
 
 from dataprofiler.profilers import DateTimeColumn
 from dataprofiler.profilers.profiler_options import DateTimeOptions

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -10,7 +10,6 @@ from unittest import mock
 import networkx as nx
 import numpy as np
 import pandas as pd
-import six
 
 import dataprofiler as dp
 from dataprofiler import StructuredDataLabeler, UnstructuredDataLabeler

--- a/dataprofiler/tests/profilers/test_text_column_profile.py
+++ b/dataprofiler/tests/profilers/test_text_column_profile.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import numpy as np
 import pandas as pd
-import six
 
 from dataprofiler.profilers import TextColumn, utils
 from dataprofiler.profilers.profiler_options import TextOptions

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ numpy>=1.22.0
 pandas>=1.1.2
 python-dateutil>=2.7.5
 pytz>=2020.1
-six>=1.15.0
 pyarrow>=1.0.1
 chardet>=3.0.4
 fastavro>=1.0.0.post1


### PR DESCRIPTION
Removing `six` as its usage has been removed by `pyupgrade`.
