### PR TITLE
Remove unnecessary cast() in csv_data.py (1)

### DIFF
--- a/dataprofiler/data_readers/csv_data.py
+++ b/dataprofiler/data_readers/csv_data.py
@@ -569,11 +569,8 @@ class CSVData(SpreadSheetDataMixin, BaseData):
                 self._quotechar = quotechar
 
             if self._header == "auto":
-                self._header = cast(
-                    int,
-                    self._guess_header_row(
-                        data_as_str, self._delimiter, self._quotechar
-                    ),
+                self._header = self._guess_header_row(
+                    data_as_str, self._delimiter, self._quotechar
                 )
                 self._checked_header = True
 


### PR DESCRIPTION
Removing this cast() doesn't cause a mypy error.

Issue: https://github.com/capitalone/DataProfiler/issues/717

`self._header` is set to type `Optional[Union[str, int]]` in the constructor. Also, `self.guess_header_row()` has return type `Optional[int]`, so casting to `int` doesn't make sense here.