### PR TITLE
fix: order bug

### DIFF
--- a/dataprofiler/profilers/order_column_profile.py
+++ b/dataprofiler/profilers/order_column_profile.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Protocol, TypeVar
+from typing import Protocol, Type, TypeVar, cast
 
 import numpy as np
 from pandas import DataFrame, Series
@@ -22,6 +22,10 @@ class Comparable(Protocol):
 
 
 CT = TypeVar("CT", bound=Comparable)
+
+# bc type in class attr causing issues, need to alias
+AliasFloatType = Type[np.float64]
+AliasStrType = Type[str]
 
 
 class OrderColumn(BaseColumnProfiler["OrderColumn"]):
@@ -49,6 +53,7 @@ class OrderColumn(BaseColumnProfiler["OrderColumn"]):
         self.order: str | None = None
         self._last_value: np.float64 | float | str | None = None
         self._first_value: np.float64 | float | str | None = None
+        self._data_store_type: AliasStrType | AliasFloatType = np.float64
         self._piecewise: bool | None = False
         self.__calculations: dict = {}
         self._filter_properties_w_options(self.__calculations, options)
@@ -131,39 +136,54 @@ class OrderColumn(BaseColumnProfiler["OrderColumn"]):
         order1: str,
         first_value1: CT,
         last_value1: CT,
+        data_store_type1: AliasStrType | AliasFloatType,
         piecewise1: bool,
         order2: str,
         first_value2: CT,
         last_value2: CT,
+        data_store_type2: AliasStrType | AliasFloatType,
         piecewise2: bool,
-    ) -> tuple[str, CT | None, CT | None, bool]:
+    ) -> tuple[str, CT | None, CT | None, bool, AliasStrType | AliasFloatType]:
         """
         Add the order of two datasets together.
 
         :param order1: order of original dataset
         :param first_value1: beginning value of original dataset
         :param last_value1: last value of original dataset
+        :param data_store_type1: type of value for first_value1 and last_value1
         :param piecewise1: original dataset is piecewise or not
         :param order2: order of new dataset
         :param first_value2: beginning value of new dataset
         :param last_value2: last value of new dataset
+        :param data_store_type2: type of value for first_value2 and last_value2
         :param piecewise2: new dataset is piecewise or not
         :type order1: String
         :type first_value1: Float | String
         :type last_value1: Float | String
         :type piecewise1: Boolean
+        :type data_store_type1: Type[str] | Type[np.float64]
         :type order2: String
         :type first_value2: Float | String
         :type last_value2: Float | String
+        :type data_store_type2: Type[str] | Type[np.float64]
         :type piecewise2: Boolean
-        :return: order, first_value, last_value, piecewise
-        :rtype: String, Float | String, Float | String, Boolean
+        :return: order, first_value, last_value, piecewise, merged_data_store_type
+        :rtype: String, Float | String, Float | String, Boolean, Type[str]
+            | Type[np.float64]
         """
         # Return either order if one is None
         if not order1:
-            return order2, first_value2, last_value2, piecewise2
+            return order2, first_value2, last_value2, piecewise2, data_store_type2
         elif not order2:
-            return order1, first_value1, last_value1, piecewise1
+            return order1, first_value1, last_value1, piecewise1, data_store_type1
+
+        merged_data_store_type: AliasStrType | AliasFloatType = np.float64
+        if data_store_type1 is str or data_store_type2 is str:
+            first_value1 = cast(CT, str(first_value1))
+            last_value1 = cast(CT, str(last_value1))
+            first_value2 = cast(CT, str(first_value2))
+            last_value2 = cast(CT, str(last_value2))
+            merged_data_store_type = str
 
         is_intersecting = self._is_intersecting(
             first_value1, last_value1, first_value2, last_value2
@@ -239,7 +259,7 @@ class OrderColumn(BaseColumnProfiler["OrderColumn"]):
         ) or order == "random":
             piecewise = False
 
-        return order, first_value, last_value, piecewise
+        return order, first_value, last_value, piecewise, merged_data_store_type
 
     def __add__(self, other: OrderColumn) -> OrderColumn:
         """
@@ -259,14 +279,16 @@ class OrderColumn(BaseColumnProfiler["OrderColumn"]):
             )
 
         merged_profile = OrderColumn(None)
-        order, first_value, last_value, piecewise = self._merge_order(
+        order, first_value, last_value, piecewise, data_store_type = self._merge_order(
             self.order,
             self._first_value,
             self._last_value,
+            self._data_store_type,
             self._piecewise,
             other.order,
             other._first_value,
             other._last_value,
+            other._data_store_type,
             other._piecewise,
         )
 
@@ -274,6 +296,7 @@ class OrderColumn(BaseColumnProfiler["OrderColumn"]):
         merged_profile._first_value = first_value
         merged_profile._last_value = last_value
         merged_profile._piecewise = piecewise
+        merged_profile._data_store_type = data_store_type
 
         BaseColumnProfiler._add_helper(merged_profile, self, other)
         self._merge_calculations(
@@ -305,9 +328,12 @@ class OrderColumn(BaseColumnProfiler["OrderColumn"]):
         :rtype: CategoricalColumn
         """
         # This is an ambiguous call to super classes.
