### PR TITLE
Fix ProfilerOptions() documentation

### DIFF
--- a/examples/structured_profilers.ipynb
+++ b/examples/structured_profilers.ipynb
@@ -245,7 +245,7 @@
     "\n",
     "Below, let's remove the histogram and increase the number of samples to the labeler component (1,000 samples). \n",
     "\n",
-    "Full list of options in the Profiler section of the [DataProfiler documentation](https://capitalone.github.io/DataProfiler)."
+    "Full list of options in the Profiler section of the [DataProfiler documentation](https://capitalone.github.io/DataProfiler/docs/0.10.2/html/profiler.html#profile-options)."
    ]
   },
   {

--- a/examples/unstructured_profilers.ipynb
+++ b/examples/unstructured_profilers.ipynb
@@ -178,7 +178,7 @@
     "\n",
     "Below, let's remove the vocab count and set the stop words. \n",
     "\n",
-    "Full list of options in the Profiler section of the [DataProfiler documentation](https://capitalone.github.io/DataProfiler)."
+    "Full list of options in the Profiler section of the [DataProfiler documentation](https://capitalone.github.io/DataProfiler/docs/0.10.2/html/profiler.html#profile-options)."
    ]
   },
   {


### PR DESCRIPTION
Fixed a bad link.

Issue #689:
The hyperlink in the below sentence in the [Profiler options](https://capitalone.github.io/DataProfiler/docs/0.8.1/html/profiler_example.html#Profiler-options) section of the Data Profiler documentation needs to link to better documentation for more in-depth options documentation.