### PR TITLE
Fix name mangling and typevar errors

### DIFF
--- a/dataprofiler/labelers/base_model.py
+++ b/dataprofiler/labelers/base_model.py
@@ -32,7 +32,7 @@ class AutoSubRegistrationMeta(abc.ABCMeta):
 class BaseModel(metaclass=abc.ABCMeta):
     """For labeling data."""
 
-    _BaseModel__subclasses: dict[str, type[BaseModel]] = {}
+    __subclasses: dict[str, type[BaseModel]] = {}
     __metaclass__ = abc.ABCMeta
 
     # boolean if the label mapping requires the mapping for index 0 reserved
@@ -90,7 +90,7 @@ class BaseModel(metaclass=abc.ABCMeta):
     def _register_subclass(cls) -> None:
         """Register a subclass for the class factory."""
         if not inspect.isabstract(cls):
-            cls._BaseModel__subclasses[cls.__name__.lower()] = cls
+            cls.__subclasses[cls.__name__.lower()] = cls
 
     @property
     def label_mapping(self) -> dict[str, int]:
@@ -156,7 +156,7 @@ class BaseModel(metaclass=abc.ABCMeta):
         from .column_name_model import ColumnNameModel  # NOQA
         from .regex_model import RegexModel  # NOQA
 
-        return cls._BaseModel__subclasses.get(class_name.lower(), None)
+        return cls.__subclasses.get(class_name.lower(), None)
 
     def get_parameters(self, param_list: list[str] | None = None) -> dict:
         """

--- a/dataprofiler/labelers/data_processing.py
+++ b/dataprofiler/labelers/data_processing.py
@@ -49,16 +49,14 @@ class BaseDataProcessor(metaclass=abc.ABCMeta):
     def _register_subclass(cls) -> None:
         """Register a subclass for the class factory."""
         if not inspect.isabstract(cls):
-            cls._BaseDataProcessor__subclasses[  # type: ignore
-                cls.__name__.lower()
-            ] = cls
+            cls.__subclasses[cls.__name__.lower()] = cls
 
     @classmethod
-    def get_class(cls: type[Processor], class_name: str) -> type[Processor] | None:
+    def get_class(
+        cls: type[BaseDataProcessor], class_name: str
+    ) -> type[BaseDataProcessor] | None:
         """Get class of BaseDataProcessor object."""
-        return cls._BaseDataProcessor__subclasses.get(  # type: ignore
-            class_name.lower(), None
-        )
+        return cls.__subclasses.get(class_name.lower(), None)
 
     def __eq__(self, other: object) -> bool:
         """


### PR DESCRIPTION
Issue: https://github.com/capitalone/DataProfiler/issues/722

Inside the `BaseDataProcessor` class definition, all references to `__subclasses` are automatically replaced with
`_BaseDataProcessor__subclasses`. This remains the case even in static methods `_register_subclass()` and `get_class()`. Same with `BaseModel` and its `__subclasses` field. So we do not have to write out the full name mangled identifiers inside the class definitions.

Also, mypy doesn't seem to be able to handle the return type of `BaseDataProcessor.get_class()` being a typevar, so that was changed to `type[BaseDataProcessor]`. This does not affect the functionality of `get_class()` since it always returns a subclass of `BaseDataProcessor`.