### PR TITLE
feat: add test and compiler serialization

### DIFF
--- a/dataprofiler/profilers/column_profile_compilers.py
+++ b/dataprofiler/profilers/column_profile_compilers.py
@@ -45,6 +45,7 @@ class BaseCompiler(metaclass=abc.ABCMeta):  # type: ignore
         if self._option_class is None:
             raise NotImplementedError("Must set the expected OptionClass.")
 
+        self.name = None
         self._profiles: dict = OrderedDict()
         if df_series is not None:
             self.name = df_series.name

--- a/dataprofiler/profilers/json_encoder.py
+++ b/dataprofiler/profilers/json_encoder.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 
 from ..labelers.base_data_labeler import BaseDataLabeler
-from . import base_column_profilers, numerical_column_stats
+from . import base_column_profilers, column_profile_compilers, numerical_column_stats
 
 
 class ProfileEncoder(json.JSONEncoder):
@@ -24,6 +24,7 @@ class ProfileEncoder(json.JSONEncoder):
             (
                 base_column_profilers.BaseColumnProfiler,
                 numerical_column_stats.NumericStatsMixin,
+                column_profile_compilers.BaseCompiler,
             ),
         ):
             return {"class": type(to_serialize).__name__, "data": to_serialize.__dict__}

--- a/dataprofiler/tests/profilers/test_base_column_profilers.py
+++ b/dataprofiler/tests/profilers/test_base_column_profilers.py
@@ -163,7 +163,7 @@ class TestBaseColumnProfileClass(unittest.TestCase):
             }
         )
 
-        self.assertEqual(serialized, expected)
+        self.assertEqual(expected, serialized)
 
 
 class TestBaseColumnPrimitiveTypeProfileClass(unittest.TestCase):


### PR DESCRIPTION
Adds tests and adds the capability to serialize the base compiler. Includes fake _profiles to test nested serialization.

Interestingly, class attributes don't need serialization. Not sure if this is ideal or not but something I noticed.