### PR TITLE
refactor: use seed for sample for consistency

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
+import os
 import pickle
 import random
 import re
@@ -18,7 +19,7 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 
-from .. import data_readers, dp_logging
+from .. import data_readers, dp_logging, settings
 from ..data_readers.data import Data
 from ..labelers.base_data_labeler import BaseDataLabeler
 from ..labelers.data_labelers import DataLabeler
@@ -647,11 +648,22 @@ class StructuredColProfiler:
         df_series = df_series.loc[true_sample_list]
         total_na = total_sample_size - len(true_sample_list)
 
+        rng = np.random.default_rng(settings._seed)
+
+        if "DATAPROFILER_SEED" in os.environ and settings._seed is None:
+            seed = os.environ.get("DATAPROFILER_SEED")
+            if isinstance(seed, int):
+                rng = np.random.default_rng(int(seed))
+            else:
+                warnings.warn("Seed should be an integer", RuntimeWarning)
+
         base_stats = {
             "sample_size": total_sample_size,
             "null_count": total_na,
             "null_types": na_columns,
-            "sample": random.sample(list(df_series.values), min(len(df_series), 5)),
+            "sample": rng.choice(
+                list(df_series.values), (min(len(df_series), 5),), replace=False
+            ).tolist(),
             "min_id": min_id,
             "max_id": max_id,
         }

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1491,7 +1491,7 @@ class TestStructuredProfiler(unittest.TestCase):
                 save_profile.save()
                 mock_file.seek(0)
                 with mock.patch(
-                    "dataprofiler.profilers.profile_builder." "DataLabeler",
+                    "dataprofiler.profilers.profile_builder.DataLabeler",
                     return_value=data_labeler,
                 ):
                     load_profile = dp.StructuredProfiler.load("mock.pkl")
@@ -1532,7 +1532,7 @@ class TestStructuredProfiler(unittest.TestCase):
             save_profile.save()
 
             mock_file.seek(0)
-            with mock.patch("dataprofiler.profilers.profile_builder." "DataLabeler"):
+            with mock.patch("dataprofiler.profilers.profile_builder.DataLabeler"):
                 load_profile = dp.StructuredProfiler.load("mock.pkl")
 
         # Check that reports are equivalent
@@ -1545,7 +1545,7 @@ class TestStructuredProfiler(unittest.TestCase):
         load_profile.update_profile(pd.DataFrame({"a": [4, 5]}))
 
     @mock.patch(
-        "dataprofiler.profilers.data_labeler_column_profile." "DataLabelerColumn.update"
+        "dataprofiler.profilers.data_labeler_column_profile.DataLabelerColumn.update"
     )
     @mock.patch(
         "dataprofiler.profilers.profile_builder.DataLabeler",
@@ -1578,9 +1578,9 @@ class TestStructuredProfiler(unittest.TestCase):
 
         # Save and Load profile with Mock IO
         with mock.patch("builtins.open") as mock_open, mock.patch(
-            "dataprofiler.profilers.profile_builder." "datetime"
-        ) as time_out:
-            time_out.now().strftime.return_value = "now"
+            "dataprofiler.profilers.profile_builder.datetime"
+        ) as mock_pb_datetime:
+            mock_pb_datetime.now().strftime.return_value = "now"
             mock_file = setup_save_mock_string_open(mock_open)
             save_profile.save("output/mock.json", "json")
             mock_file.seek(0)
@@ -1623,9 +1623,9 @@ class TestStructuredProfiler(unittest.TestCase):
 
         # do a second call without a specified file path
         with mock.patch("builtins.open") as mock_open, mock.patch(
-            "dataprofiler.profilers.profile_builder." "datetime"
-        ) as time_out:
-            time_out.now().strftime.return_value = "now"
+            "dataprofiler.profilers.profile_builder.datetime"
+        ) as mock_pb_datetime:
+            mock_pb_datetime.now().strftime.return_value = "now"
             setup_save_mock_string_open(mock_open)
             save_profile.save(save_method="json")
 


### PR DESCRIPTION
This PR:
 * refactors to use seed when sampling for consistency
 * Fixes structuredprofiler tests to include for corr, null_mat, chi2
 * fixes decorators to make things faster