### PR TITLE
Fix lsp violations

### DIFF
--- a/dataprofiler/profilers/base_column_profilers.py
+++ b/dataprofiler/profilers/base_column_profilers.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import abc
 import warnings
 from collections import defaultdict
-from typing import Any, Callable
+from typing import Any, Callable, Generic, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -15,8 +15,10 @@ from dataprofiler.profilers.profiler_options import BaseInspectorOptions
 
 from . import utils
 
+BaseColumnProfilerT = TypeVar("BaseColumnProfilerT", bound="BaseColumnProfiler")
 
-class BaseColumnProfiler(metaclass=abc.ABCMeta):  # type: ignore
+
+class BaseColumnProfiler(Generic[BaseColumnProfilerT], metaclass=abc.ABCMeta):
     """Abstract class for profiling a column of data."""
 
     col_type = None
@@ -147,7 +149,7 @@ class BaseColumnProfiler(metaclass=abc.ABCMeta):  # type: ignore
                     )
 
     def _add_helper(
-        self, other1: BaseColumnProfiler, other2: BaseColumnProfiler
+        self, other1: BaseColumnProfilerT, other2: BaseColumnProfilerT
     ) -> None:
         """
         Merge the properties of two BaseColumnProfile objects.
@@ -176,7 +178,7 @@ class BaseColumnProfiler(metaclass=abc.ABCMeta):  # type: ignore
 
         self.sample_size = other1.sample_size + other2.sample_size
 
-    def diff(self, other_profile: BaseColumnProfiler, options: dict = None) -> dict:
+    def diff(self, other_profile: BaseColumnProfilerT, options: dict = None) -> dict:
         """
         Find the differences for columns.
 
@@ -248,9 +250,14 @@ class BaseColumnProfiler(metaclass=abc.ABCMeta):  # type: ignore
         raise NotImplementedError()
 
 
+BaseColumnPrimitiveTypeProfilerT = TypeVar(
+    "BaseColumnPrimitiveTypeProfilerT", bound="BaseColumnPrimitiveTypeProfiler"
+)
+
+
 class BaseColumnPrimitiveTypeProfiler(
-    BaseColumnProfiler,
-    metaclass=abc.ABCMeta,  # type: ignore
+    BaseColumnProfiler[BaseColumnPrimitiveTypeProfilerT],
+    metaclass=abc.ABCMeta,
 ):
     """Abstract class for profiling primative data type for col of data."""
 