+        data["_data_store_type"] = (
+            str if data["_data_store_type"] == "str" else np.float64
+        )
         profile = super().load_from_dict(data)
         try:
-            if profile.sample_size:
+            if profile.sample_size and profile._data_store_type is np.float64:
                 profile._first_value = np.float64(profile._first_value)
                 profile._last_value = np.float64(profile._last_value)
         except ValueError:
@@ -342,7 +368,9 @@ class OrderColumn(BaseColumnProfiler["OrderColumn"]):
         return differences
 
     @BaseColumnProfiler._timeit(name="order")
-    def _get_data_order(self, df_series: Series) -> tuple[str, float, float]:
+    def _get_data_order(
+        self, df_series: Series, data_store_type: AliasStrType | AliasFloatType
+    ) -> tuple[str, float, float, AliasStrType | AliasFloatType]:
         """
         Retrieve the order profile of a given data series.
 
@@ -351,20 +379,22 @@ class OrderColumn(BaseColumnProfiler["OrderColumn"]):
 
         :param df_series: a given column
         :type df_series: pandas.core.series.Series
-        :return: order, first_value, last_value
-        :rtype: String, Float, Float
+        :param data_store_type: type of value for first_value and last_value
+        :type data_store_type: Type[str] | Type[np.float64]
+        :return: order, first_value, last_value, data_store_type
+        :rtype: String, Float, Float, type, Type[str] | Type[np.float64]
         """
         try:
-            df_series = df_series.astype(float)
+            if data_store_type is not str:
+                df_series = df_series.astype(float)
         except ValueError:
-            pass
+            data_store_type = str
 
         order = None
         last_value = df_series.iloc[0]
         first_value = df_series.iloc[0]
 
-        for i in range(1, len(df_series)):
-            value = df_series.iloc[i]
+        for value in df_series.values:
             if value < last_value and order == "ascending":
                 order = "random"
                 break
@@ -379,7 +409,7 @@ class OrderColumn(BaseColumnProfiler["OrderColumn"]):
         if not order:
             order = "constant value"
 
-        return order, first_value, last_value
+        return order, first_value, last_value, data_store_type
 
     def _update_order(
         self,
@@ -407,21 +437,26 @@ class OrderColumn(BaseColumnProfiler["OrderColumn"]):
         """
         if self.order == "random":
             return
-        order, first_value, last_value = self._get_data_order(df_series)
+        order, first_value, last_value, data_store_type = self._get_data_order(
+            df_series, self._data_store_type
+        )
 
         (
             self.order,
             self._first_value,
             self._last_value,
             self._piecewise,
+            self._data_store_type,
         ) = self._merge_order(
             self.order,
             self._first_value,
             self._last_value,
+            self._data_store_type,
             self._piecewise,
             order,
             first_value,
             last_value,
+            data_store_type,
             piecewise2=False,
         )
 

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -898,7 +898,8 @@ class BaseProfiler:
         :return: Profiler with attributes populated.
         :rtype: BaseProfiler
         """
-        profiler = cls(None)
+        options = load_option(data["options"], config)
+        profiler = cls(None, options=options)
 
         for attr, value in data.items():
             if "times" == attr:
@@ -907,7 +908,7 @@ class BaseProfiler:
                 for idx, profile in enumerate(value):
                     value[idx] = load_structured_col_profiler(profile, config)
             if "options" == attr:
-                value = load_option(value, config)
+                continue
 
             setattr(profiler, attr, value)
         return profiler

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -1521,7 +1521,7 @@ class TestStructuredProfiler(unittest.TestCase):
 
     def test_save_and_load_json_file(self):
         datapth = "dataprofiler/tests/data/"
-        test_files = ["csv/iris.csv"]
+        test_files = ["csv/guns.csv", "csv/iris.csv"]
 
         for test_file in test_files:
             # Create Data and StructuredProfiler objects


### PR DESCRIPTION
If a str in the middle of numbers forced conversion to a str, this would cause failures.

This fixes it and adds tests

Also fixes bug in profiler when loading to not load model multiple times