### PR TITLE
fixed snappy install issue on Mac

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -28,7 +28,7 @@ MacOS with homebrew:
 
 .. code-block:: console
 
-    brew install snappy
+    brew install snappy && CPPFLAGS="-I/usr/local/include -L/usr/local/lib" pip install python-snappy
 
 
 Linux install:


### PR DESCRIPTION
Fixed issue #970 

Problem Statement
Current documentation step does not yield successful setup of snappy.
Section referenced in documentation - https://capitalone.github.io/DataProfiler/docs/0.10.1/html/install.html#snappy-installation

Proposed Solution
Update documentation as per the official procedure on python-snappy.
Reference - https://github.com/andrix/python-snappy#frequently-asked-questions

brew install snappy && CPPFLAGS="-I/usr/local/include -L/usr/local/lib" pip install python-snappy