@@ -278,10 +285,10 @@ class BaseColumnPrimitiveTypeProfiler(
         self.match_count += profile.pop("match_count")
         BaseColumnProfiler._update_column_base_properties(self, profile)
 
-    def _add_helper(  # type: ignore[override]
+    def _add_helper(
         self,
-        other1: BaseColumnPrimitiveTypeProfiler,
-        other2: BaseColumnPrimitiveTypeProfiler,
+        other1: BaseColumnPrimitiveTypeProfilerT,
+        other2: BaseColumnPrimitiveTypeProfilerT,
     ) -> None:
         """
         Merge the properties of two objects inputted.
@@ -291,5 +298,5 @@ class BaseColumnPrimitiveTypeProfiler(
         :type other1: BaseColumnPrimitiveTypeProfiler
         :type other2: BaseColumnPrimitiveTypeProfiler
         """
-        BaseColumnProfiler._add_helper(self, other1, other2)
+        super()._add_helper(other1, other2)
         self.match_count = other1.match_count + other2.match_count

--- a/dataprofiler/profilers/categorical_column_profile.py
+++ b/dataprofiler/profilers/categorical_column_profile.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from collections import defaultdict
 from operator import itemgetter
-from typing import cast
 
 from pandas import DataFrame, Series
 
@@ -11,7 +10,7 @@ from . import BaseColumnProfiler, utils
 from .profiler_options import CategoricalOptions
 
 
-class CategoricalColumn(BaseColumnProfiler):
+class CategoricalColumn(BaseColumnProfiler["CategoricalColumn"]):
     """
     Categorical column profile subclass of BaseColumnProfiler.
 
@@ -73,7 +72,7 @@ class CategoricalColumn(BaseColumnProfiler):
         )
         return merged_profile
 
-    def diff(self, other_profile: BaseColumnProfiler, options: dict = None) -> dict:
+    def diff(self, other_profile: CategoricalColumn, options: dict = None) -> dict:
         """
         Find the differences for CategoricalColumns.
 
@@ -84,7 +83,6 @@ class CategoricalColumn(BaseColumnProfiler):
         """
         # Make sure other_profile's type matches this class
         differences: dict = super().diff(other_profile, options)
-        other_profile = cast(CategoricalColumn, other_profile)
 
         differences["categorical"] = utils.find_diff_of_strings_and_bools(
             self.is_match, other_profile.is_match

--- a/dataprofiler/profilers/column_profile_compilers.py
+++ b/dataprofiler/profilers/column_profile_compilers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import abc
 from collections import OrderedDict
 from multiprocessing.pool import Pool
-from typing import cast
+from typing import Generic, TypeVar
 
 from pandas import Series
 
@@ -20,8 +20,10 @@ from .text_column_profile import TextColumn
 from .unstructured_labeler_profile import UnstructuredLabelerProfile
 from .unstructured_text_profile import TextProfiler
 
+BaseCompilerT = TypeVar("BaseCompilerT", bound="BaseCompiler")
 
-class BaseCompiler(metaclass=abc.ABCMeta):  # type: ignore
+
+class BaseCompiler(Generic[BaseCompilerT], metaclass=abc.ABCMeta):
     """Abstract class for generating a report."""
 
     # NOTE: these profilers are ordered. Test functionality if changed.
@@ -140,7 +142,7 @@ class BaseCompiler(metaclass=abc.ABCMeta):  # type: ignore
             )
         return merged_profile_compiler
 
-    def diff(self, other: BaseCompiler, options: dict = None) -> dict:
+    def diff(self, other: BaseCompilerT, options: dict = None) -> dict:
         """
         Find the difference between 2 compilers and returns the report.
 
@@ -218,7 +220,9 @@ class BaseCompiler(metaclass=abc.ABCMeta):  # type: ignore
         return self
 
 
-class ColumnPrimitiveTypeProfileCompiler(BaseCompiler):
+class ColumnPrimitiveTypeProfileCompiler(
+    BaseCompiler["ColumnPrimitiveTypeProfileCompiler"]
+):
     """For generating ordered column profile reports."""
 
     # NOTE: these profilers are ordered. Test functionality if changed.
@@ -280,7 +284,9 @@ class ColumnPrimitiveTypeProfileCompiler(BaseCompiler):
                     return matched_profile
         return matched_profile
 
-    def diff(self, other: BaseCompiler, options: dict = None) -> dict:
+    def diff(
+        self, other: ColumnPrimitiveTypeProfileCompiler, options: dict = None
+    ) -> dict:
         """
         Find the difference between 2 compilers and returns the report.
 
@@ -291,7 +297,6 @@ class ColumnPrimitiveTypeProfileCompiler(BaseCompiler):
         """
         # Call super for compiler instance check
         diff_profile = super().diff(other, options)
-        other = cast(ColumnPrimitiveTypeProfileCompiler, other)
 
         # Initialize profile diff dict with data type representation
         diff_profile["data_type_representation"] = dict()
@@ -331,7 +336,7 @@ class ColumnPrimitiveTypeProfileCompiler(BaseCompiler):
         return diff_profile
 
 
-class ColumnStatsProfileCompiler(BaseCompiler):
+class ColumnStatsProfileCompiler(BaseCompiler["ColumnStatsProfileCompiler"]):
     """For generating OrderColumn and CategoricalColumn reports."""
 
     # NOTE: these profilers are ordered. Test functionality if changed.
@@ -354,7 +359,7 @@ class ColumnStatsProfileCompiler(BaseCompiler):
             report.update(profiler.report(remove_disabled_flag))
         return report
 
-    def diff(self, other: BaseCompiler, options: dict = None) -> dict:
+    def diff(self, other: ColumnStatsProfileCompiler, options: dict = None) -> dict:
         """
         Find the difference between 2 compilers and returns the report.
 
@@ -376,7 +381,7 @@ class ColumnStatsProfileCompiler(BaseCompiler):
         return diff_profile
 
 
-class ColumnDataLabelerCompiler(BaseCompiler):
+class ColumnDataLabelerCompiler(BaseCompiler["ColumnDataLabelerCompiler"]):
     """For generating DataLabelerColumn report."""
 
     # NOTE: these profilers are ordered. Test functionality if changed.
@@ -399,7 +404,7 @@ class ColumnDataLabelerCompiler(BaseCompiler):
             report["statistics"].update(col_profile)
         return report
 
-    def diff(self, other: BaseCompiler, options: dict = None) -> dict:
+    def diff(self, other: ColumnDataLabelerCompiler, options: dict = None) -> dict:
         """
         Find the difference between 2 compilers and return the report.
 
@@ -427,7 +432,7 @@ class ColumnDataLabelerCompiler(BaseCompiler):
         return diff_profile
 
 
-class UnstructuredCompiler(BaseCompiler):
+class UnstructuredCompiler(BaseCompiler["UnstructuredCompiler"]):
     """For generating TextProfiler and UnstructuredLabelerProfile reports."""
 
     # NOTE: these profilers are ordered. Test functionality if changed.
@@ -451,7 +456,7 @@ class UnstructuredCompiler(BaseCompiler):
             )
         return profile
 
-    def diff(self, other: BaseCompiler, options: dict = None) -> dict:
+    def diff(self, other: UnstructuredCompiler, options: dict = None) -> dict:
         """
         Find the difference between 2 compilers and return the report.
 

--- a/dataprofiler/profilers/data_labeler_column_profile.py
+++ b/dataprofiler/profilers/data_labeler_column_profile.py
@@ -13,7 +13,7 @@ from . import BaseColumnProfiler, utils
 from .profiler_options import DataLabelerOptions
 
 
-class DataLabelerColumn(BaseColumnProfiler):
+class DataLabelerColumn(BaseColumnProfiler["DataLabelerColumn"]):
     """Sublass of BaseColumnProfiler for profiling data labeler col."""
 
     type = "data_labeler"
@@ -318,7 +318,7 @@ class DataLabelerColumn(BaseColumnProfiler):
         """
         return self.profile
 
-    def diff(self, other_profile: BaseColumnProfiler, options: dict = None) -> dict:
+    def diff(self, other_profile: DataLabelerColumn, options: dict = None) -> dict:
         """
         Generate differences between the orders of two DataLabeler columns.
 
@@ -328,7 +328,6 @@ class DataLabelerColumn(BaseColumnProfiler):
         """
         # Make sure other_profile's type matches this class
         differences = super().diff(other_profile, options)
-        other_profile = cast(DataLabelerColumn, other_profile)
 
         self_labels = None
         if self.sample_size:

--- a/dataprofiler/profilers/datetime_column_profile.py
+++ b/dataprofiler/profilers/datetime_column_profile.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import datetime
 import re
 import warnings
-from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -14,7 +13,7 @@ from .base_column_profilers import BaseColumnPrimitiveTypeProfiler, BaseColumnPr
 from .profiler_options import DateTimeOptions
 
 
-class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
+class DateTimeColumn(BaseColumnPrimitiveTypeProfiler["DateTimeColumn"]):
     """
     Datetime column profile subclass of BaseColumnProfiler.
 
@@ -156,7 +155,7 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
             return float(self.match_count) / self.sample_size
         return None
 
-    def diff(self, other_profile: BaseColumnProfiler, options: dict = None) -> dict:
+    def diff(self, other_profile: DateTimeColumn, options: dict = None) -> dict:
         """
         Generate differences between max, min, and formats of two DateTime cols.
 
@@ -166,7 +165,6 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler):
         """
         # Make sure other_profile's type matches this class
         super().diff(other_profile, options)
-        other_profile = cast(DateTimeColumn, other_profile)
 
         differences = {
             "min": utils.find_diff_of_dates(

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -13,7 +13,9 @@ from .numerical_column_stats import NumericStatsMixin
 from .profiler_options import FloatOptions
 
 
-class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):  # type: ignore
+class FloatColumn(
+    NumericStatsMixin["FloatColumn"], BaseColumnPrimitiveTypeProfiler["FloatColumn"]
+):
     """
     Float column profile mixin with numerical stats.
 
