### PR TITLE
Remove unnecessary cast() in graph_data.py

### DIFF
--- a/dataprofiler/data_readers/graph_data.py
+++ b/dataprofiler/data_readers/graph_data.py
@@ -252,7 +252,7 @@ class GraphData(BaseData):
             )
 
         data_as_pd = data_utils.read_csv_df(
-            cast(str, self.input_file_path),
+            self.input_file_path,
             self._delimiter,
             cast(Optional[int], self._header),
             [],


### PR DESCRIPTION
Issue: https://github.com/capitalone/DataProfiler/issues/717

Removing this `cast()` does not cause a mypy error.

By the time this line is reached, the type of `self.input_file_path` is `builtins.str`. This is because the `assert` statement at line 196, earlier in the function, removes the `None` type from `self.input_file_path`. Therefore this `cast()` doesn't do anything.