### PR TITLE
Fix ProfilerOptions() documentation 

### DIFF
--- a/docs/0.10.2/doctrees/nbsphinx/profiler_example.ipynb
+++ b/docs/0.10.2/doctrees/nbsphinx/profiler_example.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f37ca393",
    "metadata": {},
@@ -9,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ff9bd095",
    "metadata": {},
@@ -32,6 +34,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "de58b9c4",
    "metadata": {},
@@ -40,6 +43,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8001185a",
    "metadata": {},
@@ -166,6 +170,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d7ec39d2",
    "metadata": {},
@@ -193,6 +198,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "241f6e3e",
    "metadata": {},
@@ -201,6 +207,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5b20879b",
    "metadata": {},
@@ -227,6 +234,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "fe02ad64",
    "metadata": {},
@@ -235,6 +243,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "40804cc9",
    "metadata": {},
@@ -245,7 +254,7 @@
     "\n",
     "Below, let's remove the histogram and increase the number of samples to the labeler component (1,000 samples). \n",
     "\n",
-    "Full list of options in the Profiler section of the [DataProfiler documentation](https://capitalone.github.io/DataProfiler)."
+    "Full list of options in the Profiler section of the [DataProfiler documentation](https://capitalone.github.io/DataProfiler/docs/0.10.2/html/profiler.html#profile-options)."
    ]
   },
   {
@@ -276,6 +285,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2052415a",
    "metadata": {},
@@ -284,6 +294,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7e02f746",
    "metadata": {},
@@ -320,6 +331,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "66ec6dc5",
    "metadata": {},
@@ -328,6 +340,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e2265fe9",
    "metadata": {},
@@ -362,6 +375,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7ea07dc6",
    "metadata": {},
@@ -370,6 +384,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "375ff25c-b189-436a-b07d-5e7f13cc6e03",
    "metadata": {},
@@ -404,6 +419,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2ae471ff-852f-400a-9bee-5c9fef96f10a",
    "metadata": {},
@@ -462,6 +478,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "30868000",
    "metadata": {},
@@ -470,6 +487,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f2858072",
    "metadata": {},
@@ -502,6 +520,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8f9859c2",
    "metadata": {},

--- a/docs/0.10.2/doctrees/nbsphinx/unstructured_profiler_example.ipynb
+++ b/docs/0.10.2/doctrees/nbsphinx/unstructured_profiler_example.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f37ca393",
    "metadata": {},
@@ -9,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ff9bd095",
    "metadata": {},
@@ -32,6 +34,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "de58b9c4",
    "metadata": {},
@@ -40,6 +43,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8001185a",
    "metadata": {},
@@ -125,6 +129,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4d183992",
    "metadata": {},
@@ -133,6 +138,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d7ec39d2",
    "metadata": {},
@@ -160,6 +166,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "fe02ad64",
    "metadata": {},
@@ -168,6 +175,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "40804cc9",
    "metadata": {},
@@ -178,7 +186,7 @@
     "\n",
     "Below, let's remove the vocab count and set the stop words. \n",
     "\n",
-    "Full list of options in the Profiler section of the [DataProfiler documentation](https://capitalone.github.io/DataProfiler)."
+    "Full list of options in the Profiler section of the [DataProfiler documentation](https://capitalone.github.io/DataProfiler/docs/0.10.2/html/profiler.html#profile-options)."
    ]
   },
   {
@@ -209,6 +217,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2052415a",
    "metadata": {},
@@ -217,6 +226,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7e02f746",
    "metadata": {},
@@ -249,6 +259,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "66ec6dc5",
    "metadata": {},
@@ -257,6 +268,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e2265fe9",
    "metadata": {},
@@ -288,6 +300,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7ea07dc6",
    "metadata": {},
@@ -296,6 +309,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4704961a",
    "metadata": {},
@@ -327,6 +341,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "30868000",
    "metadata": {},
@@ -335,6 +350,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f2858072",
    "metadata": {},
@@ -367,6 +383,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8f9859c2",
    "metadata": {},

--- a/docs/0.10.2/html/profiler_example.html
+++ b/docs/0.10.2/html/profiler_example.html
@@ -385,7 +385,7 @@
 <p>The DataProfiler has the ability to turn on and off components as needed. This is accomplished via the <code class="docutils literal notranslate"><span class="pre">ProfilerOptions</span></code> class.</p>
 <p>For example, if a user doesn’t require histogram information they may desire to turn off the histogram functionality. Simialrly, if a user is looking for a more accurate labeling, they can increase the samples used to label.</p>
 <p>Below, let’s remove the histogram and increase the number of samples to the labeler component (1,000 samples).</p>
-<p>Full list of options in the Profiler section of the <a class="reference external" href="https://capitalone.github.io/DataProfiler">DataProfiler documentation</a>.</p>
+<p>Full list of options in the Profiler section of the <a class="reference external" href="https://capitalone.github.io/DataProfiler/docs/0.10.2/html/profiler.html#profile-options">DataProfiler documentation</a>.</p>
 <div class="nbinput nblast docutils container">
 <div class="prompt highlight-none notranslate"><div class="highlight"><pre><span></span>[ ]:
 </pre></div>

--- a/docs/0.10.2/html/profiler_example.ipynb
+++ b/docs/0.10.2/html/profiler_example.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f37ca393",
    "metadata": {},
@@ -9,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ff9bd095",
    "metadata": {},
@@ -32,6 +34,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "de58b9c4",
    "metadata": {},
@@ -40,6 +43,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8001185a",
    "metadata": {},
@@ -166,6 +170,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d7ec39d2",
    "metadata": {},
@@ -193,6 +198,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "241f6e3e",
    "metadata": {},
@@ -201,6 +207,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5b20879b",
    "metadata": {},
@@ -227,6 +234,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "fe02ad64",
    "metadata": {},
@@ -235,6 +243,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "40804cc9",
    "metadata": {},
@@ -245,7 +254,7 @@
     "\n",
     "Below, let's remove the histogram and increase the number of samples to the labeler component (1,000 samples). \n",
     "\n",
-    "Full list of options in the Profiler section of the [DataProfiler documentation](https://capitalone.github.io/DataProfiler)."
+    "Full list of options in the Profiler section of the [DataProfiler documentation](https://capitalone.github.io/DataProfiler/docs/0.10.2/html/profiler.html#profile-options)."
    ]
   },
   {
@@ -276,6 +285,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2052415a",
    "metadata": {},
@@ -284,6 +294,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7e02f746",
    "metadata": {},
@@ -320,6 +331,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "66ec6dc5",
    "metadata": {},
@@ -328,6 +340,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e2265fe9",
    "metadata": {},
@@ -362,6 +375,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7ea07dc6",
    "metadata": {},
@@ -370,6 +384,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "375ff25c-b189-436a-b07d-5e7f13cc6e03",
    "metadata": {},
@@ -404,6 +419,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2ae471ff-852f-400a-9bee-5c9fef96f10a",
    "metadata": {},
@@ -462,6 +478,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "30868000",
    "metadata": {},
@@ -470,6 +487,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f2858072",
    "metadata": {},
@@ -502,6 +520,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8f9859c2",
    "metadata": {},

--- a/docs/0.10.2/html/unstructured_profiler_example.html
+++ b/docs/0.10.2/html/unstructured_profiler_example.html
@@ -331,7 +331,7 @@
 <p>The DataProfiler has the ability to turn on and off components as needed. This is accomplished via the <code class="docutils literal notranslate"><span class="pre">ProfilerOptions</span></code> class.</p>
 <p>For example, if a user doesn’t require vocab count information they may desire to turn off the word count functionality.</p>
 <p>Below, let’s remove the vocab count and set the stop words.</p>
-<p>Full list of options in the Profiler section of the <a class="reference external" href="https://capitalone.github.io/DataProfiler">DataProfiler documentation</a>.</p>
+<p>Full list of options in the Profiler section of the <a class="reference external" href="https://capitalone.github.io/DataProfiler/docs/0.10.2/html/profiler.html#profile-options">DataProfiler documentation</a>.</p>
 <div class="nbinput nblast docutils container">
 <div class="prompt highlight-none notranslate"><div class="highlight"><pre><span></span>[ ]:
 </pre></div>

--- a/docs/0.10.2/html/unstructured_profiler_example.ipynb
+++ b/docs/0.10.2/html/unstructured_profiler_example.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f37ca393",
    "metadata": {},
@@ -9,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ff9bd095",
    "metadata": {},
@@ -32,6 +34,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "de58b9c4",
    "metadata": {},
@@ -40,6 +43,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8001185a",
    "metadata": {},
@@ -125,6 +129,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4d183992",
    "metadata": {},
@@ -133,6 +138,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d7ec39d2",
    "metadata": {},
@@ -160,6 +166,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "fe02ad64",
    "metadata": {},
@@ -168,6 +175,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "40804cc9",
    "metadata": {},
@@ -178,7 +186,7 @@
     "\n",
     "Below, let's remove the vocab count and set the stop words. \n",
     "\n",
-    "Full list of options in the Profiler section of the [DataProfiler documentation](https://capitalone.github.io/DataProfiler)."
+    "Full list of options in the Profiler section of the [DataProfiler documentation](https://capitalone.github.io/DataProfiler/docs/0.10.2/html/profiler.html#profile-options)."
    ]
   },
   {
@@ -209,6 +217,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2052415a",
    "metadata": {},
@@ -217,6 +226,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7e02f746",
    "metadata": {},
@@ -249,6 +259,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "66ec6dc5",
    "metadata": {},
@@ -257,6 +268,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e2265fe9",
    "metadata": {},
@@ -288,6 +300,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7ea07dc6",
    "metadata": {},
@@ -296,6 +309,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4704961a",
    "metadata": {},
@@ -327,6 +341,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "30868000",
    "metadata": {},
@@ -335,6 +350,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f2858072",
    "metadata": {},
@@ -367,6 +383,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8f9859c2",
    "metadata": {},


### PR DESCRIPTION
Fixed a bad link.

Issue #689:
The hyperlink in the below sentence in the [Profiler options](https://capitalone.github.io/DataProfiler/docs/0.8.1/html/profiler_example.html#Profiler-options) section of the Data Profiler documentation needs to link to better documentation for more in-depth options documentation.