@@ -120,7 +122,7 @@ class FloatColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):  # type: 
 
         return merged_profile
 
-    def diff(self, other_profile: BaseColumnProfiler, options: dict = None) -> dict:
+    def diff(self, other_profile: FloatColumn, options: dict = None) -> dict:
         """
         Find the differences for FloatColumns.
 

--- a/dataprofiler/profilers/int_column_profile.py
+++ b/dataprofiler/profilers/int_column_profile.py
@@ -9,7 +9,9 @@ from .numerical_column_stats import NumericStatsMixin
 from .profiler_options import IntOptions
 
 
-class IntColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):  # type: ignore
+class IntColumn(
+    NumericStatsMixin["IntColumn"], BaseColumnPrimitiveTypeProfiler["IntColumn"]
+):
     """
     Integer column profile mixin with of numerical stats.
 

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -6,7 +6,7 @@ import abc
 import copy
 import itertools
 import warnings
-from typing import Any, Callable, Dict, List, cast
+from typing import Any, Callable, Dict, List, TypeVar, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -31,7 +31,10 @@ class abstractstaticmethod(staticmethod):
     __isabstractmethod__ = True
 
 
-class NumericStatsMixin(BaseColumnProfiler, metaclass=abc.ABCMeta):
+NumericStatsMixinT = TypeVar("NumericStatsMixinT", bound="NumericStatsMixin")
+
+
+class NumericStatsMixin(BaseColumnProfiler[NumericStatsMixinT], metaclass=abc.ABCMeta):
     """
     Abstract numerical column profile subclass of BaseColumnProfiler.
 
@@ -201,8 +204,8 @@ class NumericStatsMixin(BaseColumnProfiler, metaclass=abc.ABCMeta):
 
     def _add_helper(
         self,
-        other1: BaseColumnProfiler,
-        other2: BaseColumnProfiler,
+        other1: NumericStatsMixinT,
+        other2: NumericStatsMixinT,
     ) -> None:
         """
         Help merge profiles.
