### PR TITLE
refactor: allow options to go through all

### DIFF
--- a/dataprofiler/profilers/categorical_column_profile.py
+++ b/dataprofiler/profilers/categorical_column_profile.py
@@ -201,7 +201,7 @@ class CategoricalColumn(BaseColumnProfiler["CategoricalColumn"]):
         return self.profile
 
     @classmethod
-    def load_from_dict(cls, data):
+    def load_from_dict(cls, data: dict, options: dict | None = None):
         """
         Parse attribute from json dictionary into self.
 

--- a/dataprofiler/profilers/column_profile_compilers.py
+++ b/dataprofiler/profilers/column_profile_compilers.py
@@ -222,12 +222,14 @@ class BaseCompiler(Generic[BaseCompilerT], metaclass=abc.ABCMeta):
         return self
 
     @classmethod
-    def load_from_dict(cls, data) -> BaseCompiler:
+    def load_from_dict(cls, data, options: dict | None = None) -> BaseCompiler:
         """
         Parse attribute from json dictionary into self.
 
         :param data: dictionary with attributes and values.
         :type data: dict[string, Any]
+        :param options: options for loading column profiler params from dictionary
+        :type options: Dict | None
 
         :return: Compiler with attributes populated.
         :rtype: BaseCompiler
@@ -237,7 +239,7 @@ class BaseCompiler(Generic[BaseCompilerT], metaclass=abc.ABCMeta):
         for attr, value in data.items():
             if "_profiles" in attr:
                 for col_type, profile_as_dict in value.items():
