### PR TITLE
Delay transforming priority_order into ndarray

### DIFF
--- a/dataprofiler/labelers/data_processing.py
+++ b/dataprofiler/labelers/data_processing.py
@@ -2047,9 +2047,9 @@ class RegexPostProcessor(BaseDataPostprocessor, metaclass=AutoSubRegistrationMet
         elif aggregation_func == "random":
             num_labels = max(label_mapping.values()) + 1
             random_state: random.Random = self._parameters["random_state"]
-            priority_order = np.array(list(range(num_labels)))
-            random_state.shuffle(priority_order)  # type: ignore
-            self.priority_prediction(results, priority_order)
+            priority_order = list(range(num_labels))
+            random_state.shuffle(priority_order)
+            self.priority_prediction(results, np.array(priority_order))
         else:
             raise ValueError(
                 f"`{aggregation_func}` is not a valid aggregation function"


### PR DESCRIPTION
Issue: https://github.com/capitalone/DataProfiler/issues/722

In the changed code, we had a mypy error because numpy `ndarray`s are not compatible with `random.Random.shuffle()` (expected argument type is `MutableSequence[Any]`)

We fix this by first instantiating `priority_order` as a list, then shuffling it, then creating an ndarray from it afterwards.