@@ -211,12 +214,6 @@ class NumericStatsMixin(BaseColumnProfiler, metaclass=abc.ABCMeta):
         :param other2: profile2 being added to self
         :return: None
         """
-        if not (
-            isinstance(other1, NumericStatsMixin)
-            and isinstance(other2, NumericStatsMixin)
-        ):
-            raise ValueError("Parameters must be of type NumericStatsMixin.")
-
         BaseColumnProfiler._merge_calculations(
             self._NumericStatsMixin__calculations,
             other1._NumericStatsMixin__calculations,
@@ -368,7 +365,7 @@ class NumericStatsMixin(BaseColumnProfiler, metaclass=abc.ABCMeta):
 
     def diff(
         self,
-        other_profile: BaseColumnProfiler,
+        other_profile: NumericStatsMixinT,
         options: dict = None,
     ) -> dict:
         """

--- a/dataprofiler/profilers/order_column_profile.py
+++ b/dataprofiler/profilers/order_column_profile.py
@@ -9,7 +9,7 @@ from . import BaseColumnProfiler, utils
 from .profiler_options import OrderOptions
 
 
-class OrderColumn(BaseColumnProfiler):
+class OrderColumn(BaseColumnProfiler["OrderColumn"]):
     """
     Index column profile subclass of BaseColumnProfiler.
 
@@ -279,7 +279,7 @@ class OrderColumn(BaseColumnProfiler):
         """
         return dict(order=self.order, times=self.times)
 
-    def diff(self, other_profile: BaseColumnProfiler, options: dict = None) -> dict:
+    def diff(self, other_profile: OrderColumn, options: dict = None) -> dict:
         """
         Generate the differences between the orders of two OrderColumns.
 
@@ -289,7 +289,6 @@ class OrderColumn(BaseColumnProfiler):
         """
         # Make sure other_profile's type matches this class
         super().diff(other_profile, options)
-        other_profile = cast(OrderColumn, other_profile)
 
         differences = {
             "order": utils.find_diff_of_strings_and_bools(

--- a/dataprofiler/profilers/text_column_profile.py
+++ b/dataprofiler/profilers/text_column_profile.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import itertools
-from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -13,7 +12,9 @@ from .numerical_column_stats import NumericStatsMixin
 from .profiler_options import TextOptions
 
 
-class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):  # type: ignore
+class TextColumn(
+    NumericStatsMixin["TextColumn"], BaseColumnPrimitiveTypeProfiler["TextColumn"]
+):
     """
     Text column profile subclass of BaseColumnProfiler.
 
@@ -97,7 +98,7 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):  # type: i
         profile.update(dict(vocab=self.vocab))
         return profile
 
-    def diff(self, other_profile: BaseColumnProfiler, options: dict = None) -> dict:
+    def diff(self, other_profile: TextColumn, options: dict = None) -> dict:
         """
         Find the differences for text columns.
 
@@ -108,7 +109,6 @@ class TextColumn(NumericStatsMixin, BaseColumnPrimitiveTypeProfiler):  # type: i
         """
         # Make sure other_profile's type matches this class
         differences = NumericStatsMixin.diff(self, other_profile, options)
-        other_profile = cast(TextColumn, other_profile)
 
         del differences["psi"]
         vocab_diff = utils.find_diff_of_lists_and_sets(self.vocab, other_profile.vocab)


### PR DESCRIPTION
Issue: https://github.com/capitalone/DataProfiler/issues/747

* Makes the superclasses `BaseColumnProfiler`, `NumericStatsMixin`, and
`BaseCompiler generic`, to avoid casting in subclass diff() methods and
violating LSP in principle.
* Removes unneeded casting in `diff()` methods
