### PR TITLE
None-check labels dependants

### DIFF
--- a/dataprofiler/labelers/data_processing.py
+++ b/dataprofiler/labelers/data_processing.py
@@ -735,8 +735,8 @@ class CharPreprocessor(BaseDataPreprocessor, metaclass=AutoSubRegistrationMeta):
             X_train = np.array(
                 [[sentence] for sentence in batch_data["samples"]], dtype=object
             )
-            if labels is not None:
-                num_classes = max(label_mapping.values()) + 1  # type: ignore
+            if labels is not None and label_mapping is not None:
+                num_classes = max(label_mapping.values()) + 1
 
                 Y_train = tf.keras.utils.to_categorical(
                     batch_data["labels"], num_classes
@@ -1503,8 +1503,12 @@ class StructCharPreprocessor(CharPreprocessor, metaclass=AutoSubRegistrationMeta
                 unstructured_label_set,
             ) = self.convert_to_unstructured_format(batch_data, batch_labels)
             unstructured_data[ind] = unstructured_text
-            if labels is not None:
-                unstructured_labels[ind] = unstructured_label_set  # type: ignore
+            if (
+                labels is not None
+                and unstructured_labels is not None
+                and unstructured_label_set is not None
+            ):
+                unstructured_labels[ind] = unstructured_label_set
 
         if labels is not None:
             np_unstruct_labels = np.array(unstructured_labels, dtype="object")


### PR DESCRIPTION
The mypy errors addressed here occur because variables `label_mapping` (in `CharPreprocessor.process()`), `unstructured_labels`, and `unstructured_label_set` (in `StructCharPreprocessor.process()`) have optional types when they're used. This is fixed by checking that they are not `None` prior to the operation, which mypy recognizes as removing the `None` type from them.

This should have no effect on functionality because we are already checking that `labels` is not `None`, and the variables above all depend on `labels` such that they are `None` only if `labels` is `None`.