### PR TITLE
fix: null_rep mat should calculate even if datetime

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -2469,7 +2469,7 @@ class StructuredProfiler(BaseProfiler):
         total_row_sum = np.asarray(
             [
                 get_data_type_profiler(profile).sum
-                if get_data_type(profile)
+                if get_data_type(profile) not in [None, "datetime"]
                 else np.nan
                 for profile in self._profile
             ]


### PR DESCRIPTION
This PR fixes a bug:
* null mats would cause errors if datetime col was computed for null mat matrix
* add test to validate it can handle datetime