### PR TITLE
Changed `publish-python-package.yml` to include only release branches.

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -6,6 +6,7 @@ name: Publish Python Package
 
 on:
   release:
+    types: [created]
     branches:
       - 'release/*'
 

--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -6,7 +6,8 @@ name: Publish Python Package
 
 on:
   release:
-    types: [created]
+    branches:
+      - 'release/*'
 
 jobs:
   deploy:


### PR DESCRIPTION
Currently, `publish-python-package.yml` releases any branch of DataProfiler on creation of the branch. This is undesirable. We want to only release the branches named `release/<version>`. To do this, we edit `publish-python-package.yml`. Next step after this is to add the branches, but first must ensure that this workflow works and is safe.

For reference, here are documentations for the changes:
 - https://docs.github.com/en/actions/using-workflows/triggering-a-workflow
 This one lets us specify a branch
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onevent_nametypes
 This one details how to make events trigger releases