### PR TITLE
fix: update ml reqs

### DIFF
--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -1,7 +1,7 @@
 scikit-learn>=0.23.2
 keras>=2.4.3
 rapidfuzz>=2.6.1
-tensorflow-gpu>=2.6.4,<= 2.11; sys.platform == 'linux'
+tensorflow>=2.6.4; sys.platform != 'darwin'
 tensorflow>=2.6.4; sys_platform == 'darwin' and platform_machine != 'arm64'
 tensorflow-macos>=2.6.4; sys_platform == 'darwin' and platform_machine == 'arm64'
 tqdm>=4.0.0


### PR DESCRIPTION
Updates to allow linux or windows to install TF >=2.6.4

Linux can now use TF >=2.11 and use the GPU.

Further info on TF allowance:
https://www.tensorflow.org/install/pip#linux

Addresses: https://github.com/capitalone/DataProfiler/issues/775