### PR TITLE
Specify __init__ calls in data readers reload() methods

### DIFF
--- a/dataprofiler/data_readers/csv_data.py
+++ b/dataprofiler/data_readers/csv_data.py
@@ -755,4 +755,4 @@ class CSVData(SpreadSheetDataMixin, BaseData):
             header=self.header, delimiter=self.delimiter, quotechar=self.quotechar
         )
         super().reload(input_file_path, data, options)
-        self.__init__(self.input_file_path, data, options)  # type: ignore
+        CSVData.__init__(self, self.input_file_path, data, options)

--- a/dataprofiler/data_readers/json_data.py
+++ b/dataprofiler/data_readers/json_data.py
@@ -443,4 +443,4 @@ class JSONData(SpreadSheetDataMixin, BaseData):
         """
         self._selected_keys = None
         super().reload(input_file_path, data, options)
-        self.__init__(self.input_file_path, data, options)  # type: ignore
+        JSONData.__init__(self, self.input_file_path, data, options)

--- a/dataprofiler/data_readers/parquet_data.py
+++ b/dataprofiler/data_readers/parquet_data.py
@@ -172,4 +172,4 @@ class ParquetData(SpreadSheetDataMixin, BaseData):
         :return: None
         """
         super().reload(input_file_path, data, options)
-        self.__init__(self.input_file_path, data, options)  # type: ignore
+        ParquetData.__init__(self, self.input_file_path, data, options)

--- a/dataprofiler/data_readers/text_data.py
+++ b/dataprofiler/data_readers/text_data.py
@@ -145,4 +145,4 @@ class TextData(BaseData):
         :return: None
         """
         super().reload(input_file_path, data, options)
-        self.__init__(self.input_file_path, data, options)  # type: ignore
+        TextData.__init__(self, self.input_file_path, data, options)


### PR DESCRIPTION
Issue: https://github.com/capitalone/DataProfiler/issues/721

Previously, these lines without a `# type: ignore` caused a mypy error, because the `__init__()` called may have been overridden by a subclass. Specifying that the initializer called belongs to the current class fixes the mypy error.

Another example of this syntax: https://stackoverflow.com/questions/753640/inheritance-and-overriding-init-in-python/11055691#11055691