-                    value[col_type] = load_column_profile(profile_as_dict)
+                    value[col_type] = load_column_profile(profile_as_dict, options)
                 # since needs to be in the same order, use _profilers to enforce
                 value = OrderedDict(
                     {

--- a/dataprofiler/profilers/data_labeler_column_profile.py
+++ b/dataprofiler/profilers/data_labeler_column_profile.py
@@ -323,9 +323,20 @@ class DataLabelerColumn(BaseColumnProfiler["DataLabelerColumn"]):
         opt = DataLabelerOptions()
         data_labeler_load_attr = data.pop("data_labeler")
         if "from_library" in data_labeler_load_attr:
-            opt.data_labeler_object = DataLabeler.load_from_library(
-                data_labeler_load_attr["from_library"]
+            data_labeler_object = (
+                (
+                    options.get(cls.__name__, {})
+                    .get("from_library", {})
+                    .get(data_labeler_load_attr["from_library"])
+                )
+                if options is not None
+                else None
             )
+            if data_labeler_object is None:
+                data_labeler_object = DataLabeler.load_from_library(
+                    data_labeler_load_attr["from_library"]
+                )
+            opt.data_labeler_object = data_labeler_object
         elif "from_disk" in data_labeler_load_attr:
             raise NotImplementedError(
                 "Models intialized from disk have not yet been made deserializable"

--- a/dataprofiler/profilers/datetime_column_profile.py
+++ b/dataprofiler/profilers/datetime_column_profile.py
@@ -132,12 +132,14 @@ class DateTimeColumn(BaseColumnPrimitiveTypeProfiler["DateTimeColumn"]):
         return self.profile
 
     @classmethod
-    def load_from_dict(cls, data):
+    def load_from_dict(cls, data, options: dict | None = None):
         """
         Parse attribute from json dictionary into self.
 
         :param data: dictionary with attributes and values.
         :type data: dict[string, Any]
+        :param options: options for loading column profiler params from dictionary
+        :type options: Dict | None
 
         :return: Profiler with attributes populated.
         :rtype: DateTimeColumn

--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -158,12 +158,14 @@ class FloatColumn(
         return profile
 
     @classmethod
-    def load_from_dict(cls, data):
+    def load_from_dict(cls, data, options: dict | None = None):
         """
         Parse attribute from json dictionary into self.
 
         :param data: dictionary with attributes and values.
         :type data: dict[string, Any]
+        :param options: options for loading column profiler params from dictionary
+        :type options: Dict | None
 
         :return: Profiler with attributes populated.
         :rtype: FloatColumn

--- a/dataprofiler/profilers/int_column_profile.py
+++ b/dataprofiler/profilers/int_column_profile.py
@@ -73,12 +73,14 @@ class IntColumn(
         return self.profile
 
     @classmethod
-    def load_from_dict(cls, data):
+    def load_from_dict(cls, data, options: dict | None = None):
         """
         Parse attribute from json dictionary into self.
 
         :param data: dictionary with attributes and values.
         :type data: dict[string, Any]
+        :param options: options for loading column profiler params from dictionary
+        :type options: Dict | None
 
         :return: Profiler with attributes populated.
         :rtype: IntColumn

--- a/dataprofiler/profilers/json_decoder.py
+++ b/dataprofiler/profilers/json_decoder.py
@@ -1,5 +1,7 @@
 """Contains methods to decode components of a Profiler."""
-from typing import TYPE_CHECKING, Dict, Optional, Type
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import column_profile_compilers as col_pro_compiler
@@ -9,12 +11,12 @@ if TYPE_CHECKING:
 
 
 # default, but set in the local __init__ to avoid circular imports
-_profiles: Dict[str, Type["BaseColumnProfiler"]] = {}
-_compilers: Dict[str, Type["col_pro_compiler.BaseCompiler"]] = {}
-_options: Dict[str, Type["BaseOption"]] = {}
+_profiles: dict[str, type[BaseColumnProfiler]] = {}
+_compilers: dict[str, type[col_pro_compiler.BaseCompiler]] = {}
+_options: dict[str, type[BaseOption]] = {}
 
 
-def get_column_profiler_class(class_name: str) -> Type["BaseColumnProfiler"]:
+def get_column_profiler_class(class_name: str) -> type[BaseColumnProfiler]:
     """
     Use name of class to return default-constructed version of that class.
 
@@ -26,13 +28,13 @@ def get_column_profiler_class(class_name: str) -> Type["BaseColumnProfiler"]:
     :type class_name: str representing name of class
     :return: subclass of BaseColumnProfiler object
     """
-    profile_class: Optional[Type["BaseColumnProfiler"]] = _profiles.get(class_name)
+    profile_class: type[BaseColumnProfiler] | None = _profiles.get(class_name)
     if profile_class is None:
         raise ValueError(f"Invalid profiler class {class_name} " f"failed to load.")
     return profile_class
 
 
-def get_compiler_class(class_name: str) -> Type["col_pro_compiler.BaseCompiler"]:
+def get_compiler_class(class_name: str) -> type[col_pro_compiler.BaseCompiler]:
     """
     Use name of class to return default-constructed version of that class.
 
@@ -44,7 +46,7 @@ def get_compiler_class(class_name: str) -> Type["col_pro_compiler.BaseCompiler"]
     :type class_name: str representing name of class
     :return: subclass of BaseCompiler object
     """
-    compiler_class: Optional[Type["col_pro_compiler.BaseCompiler"]] = _compilers.get(
+    compiler_class: type[col_pro_compiler.BaseCompiler] | None = _compilers.get(
         class_name
     )
     if compiler_class is None:
@@ -52,7 +54,7 @@ def get_compiler_class(class_name: str) -> Type["col_pro_compiler.BaseCompiler"]
     return compiler_class
 
 
-def get_option_class(class_name: str) -> Type["BaseOption"]:
+def get_option_class(class_name: str) -> type[BaseOption]:
     """
     Use name of class to return default-constructed version of that class.
 
@@ -64,13 +66,15 @@ def get_option_class(class_name: str) -> Type["BaseOption"]:
     :type class_name: str representing name of class
     :return: subclass of BaseOptions object
     """
-    options_class: Optional[Type["BaseOption"]] = _options.get(class_name)
+    options_class: type[BaseOption] | None = _options.get(class_name)
     if options_class is None:
         raise ValueError(f"Invalid option class {class_name} " f"failed to load.")
     return options_class
 
 
-def load_column_profile(serialized_json: dict) -> "BaseColumnProfiler":
+def load_column_profile(
+    serialized_json: dict, options: dict | None = None
+) -> BaseColumnProfiler:
     """
     Construct subclass of BaseColumnProfiler given a serialized JSON.
 
@@ -88,17 +92,22 @@ def load_column_profile(serialized_json: dict) -> "BaseColumnProfiler":
         # serialized using the custom encoder in profilers.json_encoder
     :type serialized_json: a dict that was created by calling json.loads on
         a JSON representation using the custom encoder
+    :param options: options for loading column profiler params from dictionary
+    :type options: Dict | None
+
     :return: subclass of BaseColumnProfiler that has been deserialized from
         JSON
 
     """
-    column_profiler_cls: Type[
-        "BaseColumnProfiler[BaseColumnProfiler]"
+    column_profiler_cls: type[
+        BaseColumnProfiler[BaseColumnProfiler]
     ] = get_column_profiler_class(serialized_json["class"])
-    return column_profiler_cls.load_from_dict(serialized_json["data"])
+    return column_profiler_cls.load_from_dict(serialized_json["data"], options)
 
 
-def load_compiler(serialized_json: dict) -> "col_pro_compiler.BaseCompiler":
+def load_compiler(
+    serialized_json: dict, options: dict | None = None
+) -> col_pro_compiler.BaseCompiler:
     """
     Construct subclass of BaseCompiler given a serialized JSON.
 
@@ -116,17 +125,19 @@ def load_compiler(serialized_json: dict) -> "col_pro_compiler.BaseCompiler":
         serialized using the custom encoder in profilers.json_encoder
     :type serialized_json: a dict that was created by calling json.loads on
         a JSON representation using the custom encoder
+    :param options: options for loading column compiler params from dictionary
+    :type options: Dict | None
     :return: subclass of BaseCompiler that has been deserialized from
         JSON
 
     """
-    column_profiler_cls: Type["col_pro_compiler.BaseCompiler"] = get_compiler_class(
+    column_profiler_cls: type[col_pro_compiler.BaseCompiler] = get_compiler_class(
         serialized_json["class"]
     )
-    return column_profiler_cls.load_from_dict(serialized_json["data"])
+    return column_profiler_cls.load_from_dict(serialized_json["data"], options)
 
 
-def load_option(serialized_json: dict) -> "BaseOption":
+def load_option(serialized_json: dict, options: dict | None = None) -> BaseOption:
     """
     Construct subclass of BaseOption given a serialized JSON.
 
@@ -144,9 +155,11 @@ def load_option(serialized_json: dict) -> "BaseOption":
         serialized using the custom encoder in profilers.json_encoder
     :type serialized_json: a dict that was created by calling json.loads on
         a JSON representation using the custom encoder
+    :param options: options for loading column profiler params from dictionary
+    :type options: Dict | None
     :return: subclass of BaseOption that has been deserialized from
         JSON
 
     """
-    option_cls: Type["BaseOption"] = get_option_class(serialized_json["class"])
-    return option_cls.load_from_dict(serialized_json["data"])
+    option_cls: type[BaseOption] = get_option_class(serialized_json["class"])
+    return option_cls.load_from_dict(serialized_json["data"], options)

--- a/dataprofiler/profilers/order_column_profile.py
+++ b/dataprofiler/profilers/order_column_profile.py
@@ -47,8 +47,8 @@ class OrderColumn(BaseColumnProfiler["OrderColumn"]):
                 "OrderColumn parameter 'options' must be of type" " OrderOptions."
             )
         self.order: str | None = None
-        self._last_value: float | str | None = None
-        self._first_value: float | str | None = None
+        self._last_value: np.float64 | float | str | None = None
+        self._first_value: np.float64 | float | str | None = None
         self._piecewise: bool | None = False
         self.__calculations: dict = {}
         self._filter_properties_w_options(self.__calculations, options)
@@ -292,12 +292,14 @@ class OrderColumn(BaseColumnProfiler["OrderColumn"]):
         return self.profile
 
     @classmethod
-    def load_from_dict(cls, data):
+    def load_from_dict(cls, data, options: dict | None = None):
         """
         Parse attribute from json dictionary into self.
 
         :param data: dictionary with attributes and values.
         :type data: dict[string, Any]
+        :param options: options for loading column profiler params from dictionary
+        :type options: Dict | None
 
         :return: Profiler with attributes populated.
         :rtype: CategoricalColumn

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -147,12 +147,14 @@ class BaseOption(Generic[BaseOptionT]):
         return None
 
     @classmethod
-    def load_from_dict(cls, data) -> BaseOption:
+    def load_from_dict(cls, data, options: dict | None = None) -> BaseOption:
         """
         Parse attribute from json dictionary into self.
 
         :param data: dictionary with attributes and values.
         :type data: dict[string, Any]
+        :param options: options for loading options params from dictionary
+        :type options: Dict | None
 
         :return: Profiler with attributes populated.
         :rtype: BaseColumnProfiler

--- a/dataprofiler/profilers/text_column_profile.py
+++ b/dataprofiler/profilers/text_column_profile.py
@@ -195,12 +195,15 @@ class TextColumn(
         return self
 
     @classmethod
-    def load_from_dict(cls, data):
+    def load_from_dict(cls, data, options: dict | None = None):
         """
         Parse attribute from json dictionary into self.
 
         :param data: dictionary with attributes and values.
         :type data: dict[string, Any]
+        :param options: options for loading column profiler params from dictionary
+        :type options: Dict | None
+
         :return: Profiler with attributes populated.
         :rtype: TextColumn
         """

--- a/dataprofiler/tests/profilers/test_column_profile_compilers.py
+++ b/dataprofiler/tests/profilers/test_column_profile_compilers.py
@@ -797,9 +797,9 @@ class TestColumnDataLabelerCompiler(unittest.TestCase):
             "data_label_representation", None
         ) == {"a": 0.6, "b": 0.4}
 
-    def test_json_decode_with_options(self, mock_instance):
-        self._setup_data_labeler_mock(mock_instance)
-        mock_instance._default_model_loc = "structured_model"
+    def test_json_decode_with_options(self, mock_DataLabeler_cls):
+        self._setup_data_labeler_mock(mock_DataLabeler_cls)
+        mock_DataLabeler_cls._default_model_loc = "structured_model"
 
         data = pd.Series(["2", "-1", "1", "2"], name="test")
         with test_utils.mock_timeit():
@@ -807,24 +807,29 @@ class TestColumnDataLabelerCompiler(unittest.TestCase):
 
         serialized = json.dumps(expected_compiler, cls=ProfileEncoder)
 
+        # create a new labeler ot load instead of from_library
         new_mock_data_labeler = mock.Mock(spec=BaseDataLabeler)
         new_mock_data_labeler.name = "new fake data labeler"
         new_mock_data_labeler._default_model_loc = "my/fake/path"
-        mock_instance.load_from_library.return_value = new_mock_data_labeler
-        mock_instance.load_from_library.side_effect = None
-        options = {"DataLabelerColumn": {"from_library": new_mock_data_labeler}}
+        options = {
+            "DataLabelerColumn": {
+                "from_library": {"structured_model": new_mock_data_labeler}
+            }
+        }
 
+        mock_DataLabeler_cls.reset_mock()  # set to 0 calls as option should override
         deserialized = load_compiler(json.loads(serialized), options)
 
-        # ensure doesn't change original, but options update deserialized
+        # ensure doesn't change original, but options updates deserialized labeler
         assert (
             expected_compiler._profiles.get("data_labeler", mock.Mock()).data_labeler
-            == mock_instance.return_value
+            == mock_DataLabeler_cls.return_value
         )
         assert (
             deserialized._profiles.get("data_labeler", mock.Mock()).data_labeler
             == new_mock_data_labeler
         )
+        mock_DataLabeler_cls.assert_not_called()
 
 
 class TestUnstructuredCompiler(unittest.TestCase):

--- a/dataprofiler/tests/profilers/test_data_labeler_column_profile.py
+++ b/dataprofiler/tests/profilers/test_data_labeler_column_profile.py
@@ -498,6 +498,22 @@ class TestDataLabelerColumnProfiler(unittest.TestCase):
 
         test_utils.assert_profiles_equal(deserialized, expected)
 
+        # test decode with options to override load labeler
+        # create a new labeler ot load instead of from_library
+        new_mock_data_labeler = mock.Mock(spec=BaseDataLabeler)
+        new_mock_data_labeler.name = "new fake data labeler"
+        new_mock_data_labeler._default_model_loc = "my/fake/path"
+        options = {
+            "DataLabelerColumn": {
+                "from_library": {"structured_model": new_mock_data_labeler}
+            }
+        }
+
+        mock_instance.reset_mock()  # set to 0 calls as option should override
+        deserialized = load_column_profile(json.loads(serialized), options)
+        assert deserialized.data_labeler == new_mock_data_labeler
+        mock_instance.assert_not_called()
+
     def test_json_decode_after_update(self, mock_instance):
         self._setup_data_labeler_mock(mock_instance)
         data = pd.Series(["1", "2", "3", "4"], dtype=object)


### PR DESCRIPTION
This PR adds options to load_from_dict to:
* low level column profilers
* compilers
* options
* adds a test to validate passing of data_labeler through options from a higher level.