### PR TITLE
Make _assimilate_histogram() not use self

### DIFF
--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -13,7 +13,7 @@ import numpy.typing as npt
 import pandas as pd
 import scipy.stats
 
-from . import histogram_utils, profiler_utils
+from . import float_column_profile, histogram_utils, profiler_utils
 from .base_column_profilers import BaseColumnProfiler
 from .profiler_options import NumericalOptions
 
@@ -710,6 +710,9 @@ class NumericStatsMixin(BaseColumnProfiler[NumericStatsMixinT], metaclass=abc.AB
                     entity_count_per_bin=self_histogram["bin_counts"],
                     bin_edges=self_histogram["bin_edges"],
                     suggested_bin_count=num_psi_bins,
+                    is_float_histogram=isinstance(
+                        self, float_column_profile.FloatColumn
+                    ),
                     options={
                         "min_edge": min_min_edge,
                         "max_edge": max_max_edge,
@@ -731,6 +734,9 @@ class NumericStatsMixin(BaseColumnProfiler[NumericStatsMixinT], metaclass=abc.AB
                     entity_count_per_bin=other_histogram["bin_counts"],
                     bin_edges=other_histogram["bin_edges"],
                     suggested_bin_count=num_psi_bins,
+                    is_float_histogram=isinstance(
+                        self, float_column_profile.FloatColumn
+                    ),
                     options={
                         "min_edge": min_min_edge,
                         "max_edge": max_max_edge,
@@ -1360,7 +1366,12 @@ class NumericStatsMixin(BaseColumnProfiler[NumericStatsMixinT], metaclass=abc.AB
         self._stored_histogram["total_loss"] += histogram_loss
 
     def _regenerate_histogram(
-        self, entity_count_per_bin, bin_edges, suggested_bin_count, options=None
+        self,
+        entity_count_per_bin,
+        bin_edges,
+        suggested_bin_count,
+        is_float_histogram,
+        options=None,
     ) -> tuple[dict[str, np.ndarray], float]:
 
         # create proper binning
@@ -1372,6 +1383,11 @@ class NumericStatsMixin(BaseColumnProfiler[NumericStatsMixinT], metaclass=abc.AB
             new_bin_edges = np.linspace(
                 options["min_edge"], options["max_edge"], suggested_bin_count + 1
             )
+
+        # if it's not a float histogram, then assume it only contains integer values
+        if not is_float_histogram:
+            bin_edges = np.round(bin_edges)
+
         return self._assimilate_histogram(
             from_hist_entity_count_per_bin=entity_count_per_bin,
             from_hist_bin_edges=bin_edges,
@@ -1416,11 +1432,6 @@ class NumericStatsMixin(BaseColumnProfiler[NumericStatsMixinT], metaclass=abc.AB
                 continue
 
             bin_edge = from_hist_bin_edges[bin_id : bin_id + 3]
-
-            # if we know not float, we can assume values in bins are integers.
-            is_float_profile = self.__class__.__name__ == "FloatColumn"
-            if not is_float_profile:
-                bin_edge = np.round(bin_edge)
 
             # loop until we have a new bin which contains the current bin.
             while (
@@ -1513,6 +1524,7 @@ class NumericStatsMixin(BaseColumnProfiler[NumericStatsMixinT], metaclass=abc.AB
             entity_count_per_bin=bin_counts,
             bin_edges=bin_edges,
             suggested_bin_count=suggested_bin_count,
+            is_float_histogram=isinstance(self, float_column_profile.FloatColumn),
         )
 
     def _get_best_histogram_for_profile(self) -> dict:


### PR DESCRIPTION
NOTE: This is an alternative of PR https://github.com/capitalone/DataProfiler/pull/1073. If this is merged, then close PR https://github.com/capitalone/DataProfiler/pull/1073

Issue: https://github.com/capitalone/DataProfiler/issues/820

This is a necessary step to resolving issue https://github.com/capitalone/DataProfiler/issues/820. Previously, `_assimilate_histogram()` called `self` to decide whether the given histogram contained integers or floats, and rounded the bins for histograms that only contained integers.

`_assimilate_histogram()` is called in exactly two places: `_regenerate_histogram()` and `_add_helper_merge_profile_histograms()`. To remove the dependency on `self`, we can move the code for rounding bin edges to `_regenerate_histograms()` and add an argument indicating whether the given histogram contains integers or floats.

While `_regenerate_histogram()` should behave exactly the same as before, the histogram loss calculation in `_add_helper_merge_profile_histograms()` may change slightly since we no longer round its histogram bins.