### PR TITLE
Reuse passed labeler

### DIFF
--- a/dataprofiler/profilers/data_labeler_column_profile.py
+++ b/dataprofiler/profilers/data_labeler_column_profile.py
@@ -308,44 +308,28 @@ class DataLabelerColumn(BaseColumnProfiler["DataLabelerColumn"]):
         return profile
 
     @classmethod
-    def load_from_dict(cls, data, options: dict | None = None) -> DataLabelerColumn:
+    def load_from_dict(cls, data, config: dict | None = None) -> DataLabelerColumn:
         """
         Parse attribute from json dictionary into self.
 
         :param data: dictionary with attributes and values.
         :type data: dict[string, Any]
-        :param options: options for loading column profiler params from dictionary
-        :type options: Dict | None
+        :param config: config for loading column profiler params from dictionary
+        :type config: Dict | None
 
         :return: Profiler with attributes populated.
         :rtype: DataLabelerColumn
         """
         opt = DataLabelerOptions()
+        data_labeler_object = None
+
         data_labeler_load_attr = data.pop("data_labeler")
-        if "from_library" in data_labeler_load_attr:
-            data_labeler_object = (
-                (
-                    options.get(cls.__name__, {})
-                    .get("from_library", {})
-                    .get(data_labeler_load_attr["from_library"])
-                )
-                if options is not None
-                else None
+        if data_labeler_load_attr:
+            data_labeler_object = utils.reload_labeler_from_options_or_get_new(
+                data_labeler_load_attr, config
             )
-            if data_labeler_object is None:
-                data_labeler_object = DataLabeler.load_from_library(
-                    data_labeler_load_attr["from_library"]
-                )
-            opt.data_labeler_object = data_labeler_object
-        elif "from_disk" in data_labeler_load_attr:
-            raise NotImplementedError(
-                "Models intialized from disk have not yet been made deserializable"
-            )
-        else:
-            raise ValueError(
-                "Deserialization cannot be done on labelers without "
-                "_default_model_loc set to known value."
-            )
+            if data_labeler_object is not None:
+                opt.data_labeler_object = data_labeler_object
 
         # This is an ambiguous call to super classes.
         # If load_from_dict is part of both super classes there may be issues

--- a/dataprofiler/profilers/json_decoder.py
+++ b/dataprofiler/profilers/json_decoder.py
@@ -118,7 +118,7 @@ def get_structured_col_profiler_class(class_name: str) -> type[StructuredColProf
 
 
 def load_column_profile(
-    serialized_json: dict, options: dict | None = None
+    serialized_json: dict, config: dict | None = None
 ) -> BaseColumnProfiler:
     """
     Construct subclass of BaseColumnProfiler given a serialized JSON.
@@ -137,8 +137,8 @@ def load_column_profile(
         # serialized using the custom encoder in profilers.json_encoder
     :type serialized_json: a dict that was created by calling json.loads on
         a JSON representation using the custom encoder
-    :param options: options for loading column profiler params from dictionary
-    :type options: Dict | None
+    :param config: config for overriding data params when loading from dict
+    :type config: Dict | None
 
     :return: subclass of BaseColumnProfiler that has been deserialized from
         JSON
@@ -147,11 +147,11 @@ def load_column_profile(
     column_profiler_cls: type[
         BaseColumnProfiler[BaseColumnProfiler]
     ] = get_column_profiler_class(serialized_json["class"])
-    return column_profiler_cls.load_from_dict(serialized_json["data"], options)
+    return column_profiler_cls.load_from_dict(serialized_json["data"], config)
 
 
 def load_compiler(
-    serialized_json: dict, options: dict | None = None
+    serialized_json: dict, config: dict | None = None
 ) -> col_pro_compiler.BaseCompiler:
     """
     Construct subclass of BaseCompiler given a serialized JSON.
@@ -170,8 +170,8 @@ def load_compiler(
         serialized using the custom encoder in profilers.json_encoder
     :type serialized_json: a dict that was created by calling json.loads on
         a JSON representation using the custom encoder
-    :param options: options for loading column compiler params from dictionary
-    :type options: Dict | None
+    :param config: config for overriding data params when loading from dict
+    :type config: Dict | None
     :return: subclass of BaseCompiler that has been deserialized from
         JSON
 
@@ -179,10 +179,10 @@ def load_compiler(
     column_profiler_cls: type[col_pro_compiler.BaseCompiler] = get_compiler_class(
         serialized_json["class"]
     )
-    return column_profiler_cls.load_from_dict(serialized_json["data"], options)
+    return column_profiler_cls.load_from_dict(serialized_json["data"], config)
 
 
-def load_option(serialized_json: dict, options: dict | None = None) -> BaseOption:
+def load_option(serialized_json: dict, config: dict | None = None) -> BaseOption:
     """
     Construct subclass of BaseOption given a serialized JSON.
 
@@ -200,17 +200,17 @@ def load_option(serialized_json: dict, options: dict | None = None) -> BaseOptio
         serialized using the custom encoder in profilers.json_encoder
     :type serialized_json: a dict that was created by calling json.loads on
         a JSON representation using the custom encoder
-    :param options: options for loading column profiler params from dictionary
-    :type options: Dict | None
+    :param config: config for overriding data params when loading from dict
+    :type config: Dict | None
     :return: subclass of BaseOption that has been deserialized from
         JSON
 
     """
     option_cls: type[BaseOption] = get_option_class(serialized_json["class"])
-    return option_cls.load_from_dict(serialized_json["data"], options)
+    return option_cls.load_from_dict(serialized_json["data"], config)
 
 
-def load_profiler(serialized_json: dict, options=None) -> BaseProfiler:
+def load_profiler(serialized_json: dict, config=None) -> BaseProfiler:
     """
     Construct subclass of BaseProfiler given a serialized JSON.
 
@@ -228,14 +228,18 @@ def load_profiler(serialized_json: dict, options=None) -> BaseProfiler:
         serialized using the custom encoder in profilers.json_encoder
     :type serialized_json: a dict that was created by calling json.loads on
         a JSON representation using the custom encoder
+    :param config: config for overriding data params when loading from dict
+    :type config: Dict | None
     :return: subclass of BaseProfiler that has been deserialized from
         JSON
     """
     profiler_cls: type[BaseProfiler] = get_profiler_class(serialized_json["class"])
-    return profiler_cls.load_from_dict(serialized_json["data"], options)
+    return profiler_cls.load_from_dict(serialized_json["data"], config)
 
 
-def load_structured_col_profiler(serialized_json: dict) -> StructuredColProfiler:
+def load_structured_col_profiler(
+    serialized_json: dict, config: dict | None = None
+) -> StructuredColProfiler:
     """
     Construct subclass of BaseProfiler given a serialized JSON.
 
@@ -252,10 +256,12 @@ def load_structured_col_profiler(serialized_json: dict) -> StructuredColProfiler
         serialized using the custom encoder in profilers.json_encoder
     :type serialized_json: a dict that was created by calling json.loads on
         a JSON representation using the custom encoder
+    :param config: config for overriding data params when loading from dict
+    :type config: Dict | None
     :return: subclass of BaseCompiler that has been deserialized from
         JSON
     """
     profiler_cls: type[StructuredColProfiler] = get_structured_col_profiler_class(
         serialized_json["class"]
     )
-    return profiler_cls.load_from_dict(serialized_json["data"])
+    return profiler_cls.load_from_dict(serialized_json["data"], config)

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -867,12 +867,14 @@ class BaseProfiler:
         raise NotImplementedError()
 
     @classmethod
-    def load_from_dict(cls: type[BaseProfilerT], data, options) -> BaseProfilerT:
+    def load_from_dict(cls: type[BaseProfilerT], data, config) -> BaseProfilerT:
         """
         Parse attribute from json dictionary into self.
 
         :param data: dictionary with attributes and values.
         :type data: dict[string, Any]
+        :param config: config for overriding data params when loading from dict
+        :type config: Dict | None
 
         :return: Profiler with attributes populated.
         :rtype: BaseProfiler
@@ -884,9 +886,9 @@ class BaseProfiler:
                 value = defaultdict(float, value)
             if "_profile" == attr:
                 for idx, profile in enumerate(value):
-                    value[idx] = load_structured_col_profiler(profile)
+                    value[idx] = load_structured_col_profiler(profile, config)
             if "options" == attr:
-                value = load_option(value, options)
+                value = load_option(value, config)
 
             setattr(profiler, attr, value)
         return profiler

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -1082,13 +1082,12 @@ class DataLabelerOptions(BaseInspectorOptions["DataLabelerOptions"]):
         """
         data_labeler_object = None
         data_labeler_load_attr = data.pop("data_labeler_object", {})
-
-        data_labeler_object = utils.reload_labeler_from_options_or_get_new(
-            data_labeler_load_attr, config
-        )
-
-        if data_labeler_object:
-            data["data_labeler_object"] = data_labeler_object
+        if data_labeler_load_attr:
+            data_labeler_object = utils.reload_labeler_from_options_or_get_new(
+                data_labeler_load_attr, config
+            )
+            if data_labeler_object:
+                data["data_labeler_object"] = data_labeler_object
 
         dl_options = cast(DataLabelerOptions, super().load_from_dict(data))
         return dl_options

--- a/dataprofiler/profilers/profiler_options.py
+++ b/dataprofiler/profilers/profiler_options.py
@@ -8,10 +8,9 @@ import re
 import warnings
 from typing import Generic, TypeVar, cast
 
-from dataprofiler.profilers.json_decoder import load_option
-
 from ..labelers.base_data_labeler import BaseDataLabeler
-from ..labelers.data_labelers import DataLabeler
+from . import utils
+from .json_decoder import load_option
 
 BaseOptionT = TypeVar("BaseOptionT", bound="BaseOption")
 BooleanOptionT = TypeVar("BooleanOptionT", bound="BooleanOption")
@@ -148,14 +147,14 @@ class BaseOption(Generic[BaseOptionT]):
         return None
 
     @classmethod
-    def load_from_dict(cls, data, options: dict | None = None) -> BaseOption:
+    def load_from_dict(cls, data, config: dict | None = None) -> BaseOption:
         """
         Parse attribute from json dictionary into self.
 
         :param data: dictionary with attributes and values.
         :type data: dict[string, Any]
-        :param options: options for loading options params from dictionary
-        :type options: Dict | None
+        :param config: config to override loading options params from dictionary
+        :type config: Dict | None
 
         :return: Options with attributes populated.
         :rtype: BaseOption
@@ -164,7 +163,7 @@ class BaseOption(Generic[BaseOptionT]):
 
         for attr, value in data.items():
             if isinstance(value, dict) and "class" in value:
-                value = load_option(value)
+                value = load_option(value, config)
             setattr(option, attr, value)
 
         return option
@@ -1068,38 +1067,30 @@ class DataLabelerOptions(BaseInspectorOptions["DataLabelerOptions"]):
     def load_from_dict(
         cls,
         data,
-        options: dict | None = None,
+        config: dict | None = None,
     ) -> DataLabelerOptions:
         """
         Parse attribute from json dictionary into self.
 
         :param data: dictionary with attributes and values.
         :type data: dict[string, Any]
+        :param config: config to override loading options params from dictionary
+        :type config: Dict | None
 
         :return: Profiler with attributes populated.
-        :rtype: BaseOption
+        :rtype: DataLabelerOptions
         """
         data_labeler_object = None
-        data_labeler_load_attr = data.pop("data_labeler_object")
-        if (
-            data_labeler_load_attr is not None
-            and "from_library" in data_labeler_load_attr
-        ):
-            data_labeler_object = (
-                (
-                    options.get(cls.__name__, {})
-                    .get("from_library", {})
-                    .get(data_labeler_load_attr["from_library"])
-                )
-                if options is not None
-                else None
-            )
-            if data_labeler_object is None:
-                data_labeler_object = DataLabeler.load_from_library(
-                    data_labeler_load_attr["from_library"]
-                )
+        data_labeler_load_attr = data.pop("data_labeler_object", {})
+
+        data_labeler_object = utils.reload_labeler_from_options_or_get_new(
+            data_labeler_load_attr, config
+        )
+
+        if data_labeler_object:
+            data["data_labeler_object"] = data_labeler_object
+
         dl_options = cast(DataLabelerOptions, super().load_from_dict(data))
-        dl_options.data_labeler_object = data_labeler_object
         return dl_options
 
 

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -885,9 +885,4 @@ def reload_labeler_from_options_or_get_new(
         raise NotImplementedError(
             "Models intialized from disk have not yet been made deserializable"
         )
-    else:
-        raise ValueError(
-            "Deserialization cannot be done on labelers without "
-            "_default_model_loc set to known value."
-        )
     return data_labeler_object

--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -843,7 +843,7 @@ def reload_labeler_from_options_or_get_new(
     :return: Profiler with attributes populated.
     :rtype: DataLabelerOptions
     """
-    data_labeler_object = None
+    data_labeler_object: BaseDataLabeler | None = None
     if "from_library" in data_labeler_load_attr:
         data_labeler_object = (
             (
@@ -881,4 +881,13 @@ def reload_labeler_from_options_or_get_new(
                 libray_options.update(labeler_options)
                 class_options["from_library"] = libray_options
                 config[class_name] = class_options
+    elif "from_disk" in data_labeler_load_attr:
+        raise NotImplementedError(
+            "Models intialized from disk have not yet been made deserializable"
+        )
+    else:
+        raise ValueError(
+            "Deserialization cannot be done on labelers without "
+            "_default_model_loc set to known value."
+        )
     return data_labeler_object

--- a/dataprofiler/tests/profilers/profiler_options/test_datalabeler_options.py
+++ b/dataprofiler/tests/profilers/profiler_options/test_datalabeler_options.py
@@ -3,8 +3,10 @@ import json
 from unittest import mock
 
 from dataprofiler.labelers.base_data_labeler import BaseDataLabeler
+from dataprofiler.profilers.json_decoder import load_option
 from dataprofiler.profilers.json_encoder import ProfileEncoder
 from dataprofiler.profilers.profiler_options import DataLabelerOptions
+from dataprofiler.tests.profilers import utils as test_utils
 from dataprofiler.tests.profilers.profiler_options.test_base_inspector_options import (
     TestBaseInspectorOptions,
 )
@@ -175,12 +177,9 @@ class TestDataLabelerOptions(TestBaseInspectorOptions):
     def test_json_encode(self):
         option = DataLabelerOptions()
 
-        with mock.patch(
-            "dataprofiler.labelers.base_data_labeler.BaseDataLabeler",
-            spec=BaseDataLabeler,
-        ) as BaseDataLabelerMock:
-            BaseDataLabelerMock._default_model_loc = "test_loc"
-            option.data_labeler_object = BaseDataLabelerMock
+        mock_BaseDataLabeler = mock.Mock(spec=BaseDataLabeler)
+        mock_BaseDataLabeler._default_model_loc = "test_loc"
+        option.data_labeler_object = mock_BaseDataLabeler
 
         serialized = json.dumps(option, cls=ProfileEncoder)
 
@@ -195,3 +194,56 @@ class TestDataLabelerOptions(TestBaseInspectorOptions):
         }
 
         self.assertDictEqual(expected, json.loads(serialized))
+
+    @mock.patch(
+        "dataprofiler.profilers.utils.DataLabeler",
+        spec=BaseDataLabeler,
+    )
+    def test_json_decode(self, mock_BaseDataLabeler):
+        expected_options = self.get_options()
+
+        serialized = json.dumps(expected_options, cls=ProfileEncoder)
+        deserialized = load_option(json.loads(serialized))
+
+        test_utils.assert_profiles_equal(deserialized, expected_options)
+
+        # case where labeler exists but no config
+        mock_BaseDataLabeler._default_model_loc = "test_loc"
+        expected_options.data_labeler_object = mock_BaseDataLabeler
+        mock_BaseDataLabeler.load_from_library.return_value = mock_BaseDataLabeler
+        config = {}
+
+        serialized = json.dumps(expected_options, cls=ProfileEncoder)
+        deserialized = load_option(json.loads(serialized), config)
+        test_utils.assert_profiles_equal(deserialized, expected_options)
+
+        expected_config = {
+            "DataLabelerOptions": {"from_library": {"test_loc": mock_BaseDataLabeler}},
+            "DataLabelerColumn": {"from_library": {"test_loc": mock_BaseDataLabeler}},
+        }
+        self.assertDictEqual(expected_config, config)
+
+        mock_BaseDataLabeler.load_from_library.reset_mock()
+        mock_BaseDataLabeler.load_from_library.return_value = None
+        deserialized = load_option(json.loads(serialized), config)
+
+        mock_BaseDataLabeler.load_from_library.assert_not_called()
+        test_utils.assert_profiles_equal(deserialized, expected_options)
+
+        config = {
+            "DataLabelerColumn": {"from_library": {"test_loc": mock_BaseDataLabeler}}
+        }
+        deserialized = load_option(json.loads(serialized), config)
+
+        mock_BaseDataLabeler.load_from_library.assert_not_called()
+        test_utils.assert_profiles_equal(deserialized, expected_options)
+        self.assertDictEqual(expected_config, config)
+
+        config = {
+            "DataLabelerOptions": {"from_library": {"test_loc": mock_BaseDataLabeler}}
+        }
+        deserialized = load_option(json.loads(serialized), config)
+
+        mock_BaseDataLabeler.load_from_library.assert_not_called()
+        test_utils.assert_profiles_equal(deserialized, expected_options)
+        self.assertDictEqual(expected_config, config)

--- a/dataprofiler/tests/profilers/test_data_labeler_column_profile.py
+++ b/dataprofiler/tests/profilers/test_data_labeler_column_profile.py
@@ -486,8 +486,10 @@ class TestDataLabelerColumnProfiler(unittest.TestCase):
 
         self.assertEqual(expected, serialized)
 
-    def test_json_decode(self, mock_instance):
-        self._setup_data_labeler_mock(mock_instance)
+    @mock.patch("dataprofiler.profilers.utils.DataLabeler", spec=BaseDataLabeler)
+    def test_json_decode(self, mock_utils_DataLabeler, mock_BaseDataLabeler):
+        self._setup_data_labeler_mock(mock_BaseDataLabeler)
+        mock_utils_DataLabeler.load_from_library.side_effect = mock_BaseDataLabeler
 
         data = pd.Series(["1", "2", "3", "4"], dtype=object)
         expected = DataLabelerColumn(data.name)
@@ -503,19 +505,35 @@ class TestDataLabelerColumnProfiler(unittest.TestCase):
         new_mock_data_labeler = mock.Mock(spec=BaseDataLabeler)
         new_mock_data_labeler.name = "new fake data labeler"
         new_mock_data_labeler._default_model_loc = "my/fake/path"
-        options = {
+        config = {
             "DataLabelerColumn": {
                 "from_library": {"structured_model": new_mock_data_labeler}
             }
         }
 
-        mock_instance.reset_mock()  # set to 0 calls as option should override
-        deserialized = load_column_profile(json.loads(serialized), options)
+        mock_BaseDataLabeler.reset_mock()  # set to 0 calls as option should override
+        mock_utils_DataLabeler.reset_mock()  # set to 0 calls as option should override
+        deserialized = load_column_profile(json.loads(serialized), config)
         assert deserialized.data_labeler == new_mock_data_labeler
-        mock_instance.assert_not_called()
+        mock_BaseDataLabeler.assert_not_called()
+        mock_utils_DataLabeler.assert_not_called()
 
-    def test_json_decode_after_update(self, mock_instance):
-        self._setup_data_labeler_mock(mock_instance)
+        # validate raises error when cannot properly load data.
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "Models intialized from disk have not yet been made deserializable",
+        ):
+            class_as_dict = json.loads(serialized)
+            class_as_dict["data"]["data_labeler"] = {"from_disk": "test"}
+            deserialized = load_column_profile(class_as_dict, config)
+
+    @mock.patch("dataprofiler.profilers.utils.DataLabeler", spec=BaseDataLabeler)
+    def test_json_decode_after_update(
+        self, mock_utils_DataLabeler, mock_BaseDataLabeler
+    ):
+        self._setup_data_labeler_mock(mock_BaseDataLabeler)
+        mock_utils_DataLabeler.load_from_library.side_effect = mock_BaseDataLabeler
+
         data = pd.Series(["1", "2", "3", "4"], dtype=object)
         expected = DataLabelerColumn(data.name)
         expected.data_labeler._default_model_loc = "structured_model"

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -2320,7 +2320,6 @@ class TestStructuredProfiler(unittest.TestCase):
 
         serialized = json.dumps(expected_profile, cls=ProfileEncoder)
         deserialized = load_profiler(json.loads(serialized))
-        mock_DataLabeler.load_from_library.assert_called_once()
 
         test_utils.assert_profiles_equal(deserialized, expected_profile)
 

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -2297,13 +2297,9 @@ class TestStructuredProfiler(unittest.TestCase):
         mock_DataLabeler.load_from_library = mock_labeler
         mock_utils_DataLabeler.load_from_library = mock_labeler
         mock_DataLabeler.return_value = mock_labeler
-        # mock_labeler = mock_DataLabeler.return_value
         mock_labeler._default_model_loc = "structured_model"
         mock_labeler.model.num_labels = 2
         mock_labeler.reverse_label_mapping = {1: "a", 2: "b"}
-        # mock_DataLabeler.load_from_library.return_value = mock_labeler
-        # mock_utils_DataLabeler.load_from_library = mock_labeler
-        # mock_DataLabeler.return_value = mock_DataLabeler
 
         fake_profile_name = None
         df_structured = pd.DataFrame([["1.5", "a", "4"], ["3.0", "z", 7]])

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -2933,7 +2933,11 @@ class TestStructuredColProfilerClass(unittest.TestCase):
         "dataprofiler.profilers.data_labeler_column_profile.DataLabeler",
         spec=BaseDataLabeler,
     )
-    def test_json_decode(self, mock_DataLabeler, *mocks):
+    @mock.patch(
+        "dataprofiler.profilers.utils.DataLabeler",
+        spec=BaseDataLabeler,
+    )
+    def test_json_decode(self, mock_utils_DataLabeler, mock_DataLabeler, *mocks):
         mock_labeler = mock.Mock(spec=BaseDataLabeler)
         mock_labeler._default_model_loc = "test"
         mock_DataLabeler.load_from_library = mock_labeler
@@ -2950,12 +2954,19 @@ class TestStructuredColProfilerClass(unittest.TestCase):
         "dataprofiler.profilers.data_labeler_column_profile.DataLabeler",
         spec=BaseDataLabeler,
     )
-    def test_json_decode_after_update(self, mock_DataLabeler, *mocks):
+    @mock.patch(
+        "dataprofiler.profilers.utils.DataLabeler",
+        spec=BaseDataLabeler,
+    )
+    def test_json_decode_after_update(
+        self, mock_utils_DataLabeler, mock_DataLabeler, *mocks
+    ):
         mock_labeler = mock_DataLabeler.return_value
         mock_labeler._default_model_loc = "test"
         mock_labeler.model.num_labels = 2
         mock_labeler.reverse_label_mapping = {1: "a", 2: "b"}
         mock_DataLabeler.load_from_library.return_value = mock_labeler
+        mock_utils_DataLabeler.load_from_library.return_value = mock_labeler
 
         # Build expected StructuredColProfiler
         df_float = pd.Series([-1.5, None, 5.0, 7.0, 4.0, 3.0, "NaN", 0, 0, 9.0]).apply(


### PR DESCRIPTION
This PR does a little refactoring and allows the user to pass a dict or config, stopping the system from recreating a labeler at each level.
*  Refactors the loading of labeler to utils
* options and labeler col use the utils func
* updated some options -> config
* fixed tests in structured profiler
* validated rework with new tests