### PR TITLE
Remove unnecessary cast() in csv_data.py (2)

### DIFF
--- a/dataprofiler/data_readers/csv_data.py
+++ b/dataprofiler/data_readers/csv_data.py
@@ -597,7 +597,7 @@ class CSVData(SpreadSheetDataMixin, BaseData):
             cast(Optional[int], self.header),
             self.selected_columns,
             read_in_string=True,
-            encoding=cast(str, self.file_encoding),
+            encoding=self.file_encoding,
         )
 
     def _get_data_as_records(self, data: pd.DataFrame) -> List[str]:


### PR DESCRIPTION
Issue: https://github.com/capitalone/DataProfiler/issues/717

- Removing this `cast()` doesn't cause a mypy error
- `self.file_encoding` has type `Optional[str]` prior to casting
- The `read_csv_df` function’s `encoding` parameter also has type `Optional[str]`
- Therefore casting to `str` for the function call isn’t necessary