### PR TITLE
Rename references to degree of freedom from df to deg_of_free

### DIFF
--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -611,8 +611,8 @@ class NumericStatsMixin(BaseColumnProfiler[NumericStatsMixinT], metaclass=abc.AB
     ) -> dict:
         results: dict = {
             "t-statistic": None,
-            "conservative": {"df": None, "p-value": None},
-            "welch": {"df": None, "p-value": None},
+            "conservative": {"deg_of_free": None, "p-value": None},
+            "welch": {"deg_of_free": None, "p-value": None},
         }
 
         invalid_stats = False
@@ -647,17 +647,17 @@ class NumericStatsMixin(BaseColumnProfiler[NumericStatsMixinT], metaclass=abc.AB
 
         s_delta = var1 / n1 + var2 / n2
         t = (mean1 - mean2) / np.sqrt(s_delta)
-        conservative_df = min(n1, n2) - 1
-        welch_df = s_delta**2 / (
+        conservative_deg_of_free = min(n1, n2) - 1
+        welch_deg_of_free = s_delta**2 / (
             (var1 / n1) ** 2 / (n1 - 1) + (var2 / n2) ** 2 / (n2 - 1)
         )
         results["t-statistic"] = t
-        results["conservative"]["df"] = float(conservative_df)
-        results["welch"]["df"] = float(welch_df)
+        results["conservative"]["deg_of_free"] = float(conservative_deg_of_free)
+        results["welch"]["deg_of_free"] = float(welch_deg_of_free)
 
-        conservative_t = scipy.stats.t(conservative_df)
+        conservative_t = scipy.stats.t(conservative_deg_of_free)
         conservative_p_val = (1 - conservative_t.cdf(abs(t))) * 2
-        welch_t = scipy.stats.t(welch_df)
+        welch_t = scipy.stats.t(welch_deg_of_free)
         welch_p_val = (1 - welch_t.cdf(abs(t))) * 2
 
         results["conservative"]["p-value"] = float(conservative_p_val)

--- a/dataprofiler/profilers/profiler_utils.py
+++ b/dataprofiler/profilers/profiler_utils.py
@@ -739,7 +739,7 @@ def perform_chi_squared_test_for_homogeneity(
     """
     results: dict[str, int | float | None] = {
         "chi2-statistic": None,
-        "df": None,
+        "deg_of_free": None,
         "p-value": None,
     }
 
@@ -758,8 +758,8 @@ def perform_chi_squared_test_for_homogeneity(
 
     # Calculate degrees of freedom
     # df = (rows - 1) * (cols - 1), in the case of two groups reduces to cols - 1
-    df = num_cats - 1
-    results["df"] = df
+    deg_of_free = num_cats - 1
+    results["deg_of_free"] = deg_of_free
 
     total = sample_size1 + sample_size2
 
@@ -781,7 +781,7 @@ def perform_chi_squared_test_for_homogeneity(
     results["chi2-statistic"] = chi2_statistic
 
     # Calculate p-value, i.e. P(X > chi2_statistic)
-    p_value: float = 1 - scipy.stats.chi2(df).cdf(chi2_statistic)
+    p_value: float = 1 - scipy.stats.chi2(deg_of_free).cdf(chi2_statistic)
     results["p-value"] = p_value
 
     return results

--- a/dataprofiler/tests/profilers/test_categorical_column_profile.py
+++ b/dataprofiler/tests/profilers/test_categorical_column_profile.py
@@ -724,7 +724,7 @@ class TestCategoricalColumn(unittest.TestCase):
                 "categorical_count": {"y": 1, "n": 1, "maybe": -2},
                 "chi2-test": {
                     "chi2-statistic": 82 / 35,
-                    "df": 2,
+                    "deg_of_free": 2,
                     "p-value": 0.3099238764710244,
                 },
                 "psi": 0.0990210257942779,
@@ -774,7 +774,7 @@ class TestCategoricalColumn(unittest.TestCase):
                 "unique_ratio": -0.05357142857142855,
                 "chi2-test": {
                     "chi2-statistic": 0.6122448979591839,
-                    "df": 2,
+                    "deg_of_free": 2,
                     "p-value": 0.7362964551863367,
                 },
                 "categories": "unchanged",

--- a/dataprofiler/tests/profilers/test_column_profile_compilers.py
+++ b/dataprofiler/tests/profilers/test_column_profile_compilers.py
@@ -231,7 +231,10 @@ class TestColumnPrimitiveTypeProfileCompiler(unittest.TestCase):
                 "t-test": {
                     "t-statistic": 0.4155260166386663,
                     "conservative": {"deg_of_free": 1.0, "p-value": 0.749287157907667},
-                    "welch": {"deg_of_free": 3.6288111187629117, "p-value": 0.7011367179395704},
+                    "welch": {
+                        "deg_of_free": 3.6288111187629117,
+                        "p-value": 0.7011367179395704,
+                    },
                 },
                 "psi": 0.17328679513998632,
             },
@@ -322,8 +325,14 @@ class TestColumnPrimitiveTypeProfileCompiler(unittest.TestCase):
                 },
                 "t-test": {
                     "t-statistic": -1.9674775073518591,
-                    "conservative": {"deg_of_free": 1.0, "p-value": 0.29936264581081673},
-                    "welch": {"deg_of_free": 1.0673824509440946, "p-value": 0.28696889329266506},
+                    "conservative": {
+                        "deg_of_free": 1.0,
+                        "p-value": 0.29936264581081673,
+                    },
+                    "welch": {
+                        "deg_of_free": 1.0673824509440946,
+                        "p-value": 0.28696889329266506,
+                    },
                 },
                 "psi": 0,
             },

--- a/dataprofiler/tests/profilers/test_column_profile_compilers.py
+++ b/dataprofiler/tests/profilers/test_column_profile_compilers.py
@@ -230,8 +230,8 @@ class TestColumnPrimitiveTypeProfileCompiler(unittest.TestCase):
                 "stddev": 3.285085839971525,
                 "t-test": {
                     "t-statistic": 0.4155260166386663,
-                    "conservative": {"df": 1.0, "p-value": 0.749287157907667},
-                    "welch": {"df": 3.6288111187629117, "p-value": 0.7011367179395704},
+                    "conservative": {"deg_of_free": 1.0, "p-value": 0.749287157907667},
+                    "welch": {"deg_of_free": 3.6288111187629117, "p-value": 0.7011367179395704},
                 },
                 "psi": 0.17328679513998632,
             },
@@ -322,8 +322,8 @@ class TestColumnPrimitiveTypeProfileCompiler(unittest.TestCase):
                 },
                 "t-test": {
                     "t-statistic": -1.9674775073518591,
-                    "conservative": {"df": 1.0, "p-value": 0.29936264581081673},
-                    "welch": {"df": 1.0673824509440946, "p-value": 0.28696889329266506},
+                    "conservative": {"deg_of_free": 1.0, "p-value": 0.29936264581081673},
+                    "welch": {"deg_of_free": 1.0673824509440946, "p-value": 0.28696889329266506},
                 },
                 "psi": 0,
             },
@@ -503,7 +503,7 @@ class TestColumnStatsProfileCompiler(unittest.TestCase):
                 "categorical_count": {"9": -1, "1": 1, "10": -1},
                 "chi2-test": {
                     "chi2-statistic": 2.1,
-                    "df": 2,
+                    "deg_of_free": 2,
                     "p-value": 0.3499377491111554,
                 },
                 "psi": 0.009815252971365292,

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -1704,7 +1704,10 @@ class TestFloatColumn(unittest.TestCase):
             "t-test": {
                 "t-statistic": 0.5393164101529813,
                 "conservative": {"deg_of_free": 2.0, "p-value": 0.643676756587475},
-                "welch": {"deg_of_free": 4.999127432888682, "p-value": 0.6128117908944144},
+                "welch": {
+                    "deg_of_free": 4.999127432888682,
+                    "p-value": 0.6128117908944144,
+                },
             },
             "psi": 0,
         }

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -1703,8 +1703,8 @@ class TestFloatColumn(unittest.TestCase):
             },
             "t-test": {
                 "t-statistic": 0.5393164101529813,
-                "conservative": {"df": 2.0, "p-value": 0.643676756587475},
-                "welch": {"df": 4.999127432888682, "p-value": 0.6128117908944144},
+                "conservative": {"deg_of_free": 2.0, "p-value": 0.643676756587475},
+                "welch": {"deg_of_free": 4.999127432888682, "p-value": 0.6128117908944144},
             },
             "psi": 0,
         }

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -1062,8 +1062,8 @@ class TestIntColumn(unittest.TestCase):
             "median_absolute_deviation": -5,
             "t-test": {
                 "t-statistic": -0.5638091828819275,
-                "conservative": {"df": 1.0, "p-value": 0.6731699660830497},
-                "welch": {"df": 1.0547717074524683, "p-value": 0.6691886269547123},
+                "conservative": {"deg_of_free": 1.0, "p-value": 0.6731699660830497},
+                "welch": {"deg_of_free": 1.0547717074524683, "p-value": 0.6691886269547123},
             },
             "psi": 0.0675775180180274,
         }

--- a/dataprofiler/tests/profilers/test_int_column_profile.py
+++ b/dataprofiler/tests/profilers/test_int_column_profile.py
@@ -1063,7 +1063,10 @@ class TestIntColumn(unittest.TestCase):
             "t-test": {
                 "t-statistic": -0.5638091828819275,
                 "conservative": {"deg_of_free": 1.0, "p-value": 0.6731699660830497},
-                "welch": {"deg_of_free": 1.0547717074524683, "p-value": 0.6691886269547123},
+                "welch": {
+                    "deg_of_free": 1.0547717074524683,
+                    "p-value": 0.6691886269547123,
+                },
             },
             "psi": 0.0675775180180274,
         }

--- a/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
+++ b/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
@@ -868,8 +868,8 @@ class TestNumericStatsMixin(unittest.TestCase):
             "stddev": np.sqrt(10 / 9) - np.sqrt(9 * 20 / 19),
             "t-test": {
                 "t-statistic": 0.3923009049186606,
-                "conservative": {"df": 9, "p-value": 0.7039643545772609},
-                "welch": {"df": 25.945257024943864, "p-value": 0.6980401261750298},
+                "conservative": {"deg_of_free": 9, "p-value": 0.7039643545772609},
+                "welch": {"deg_of_free": 25.945257024943864, "p-value": 0.6980401261750298},
             },
             "psi": None,
         }
@@ -909,8 +909,8 @@ class TestNumericStatsMixin(unittest.TestCase):
             "stddev": np.nan,
             "t-test": {
                 "t-statistic": None,
-                "conservative": {"df": None, "p-value": None},
-                "welch": {"df": None, "p-value": None},
+                "conservative": {"deg_of_free": None, "p-value": None},
+                "welch": {"deg_of_free": None, "p-value": None},
             },
             "psi": None,
         }
@@ -959,8 +959,8 @@ class TestNumericStatsMixin(unittest.TestCase):
             "stddev": np.nan,
             "t-test": {
                 "t-statistic": None,
-                "conservative": {"df": None, "p-value": None},
-                "welch": {"df": None, "p-value": None},
+                "conservative": {"deg_of_free": None, "p-value": None},
+                "welch": {"deg_of_free": None, "p-value": None},
             },
             "psi": None,
         }
@@ -1008,8 +1008,8 @@ class TestNumericStatsMixin(unittest.TestCase):
             "stddev": 0,
             "t-test": {
                 "t-statistic": None,
-                "conservative": {"df": None, "p-value": None},
-                "welch": {"df": None, "p-value": None},
+                "conservative": {"deg_of_free": None, "p-value": None},
+                "welch": {"deg_of_free": None, "p-value": None},
             },
             "psi": None,
         }
@@ -1056,8 +1056,8 @@ class TestNumericStatsMixin(unittest.TestCase):
             "stddev": np.sqrt(10 / 9) - np.sqrt(9 * 20 / 19),
             "t-test": {
                 "t-statistic": -3.138407239349285,
-                "conservative": {"df": 9, "p-value": 0.011958658754358975},
-                "welch": {"df": 25.945257024943864, "p-value": 0.004201616692122823},
+                "conservative": {"deg_of_free": 9, "p-value": 0.011958658754358975},
+                "welch": {"deg_of_free": 25.945257024943864, "p-value": 0.004201616692122823},
             },
             "psi": None,
         }

--- a/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
+++ b/dataprofiler/tests/profilers/test_numeric_stats_mixin_profile.py
@@ -869,7 +869,10 @@ class TestNumericStatsMixin(unittest.TestCase):
             "t-test": {
                 "t-statistic": 0.3923009049186606,
                 "conservative": {"deg_of_free": 9, "p-value": 0.7039643545772609},
-                "welch": {"deg_of_free": 25.945257024943864, "p-value": 0.6980401261750298},
+                "welch": {
+                    "deg_of_free": 25.945257024943864,
+                    "p-value": 0.6980401261750298,
+                },
             },
             "psi": None,
         }
@@ -1057,7 +1060,10 @@ class TestNumericStatsMixin(unittest.TestCase):
             "t-test": {
                 "t-statistic": -3.138407239349285,
                 "conservative": {"deg_of_free": 9, "p-value": 0.011958658754358975},
-                "welch": {"deg_of_free": 25.945257024943864, "p-value": 0.004201616692122823},
+                "welch": {
+                    "deg_of_free": 25.945257024943864,
+                    "p-value": 0.004201616692122823,
+                },
             },
             "psi": None,
         }

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -2153,7 +2153,7 @@ class TestStructuredProfiler(unittest.TestCase):
         diff = profile1.diff(profile2)
         expected_chi2_test_dict = {
             "chi2-statistic": 2.342857142857143,
-            "df": 2,
+            "deg_of_free": 2,
             "p-value": 0.3099238764710244,
         }
         self.assertDictEqual(

--- a/dataprofiler/tests/profilers/test_text_column_profile.py
+++ b/dataprofiler/tests/profilers/test_text_column_profile.py
@@ -589,8 +589,8 @@ class TestTextColumnProfiler(unittest.TestCase):
             ),
             "t-test": {
                 "t-statistic": -1.9339958714826413,
-                "conservative": {"df": 8.0, "p-value": 0.08916903961929257},
-                "welch": {"df": 15.761400272034564, "p-value": 0.07127621949432528},
+                "conservative": {"deg_of_free": 8.0, "p-value": 0.08916903961929257},
+                "welch": {"deg_of_free": 15.761400272034564, "p-value": 0.07127621949432528},
             },
         }
 

--- a/dataprofiler/tests/profilers/test_text_column_profile.py
+++ b/dataprofiler/tests/profilers/test_text_column_profile.py
@@ -590,7 +590,10 @@ class TestTextColumnProfiler(unittest.TestCase):
             "t-test": {
                 "t-statistic": -1.9339958714826413,
                 "conservative": {"deg_of_free": 8.0, "p-value": 0.08916903961929257},
-                "welch": {"deg_of_free": 15.761400272034564, "p-value": 0.07127621949432528},
+                "welch": {
+                    "deg_of_free": 15.761400272034564,
+                    "p-value": 0.07127621949432528,
+                },
             },
         }
 


### PR DESCRIPTION
Fixes Issue #1030 

This PR renames references to degrees of freedom in a chi-squared calculation to `deg_of_free` to not get confused with when we use `df` to refer to a data frame. 

I have run the unit test suite and verified that the 1155 tests are running without fail. 
I have also run pre-commit on all the files without issue.