### PR TITLE
Add option for sampling_ratio at the dataset level

### DIFF
--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -1133,6 +1133,7 @@ class StructuredOptions(BaseOption):
         self,
         null_values: dict[str, re.RegexFlag | int] = None,
         column_null_values: dict[int, dict[str, re.RegexFlag | int]] = None,
+        sampling_ratio: float = None,
     ) -> None:
         """
         Construct the StructuredOptions object with default values.
@@ -1164,6 +1165,9 @@ class StructuredOptions(BaseOption):
         :vartype null_replication_metrics: BooleanOptions
         :ivar null_values: option set for defined null values
         :vartype null_values: Union[None, dict]
+        :ivar sampling_ratio: What ratio of the input data to sample.
+            Float value > 0 and <= 1
+        :vartype sampling_ratio: Union[None, float]
         """
         # Option variables
         self.multiprocess = BooleanOption()
@@ -1180,6 +1184,7 @@ class StructuredOptions(BaseOption):
         # Non-Option variables
         self.null_values = null_values
         self.column_null_values = column_null_values
+        self.sampling_ratio = sampling_ratio
 
     @property
     def enabled_profiles(self) -> list[str]:
@@ -1189,6 +1194,7 @@ class StructuredOptions(BaseOption):
         properties = self.properties
         properties.pop("null_values")
         properties.pop("column_null_values")
+        properties.pop("sampling_ratio")
         for key, value in properties.items():
             if value.is_enabled:
                 enabled_profiles.append(key)
@@ -1226,6 +1232,7 @@ class StructuredOptions(BaseOption):
         properties = self.properties
         properties.pop("null_values")
         properties.pop("column_null_values")
+        properties.pop("sampling_ratio")
         for column in properties:
             if not isinstance(self.properties[column], prop_check[column]):
                 errors.append(
@@ -1272,6 +1279,25 @@ class StructuredOptions(BaseOption):
                 "that map to dictionaries that contains keys "
                 "of type str and values == 0 or are instances of "
                 "a re.RegexFlag".format(variable_path)
+            )
+
+        if self.sampling_ratio is not None and not isinstance(
+            self.sampling_ratio, float
+        ):
+            errors.append(
+                "{}.sampling_ratio must be either None or an float".format(
+                    variable_path
+                )
+            )
+
+        if (
+            self.sampling_ratio is not None
+            and isinstance(self.sampling_ratio, float)
+            and not (0.0 < self.sampling_ratio <= 1.0)
+        ):
+            errors.append(
+                "{}.sampling_ratio must be greater than 0.0 "
+                "and less than or equal to 1.0".format(variable_path)
             )
 
         if (

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -1133,7 +1133,7 @@ class StructuredOptions(BaseOption):
         self,
         null_values: dict[str, re.RegexFlag | int] = None,
         column_null_values: dict[int, dict[str, re.RegexFlag | int]] = None,
-        sampling_ratio: float = None,
+        sampling_ratio: float = 0.2,
     ) -> None:
         """
         Construct the StructuredOptions object with default values.

--- a/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_profiler_options.py
@@ -30,6 +30,8 @@ class TestProfilerOptions(unittest.TestCase):
                 self.assertFalse(profile.options.properties[column].is_enabled)
             elif column == "null_values" or column == "column_null_values":
                 self.assertIsNone(profile.options.properties[column])
+            elif column == "sampling_ratio":
+                self.assertEqual(profile.options.properties[column], 0.2)
             else:
                 self.assertTrue(profile.options.properties[column].is_enabled)
 

--- a/dataprofiler/tests/profilers/profiler_options/test_structured_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_structured_options.py
@@ -91,6 +91,10 @@ class TestStructuredOptions(TestBaseOption):
             option.set({"column_null_values": test_dict})
             self.assertEqual(test_dict, option.column_null_values)
 
+        for test_val in [0.2, None]:
+            option.set({"sampling_ratio": test_val})
+            self.assertEqual(test_val, option.sampling_ratio)
+
     def test_validate_helper(self):
         # Valid cases should return [] while invalid cases
         # should return a list of errors
@@ -275,6 +279,22 @@ class TestStructuredOptions(TestBaseOption):
         # Test None works for option set
         option.set({"column_null_values": None})
         self.assertEqual([], option._validate_helper())
+
+        expected_error_type = [
+            f"{optpth}.sampling_ratio must be either None or an float"
+        ]
+
+        expected_error_value = [
+            "{}.sampling_ratio must be greater than 0.0 and less than or equal to 1.0".format(
+                optpth
+            )
+        ]
+        # Test ratio is not a float
+        option.set({"sampling_ratio": 1})
+        self.assertEqual(expected_error_type, option._validate_helper())
+        # Test ratio is out of range
+        option.set({"sampling_ratio": 2.5})
+        self.assertEqual(expected_error_value, option._validate_helper())
 
     def test_enabled_profilers(self):
         options = self.get_options()


### PR DESCRIPTION
This PR enables users to set an optional sampling_ratio parameter that will determine the ratio of the data that will be profiled. sampling_ratio should be a float greater than 0 and less than or equal to 1. This PR only enables the option to be set. A future PR will implement the actual sampling logic. 