### PR TITLE
Remove unnecessary cast() in data.py

### DIFF
--- a/dataprofiler/data_readers/data.py
+++ b/dataprofiler/data_readers/data.py
@@ -1,7 +1,7 @@
 """Contains factory class reading various kinds of data."""
 
 from io import BytesIO
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union
 
 from .. import dp_logging
 from .avro_data import AVROData
@@ -62,7 +62,7 @@ class Data:
             )
 
         if not options:
-            options = cast(Dict, dict())
+            options = dict()
 
         if is_valid_url(input_file_path):
             input_file_path = url_to_bytes(input_file_path, options)


### PR DESCRIPTION
Issue: https://github.com/capitalone/DataProfiler/issues/717

Removing this `cast()` doesn't cause a mypy error.

Simply assigning `dict()` to `options` changes its type from `Union[builtins.dict[Any, Any], None]` to `builtins.dict[Any, Any]`. So casting doesn't do anything here.