### PR TITLE
Make _assimilate_histogram() not use self (alternative)

### DIFF
--- a/dataprofiler/profilers/numerical_column_stats.py
+++ b/dataprofiler/profilers/numerical_column_stats.py
@@ -1417,11 +1417,6 @@ class NumericStatsMixin(BaseColumnProfiler[NumericStatsMixinT], metaclass=abc.AB
 
             bin_edge = from_hist_bin_edges[bin_id : bin_id + 3]
 
-            # if we know not float, we can assume values in bins are integers.
-            is_float_profile = self.__class__.__name__ == "FloatColumn"
-            if not is_float_profile:
-                bin_edge = np.round(bin_edge)
-
             # loop until we have a new bin which contains the current bin.
             while (
                 bin_edge[0] >= dest_hist_bin_edges[new_bin_id + 1]

--- a/dataprofiler/tests/profilers/test_text_column_profile.py
+++ b/dataprofiler/tests/profilers/test_text_column_profile.py
@@ -236,7 +236,7 @@ class TestTextColumnProfiler(unittest.TestCase):
             kurtosis=-1251.0 / 1372.0,
             stddev=np.sqrt(14.0 / 9.0),
             histogram={
-                "bin_counts": np.array([5, 0, 2, 0, 1, 2]),
+                "bin_counts": np.array([5, 1, 1, 1, 0, 2]),
                 "bin_edges": np.array([1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0]),
             },
             quantiles={0: 1.25, 1: 1.5, 2: 3.0},


### PR DESCRIPTION
NOTE: This is an alternative for PR https://github.com/capitalone/DataProfiler/pull/1071. If this is merged, then close PR https://github.com/capitalone/DataProfiler/pull/1071

Issue: https://github.com/capitalone/DataProfiler/issues/820

This is a necessary step to resolving issue https://github.com/capitalone/DataProfiler/issues/820. Previously, `_assimilate_histogram()` called `self` to decide whether the given histogram contained integers or floats, and rounded the bins for histograms that only contained integers.

However, that rounding seems unnecessary. Here, we remove that rounding code entirely and modify the one test that fails, `TestTextColumnProfiler.test_profile()`. To make sure the test is still valid, here are its values:

The data in the profile of that test is:
<img width="206" alt="data" src="https://github.com/capitalone/DataProfiler/assets/53921230/87a850da-0234-4d3d-a50f-fd532a2bbe83">

The old expected histogram is:
<img width="537" alt="old_histogram" src="https://github.com/capitalone/DataProfiler/assets/53921230/dc63148e-4f0d-42e4-8796-9f26b095a438">

And the new expected histogram is:
<img width="503" alt="new_histogram" src="https://github.com/capitalone/DataProfiler/assets/53921230/b4e93b11-9f49-4b44-a4b3-a9cceeabbed6">
