### PR TITLE
Refactor `_assimilate_histogram` and `_regenerate_histogram`

### DIFF
--- a/dataprofiler/profilers/histogram_utils.py
+++ b/dataprofiler/profilers/histogram_utils.py
@@ -8,7 +8,7 @@ A copy of the license for numpy is available here:
 https://github.com/numpy/numpy/blob/main/LICENSE.txt
 """
 import operator
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from numpy.lib.histograms import (  # type: ignore[attr-defined]
@@ -356,7 +356,7 @@ def _assimilate_histogram(
     dest_hist_entity_count_per_bin: np.ndarray,
     dest_hist_bin_edges: np.ndarray,
     dest_hist_num_bin: int,
-) -> tuple[dict[str, np.ndarray[Any, Any]], float]:
+) -> Tuple[Dict[str, np.ndarray[Any, Any]], float]:
     """
     Assimilates a histogram into another histogram using specifications.
 
@@ -435,7 +435,7 @@ def _assimilate_histogram(
 
 def _regenerate_histogram(
     entity_count_per_bin, bin_edges, suggested_bin_count, options=None
-) -> tuple[dict[str, np.ndarray], float]:
+) -> Tuple[Dict[str, np.ndarray], float]:
 
     # create proper binning
     new_bin_counts = np.zeros((suggested_bin_count,))

--- a/dataprofiler/profilers/histogram_utils.py
+++ b/dataprofiler/profilers/histogram_utils.py
@@ -8,7 +8,7 @@ A copy of the license for numpy is available here:
 https://github.com/numpy/numpy/blob/main/LICENSE.txt
 """
 import operator
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from numpy.lib.histograms import (  # type: ignore[attr-defined]
@@ -356,7 +356,7 @@ def _assimilate_histogram(
     dest_hist_entity_count_per_bin: np.ndarray,
     dest_hist_bin_edges: np.ndarray,
     dest_hist_num_bin: int,
-) -> Tuple[Dict[str, np.ndarray[Any, Any]], float]:
+) -> Tuple[Dict[str, np.ndarray], float]:
     """
     Assimilates a histogram into another histogram using specifications.
 

--- a/dataprofiler/profilers/histogram_utils.py
+++ b/dataprofiler/profilers/histogram_utils.py
@@ -356,7 +356,6 @@ def _assimilate_histogram(
     dest_hist_entity_count_per_bin: np.ndarray,
     dest_hist_bin_edges: np.ndarray,
     dest_hist_num_bin: int,
-    is_float_profile: bool,
 ) -> tuple[dict[str, np.ndarray[Any, Any]], float]:
     """
     Assimilates a histogram into another histogram using specifications.
@@ -375,8 +374,6 @@ def _assimilate_histogram(
     :type dest_hist_bin_edges: List[Tuple[float]]
     :param dest_hist_num_bin: The number of bins desired for histogram
     :type dest_hist_num_bin: int
-    :param is_float_profile: Whether values in bins are floats
-    :type is_float_profile: bool
     :return: Tuple containing dictionary of histogram info and histogram loss
     """
     # allocate bin_counts
@@ -387,10 +384,6 @@ def _assimilate_histogram(
             continue
 
         bin_edge = from_hist_bin_edges[bin_id : bin_id + 3]
-
-        # if we know not float, we can assume values in bins are integers.
-        if not is_float_profile:
-            bin_edge = np.round(bin_edge)
 
         # loop until we have a new bin which contains the current bin.
         while (
@@ -441,7 +434,7 @@ def _assimilate_histogram(
 
 
 def _regenerate_histogram(
-    entity_count_per_bin, bin_edges, suggested_bin_count, is_float_profile, options=None
+    entity_count_per_bin, bin_edges, suggested_bin_count, options=None
 ) -> tuple[dict[str, np.ndarray], float]:
 
     # create proper binning
@@ -457,5 +450,4 @@ def _regenerate_histogram(
         dest_hist_entity_count_per_bin=new_bin_counts,
         dest_hist_bin_edges=new_bin_edges,
         dest_hist_num_bin=suggested_bin_count,
-        is_float_profile=is_float_profile,
     )

--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -234,7 +234,6 @@ class NumericStatsMixin(BaseColumnProfiler[NumericStatsMixinT], metaclass=abc.AB
             dest_hist_entity_count_per_bin=new_entity_count_by_bin,
             dest_hist_bin_edges=ideal_bin_edges,
             dest_hist_num_bin=ideal_count_of_bins,
-            is_float_profile=self.__class__.__name__ == "FloatColumn",
         )
 
         # Ensure loss is calculated on second run of regenerate
@@ -246,7 +245,6 @@ class NumericStatsMixin(BaseColumnProfiler[NumericStatsMixinT], metaclass=abc.AB
             dest_hist_entity_count_per_bin=new_entity_count_by_bin,
             dest_hist_bin_edges=ideal_bin_edges,
             dest_hist_num_bin=ideal_count_of_bins,
-            is_float_profile=self.__class__.__name__ == "FloatColumn",
         )
 
         aggregate_histogram_loss = hist_loss1 + hist_loss2
@@ -712,7 +710,6 @@ class NumericStatsMixin(BaseColumnProfiler[NumericStatsMixinT], metaclass=abc.AB
                     entity_count_per_bin=self_histogram["bin_counts"],
                     bin_edges=self_histogram["bin_edges"],
                     suggested_bin_count=num_psi_bins,
-                    is_float_profile=self.__class__.__name__ == "FloatColumn",
                     options={
                         "min_edge": min_min_edge,
                         "max_edge": max_max_edge,
@@ -734,7 +731,6 @@ class NumericStatsMixin(BaseColumnProfiler[NumericStatsMixinT], metaclass=abc.AB
                     entity_count_per_bin=other_histogram["bin_counts"],
                     bin_edges=other_histogram["bin_edges"],
                     suggested_bin_count=num_psi_bins,
-                    is_float_profile=self.__class__.__name__ == "FloatColumn",
                     options={
                         "min_edge": min_min_edge,
                         "max_edge": max_max_edge,
@@ -1404,7 +1400,6 @@ class NumericStatsMixin(BaseColumnProfiler[NumericStatsMixinT], metaclass=abc.AB
             entity_count_per_bin=bin_counts,
             bin_edges=bin_edges,
             suggested_bin_count=suggested_bin_count,
-            is_float_profile=self.__class__.__name__ == "FloatColumn",
         )
 
     def _get_best_histogram_for_profile(self) -> dict:


### PR DESCRIPTION
Issue: https://github.com/capitalone/DataProfiler/issues/820

The functions `_assimilate_histogram` and `_regenerate_histogram` are refactored as directed in the issue. Additionally, `_assimilate_histogram` no longer rounds bin edges, as this feature doesn't seem necessary and adds an additional argument to `_assimilate_histogram`.