### PR TITLE
Profile Builder `load()` serialization

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1169,7 +1169,15 @@ class BaseProfiler:
         """
         # Load profile from disk
         with open(filepath, "rb") as infile:
-            data: dict = pickle.load(infile)
+
+            if filepath.endswith(".json"):
+                data: dict = json.load(infile)
+            elif filepath.endswith((".pickle", ".pkl")):
+                data = pickle.load(infile)
+            else:
+                raise ValueError(
+                    "Invalid file format. Supported formats are JSON and pickle."
+                )
 
         # remove profiler class if it exists
         profiler_class: str | None = data.pop("profiler_class", None)
@@ -1586,6 +1594,18 @@ class UnstructuredProfiler(BaseProfiler):
             self._json_save_helper(filepath)
         else:
             raise ValueError('save_method must be "json" or "pickle".')
+
+    def load(self, filepath: str) -> BaseProfiler:
+        """
+        Load Profiler from disk.
+
+        :param filepath: Path of file to load from
+        :return: Profiler being loaded, StructuredProfiler or
+            UnstructuredProfiler
+        :rtype: BaseProfiler
+        """
+        # Create dictionary for all metadata, options, and profile
+        raise NotImplementedError()
 
 
 class StructuredProfiler(BaseProfiler):

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -1608,18 +1608,6 @@ class UnstructuredProfiler(BaseProfiler):
         else:
             raise ValueError('save_method must be "json" or "pickle".')
 
-    # def load(self, filepath: str, load_method: str | None) -> BaseProfiler:
-    #     """
-    #     Load Profiler from disk.
-
-    #     :param filepath: Path of file to load from
-    #     :return: Profiler being loaded, StructuredProfiler or
-    #         UnstructuredProfiler
-    #     :rtype: BaseProfiler
-    #     """
-    #     # Create dictionary for all metadata, options, and profile
-    #     raise NotImplementedError()
-
 
 class StructuredProfiler(BaseProfiler):
     """For profiling structured data."""

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1581,13 +1581,8 @@ class TestStructuredProfiler(unittest.TestCase):
             save_profile.save()
 
             mock_file.seek(0)
-<<<<<<< HEAD
-            with mock.patch("dataprofiler.profilers.profile_builder.DataLabeler"):
-                load_profile = dp.StructuredProfiler.load("mock.pkl")
-=======
             with mock.patch("dataprofiler.profilers.profile_builder." "DataLabeler"):
                 load_profile = dp.StructuredProfiler.load("mock.pkl", "pickle")
->>>>>>> 1e68306 (refactor w/ load_method option, test json load)
 
         # Check that reports are equivalent
         save_report = test_utils.clean_report(save_profile.report())

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1494,7 +1494,7 @@ class TestStructuredProfiler(unittest.TestCase):
                     "dataprofiler.profilers.profile_builder.DataLabeler",
                     return_value=data_labeler,
                 ):
-                    load_profile = dp.StructuredProfiler.load("mock.pkl")
+                    load_profile = dp.StructuredProfiler.load("mock.pkl", "pickle")
 
                 # validate loaded profile has same data labeler class
                 self.assertIsInstance(
@@ -1517,6 +1517,55 @@ class TestStructuredProfiler(unittest.TestCase):
             load_report = test_utils.clean_report(load_profile.report())
             np.testing.assert_equal(save_report, load_report)
 
+    def test_save_and_load_json_file(self):
+        datapth = "dataprofiler/tests/data/"
+        test_files = ["csv/iris.csv"]
+
+        for test_file in test_files:
+            # Create Data and StructuredProfiler objects
+            data = dp.Data(os.path.join(datapth, test_file))
+            options = ProfilerOptions()
+            options.set(
+                {
+                    "correlation.is_enabled": True,
+                    "null_replication_metrics.is_enabled": True,
+                    "multiprocess.is_enabled": False,
+                }
+            )
+            save_profile = dp.StructuredProfiler(data, options=options)
+
+            # store the expected data_labeler
+            data_labeler = save_profile.options.data_labeler.data_labeler_object
+
+            # Save and Load profile with Mock IO
+            with mock.patch("builtins.open") as m:
+                mock_file = setup_save_mock_string_open(m)
+                save_profile.save(save_method="json")
+                mock_file.seek(0)
+                with mock.patch(
+                    "dataprofiler.profilers.utils.DataLabeler.load_from_library",
+                    return_value=data_labeler,
+                ):
+                    load_profile = dp.StructuredProfiler.load("mock.json", "json")
+
+                # validate loaded profile has same data labeler class
+                self.assertIsInstance(
+                    load_profile.options.data_labeler.data_labeler_object,
+                    data_labeler.__class__,
+                )
+
+                # only checks first columns
+                # get first column
+                first_column_profile = load_profile.profile[0]
+                self.assertIsInstance(
+                    first_column_profile.profiles["data_label_profile"]
+                    ._profiles["data_labeler"]
+                    .data_labeler,
+                    data_labeler.__class__,
+                )
+
+            test_utils.assert_profiles_equal(save_profile, load_profile)
+
     def test_save_and_load_no_labeler(self):
         # Create Data and UnstructuredProfiler objects
         data = pd.DataFrame([1, 2, 3], columns=["a"])
@@ -1532,8 +1581,13 @@ class TestStructuredProfiler(unittest.TestCase):
             save_profile.save()
 
             mock_file.seek(0)
+<<<<<<< HEAD
             with mock.patch("dataprofiler.profilers.profile_builder.DataLabeler"):
                 load_profile = dp.StructuredProfiler.load("mock.pkl")
+=======
+            with mock.patch("dataprofiler.profilers.profile_builder." "DataLabeler"):
+                load_profile = dp.StructuredProfiler.load("mock.pkl", "pickle")
+>>>>>>> 1e68306 (refactor w/ load_method option, test json load)
 
         # Check that reports are equivalent
         save_report = test_utils.clean_report(save_profile.report())
@@ -3468,6 +3522,7 @@ class TestUnstructuredProfiler(unittest.TestCase):
         ):
             UnstructuredProfiler.load_from_dict({}, None)
 
+    @mock.patch("builtins.open")
     def test_save_json_file(self, *mocks):
         data = pd.Series(["this", "is my", "\n\r", "test"])
         save_profile = UnstructuredProfiler(data)
@@ -3941,7 +3996,7 @@ class TestUnstructuredProfilerWData(unittest.TestCase):
         self.assertIn("vocab", report["data_stats"]["statistics"])
         self.assertIn("words", report["data_stats"]["statistics"])
 
-    def test_save_and_load_pkl(self):
+    def test_save_and_load_pkl_file(self):
         data_folder = "dataprofiler/tests/data/"
         test_files = ["txt/code.txt", "txt/sentence-10x.txt"]
 


### PR DESCRIPTION
- expands BaseProfiler load function to support both pickle and json by checking the file extension first. 
- Unstructuredprofiler raised a NotImplementedError() on it's load()