### PR TITLE
Fix override errors

### DIFF
--- a/dataprofiler/profilers/categorical_column_profile.py
+++ b/dataprofiler/profilers/categorical_column_profile.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from operator import itemgetter
+from typing import cast
 
 from pandas import DataFrame, Series
 
@@ -72,7 +73,7 @@ class CategoricalColumn(BaseColumnProfiler):
         )
         return merged_profile
 
-    def diff(self, other_profile: CategoricalColumn, options: dict = None) -> dict:
+    def diff(self, other_profile: BaseColumnProfiler, options: dict = None) -> dict:
         """
         Find the differences for CategoricalColumns.
 
@@ -81,7 +82,9 @@ class CategoricalColumn(BaseColumnProfiler):
         :return: the CategoricalColumn differences
         :rtype: dict
         """
+        # Make sure other_profile's type matches this class
         differences: dict = super().diff(other_profile, options)
+        other_profile = cast(CategoricalColumn, other_profile)
 
         differences["categorical"] = utils.find_diff_of_strings_and_bools(
             self.is_match, other_profile.is_match

--- a/dataprofiler/profilers/column_profile_compilers.py
+++ b/dataprofiler/profilers/column_profile_compilers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import abc
 from collections import OrderedDict
 from multiprocessing.pool import Pool
+from typing import cast
 
 from pandas import Series
 
@@ -279,9 +280,7 @@ class ColumnPrimitiveTypeProfileCompiler(BaseCompiler):
                     return matched_profile
         return matched_profile
 
-    def diff(
-        self, other: ColumnPrimitiveTypeProfileCompiler, options: dict = None
-    ) -> dict:
+    def diff(self, other: BaseCompiler, options: dict = None) -> dict:
         """
         Find the difference between 2 compilers and returns the report.
 
@@ -292,6 +291,7 @@ class ColumnPrimitiveTypeProfileCompiler(BaseCompiler):
         """
         # Call super for compiler instance check
         diff_profile = super().diff(other, options)
+        other = cast(ColumnPrimitiveTypeProfileCompiler, other)
 
         # Initialize profile diff dict with data type representation
         diff_profile["data_type_representation"] = dict()
@@ -354,7 +354,7 @@ class ColumnStatsProfileCompiler(BaseCompiler):
             report.update(profiler.report(remove_disabled_flag))
         return report
 
-    def diff(self, other: ColumnStatsProfileCompiler, options: dict = None) -> dict:
+    def diff(self, other: BaseCompiler, options: dict = None) -> dict:
         """
         Find the difference between 2 compilers and returns the report.
 
@@ -365,6 +365,7 @@ class ColumnStatsProfileCompiler(BaseCompiler):
         """
         # Call super for compiler instance check
         diff_profile = super().diff(other, options)
+        other = cast(ColumnStatsProfileCompiler, other)
 
         # Iterate through profiles
         all_profiles = set(self._profiles.keys()) | set(other._profiles.keys())
@@ -399,7 +400,7 @@ class ColumnDataLabelerCompiler(BaseCompiler):
             report["statistics"].update(col_profile)
         return report
 
-    def diff(self, other: ColumnDataLabelerCompiler, options: dict = None) -> dict:
+    def diff(self, other: BaseCompiler, options: dict = None) -> dict:
         """
         Find the difference between 2 compilers and return the report.
 
@@ -413,6 +414,7 @@ class ColumnDataLabelerCompiler(BaseCompiler):
         # Call super for compiler instance check
         diff_profile = super().diff(other, options)
         diff_profile["statistics"] = dict()
+        other = cast(ColumnDataLabelerCompiler, other)
 
         # Iterate through profile(s)
         all_profiles = set(self._profiles.keys()) & set(other._profiles.keys())
@@ -451,7 +453,7 @@ class UnstructuredCompiler(BaseCompiler):
             )
         return profile
 
-    def diff(self, other: UnstructuredCompiler, options: dict = None) -> dict:
+    def diff(self, other: BaseCompiler, options: dict = None) -> dict:
         """
         Find the difference between 2 compilers and return the report.
 
@@ -464,6 +466,7 @@ class UnstructuredCompiler(BaseCompiler):
         """
         # Call super for compiler instance check
         diff_profile = super().diff(other, options)
+        other = cast(BaseCompiler, other)
 
         if "data_labeler" in self._profiles and "data_labeler" in other._profiles:
             diff_profile["data_label"] = self._profiles["data_labeler"].diff(

--- a/dataprofiler/profilers/column_profile_compilers.py
+++ b/dataprofiler/profilers/column_profile_compilers.py
@@ -365,7 +365,6 @@ class ColumnStatsProfileCompiler(BaseCompiler):
         """
         # Call super for compiler instance check
         diff_profile = super().diff(other, options)
-        other = cast(ColumnStatsProfileCompiler, other)
 
         # Iterate through profiles
         all_profiles = set(self._profiles.keys()) | set(other._profiles.keys())
@@ -414,7 +413,6 @@ class ColumnDataLabelerCompiler(BaseCompiler):
         # Call super for compiler instance check
         diff_profile = super().diff(other, options)
         diff_profile["statistics"] = dict()
-        other = cast(ColumnDataLabelerCompiler, other)
 
         # Iterate through profile(s)
         all_profiles = set(self._profiles.keys()) & set(other._profiles.keys())
@@ -466,7 +464,6 @@ class UnstructuredCompiler(BaseCompiler):
         """
         # Call super for compiler instance check
         diff_profile = super().diff(other, options)
-        other = cast(BaseCompiler, other)
 
         if "data_labeler" in self._profiles and "data_labeler" in other._profiles:
             diff_profile["data_label"] = self._profiles["data_labeler"].diff(

--- a/dataprofiler/profilers/data_labeler_column_profile.py
+++ b/dataprofiler/profilers/data_labeler_column_profile.py
@@ -318,7 +318,7 @@ class DataLabelerColumn(BaseColumnProfiler):
         """
         return self.profile
 
-    def diff(self, other_profile: DataLabelerColumn, options: dict = None) -> dict:
+    def diff(self, other_profile: BaseColumnProfiler, options: dict = None) -> dict:
         """
         Generate differences between the orders of two DataLabeler columns.
 
@@ -326,7 +326,9 @@ class DataLabelerColumn(BaseColumnProfiler):
         appropriate output formats
         :rtype: dict
         """
+        # Make sure other_profile's type matches this class
         differences = super().diff(other_profile, options)
+        other_profile = cast(DataLabelerColumn, other_profile)
 
         self_labels = None
         if self.sample_size:

--- a/dataprofiler/profilers/datetime_column_profile.py
+++ b/dataprofiler/profilers/datetime_column_profile.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import datetime
 import re
 import warnings
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -155,7 +156,7 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
             return float(self.match_count) / self.sample_size
         return None
 
-    def diff(self, other_profile: DateTimeColumn, options: dict = None) -> dict:
+    def diff(self, other_profile: BaseColumnProfiler, options: dict = None) -> dict:
         """
         Generate differences between max, min, and formats of two DateTime cols.
 
@@ -163,7 +164,9 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
         appropriate output formats
         :rtype: dict
         """
+        # Make sure other_profile's type matches this class
         super().diff(other_profile, options)
+        other_profile = cast(DateTimeColumn, other_profile)
 
         differences = {
             "min": utils.find_diff_of_dates(

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import copy
 import re
-from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -132,7 +131,6 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):  # type: 
         """
         # Make sure other_profile's type matches this class
         differences = NumericStatsMixin.diff(self, other_profile, options=None)
-        other_profile = cast(FloatColumn, other_profile)
 
         other_precision = other_profile.profile["precision"]
         precision_diff = dict()

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import copy
 import re
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -120,7 +121,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):  # type: 
 
         return merged_profile
 
-    def diff(self, other_profile: FloatColumn, options: dict = None) -> dict:
+    def diff(self, other_profile: BaseColumnProfiler, options: dict = None) -> dict:
         """
         Find the differences for FloatColumns.
 
@@ -129,7 +130,10 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):  # type: 
         :return: the FloatColumn differences
         :rtype: dict
         """
+        # Make sure other_profile's type matches this class
         differences = NumericStatsMixin.diff(self, other_profile, options=None)
+        other_profile = cast(FloatColumn, other_profile)
+
         other_precision = other_profile.profile["precision"]
         precision_diff = dict()
         for key in self.profile["precision"].keys():

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -31,7 +31,7 @@ class abstractstaticmethod(staticmethod):
     __isabstractmethod__ = True
 
 
-class NumericStatsMixin(metaclass=abc.ABCMeta):  # type: ignore
+class NumericStatsMixin(BaseColumnProfiler, metaclass=abc.ABCMeta):
     """
     Abstract numerical column profile subclass of BaseColumnProfiler.
 
@@ -201,8 +201,8 @@ class NumericStatsMixin(metaclass=abc.ABCMeta):  # type: ignore
 
     def _add_helper(
         self,
-        other1: NumericStatsMixin,
-        other2: NumericStatsMixin,
+        other1: BaseColumnProfiler,
+        other2: BaseColumnProfiler,
     ) -> None:
         """
         Help merge profiles.
@@ -211,6 +211,12 @@ class NumericStatsMixin(metaclass=abc.ABCMeta):  # type: ignore
         :param other2: profile2 being added to self
         :return: None
         """
+        if not (
+            isinstance(other1, NumericStatsMixin)
+            and isinstance(other2, NumericStatsMixin)
+        ):
+            raise ValueError("Parameters must be of type NumericStatsMixin.")
+
         BaseColumnProfiler._merge_calculations(
             self._NumericStatsMixin__calculations,
             other1._NumericStatsMixin__calculations,
@@ -362,7 +368,7 @@ class NumericStatsMixin(metaclass=abc.ABCMeta):  # type: ignore
 
     def diff(
         self,
-        other_profile: NumericStatsMixin,
+        other_profile: BaseColumnProfiler,
         options: dict = None,
     ) -> dict:
         """

--- a/dataprofiler/profilers/order_column_profile.py
+++ b/dataprofiler/profilers/order_column_profile.py
@@ -279,7 +279,7 @@ class OrderColumn(BaseColumnProfiler):
         """
         return dict(order=self.order, times=self.times)
 
-    def diff(self, other_profile: OrderColumn, options: dict = None) -> dict:
+    def diff(self, other_profile: BaseColumnProfiler, options: dict = None) -> dict:
         """
         Generate the differences between the orders of two OrderColumns.
 
@@ -287,7 +287,9 @@ class OrderColumn(BaseColumnProfiler):
         appropriate output formats
         :rtype: dict
         """
+        # Make sure other_profile's type matches this class
         super().diff(other_profile, options)
+        other_profile = cast(OrderColumn, other_profile)
 
         differences = {
             "order": utils.find_diff_of_strings_and_bools(

--- a/dataprofiler/profilers/text_column_profile.py
+++ b/dataprofiler/profilers/text_column_profile.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import itertools
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -96,7 +97,7 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):  # type: i
         profile.update(dict(vocab=self.vocab))
         return profile
 
-    def diff(self, other_profile: TextColumn, options: dict = None) -> dict:
+    def diff(self, other_profile: BaseColumnProfiler, options: dict = None) -> dict:
         """
         Find the differences for text columns.
 
@@ -105,7 +106,10 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):  # type: i
         :return: the text columns differences
         :rtype: dict
         """
+        # Make sure other_profile's type matches this class
         differences = NumericStatsMixin.diff(self, other_profile, options)
+        other_profile = cast(TextColumn, other_profile)
+
         del differences["psi"]
         vocab_diff = utils.find_diff_of_lists_and_sets(self.vocab, other_profile.vocab)
         differences["vocab"] = vocab_diff

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ line_length=88
 warn_return_any = True
 warn_unused_configs = True
 ignore_missing_imports = True
-disable_error_code = override
 
 [check-manifest]
 ignore-default-rules=True


### PR DESCRIPTION
Issue: https://github.com/capitalone/DataProfiler/issues/747

* Make `NumericStatsMixin` a subclass of `BaseColumnProfiler`
  * [Comments](https://github.com/capitalone/DataProfiler/blob/a8c3d727275b8f9e89f9848d5fc4efa0b965b68f/dataprofiler/profilers/numerical_column_stats.py#L36) indicate that `NumericStatsMixin` is supposed to be a subclass of `BaseColumnProfiler`
  * Several classes have both `NumericStatsMixin` and `BaseColumnProfiler` as superclasses. The subclasses, `NumericStatsMixin`, and `BaseColumnProfiler` all implement a `diff` method, with different method signatures. This causes the subclass to override two parent methods at once, which isn't ideal
* Make subclass methods compliant with Liskov Substitution Principle (LSP), which says you need to be able to substitute in a subclass wherever a superclass goes. This means that the parameter types for overridden methods cannot be any narrower than what the superclass has. We resolve this by making the method signatures for subclass methods the same as those of the superclass. In case someone passes in a value of the wrong type, the methods already check the types and throw errors accordingly.
* Relevant superclasses are `BaseColumnProfiler` and `BaseCompiler`
* Remove the line in `setup.cfg` which causes mypy to ignore `override` errors