### PR TITLE
feat: compute data type profile diff

### DIFF
--- a/dataprofiler/profilers/column_profile_compilers.py
+++ b/dataprofiler/profilers/column_profile_compilers.py
@@ -338,6 +338,8 @@ class ColumnPrimitiveTypeProfileCompiler(
         if all_profiles:
             for key in all_profiles:
                 if key in self._profiles and key in other._profiles:
+                    prof_diff = self._profiles[key].diff(other._profiles[key])
+                    diff_profile.update(prof_diff)
                     diff = profiler_utils.find_diff_of_numbers(
                         self._profiles[key].data_type_ratio,
                         other._profiles[key].data_type_ratio,

--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -285,6 +285,9 @@ class StructuredColProfiler:
             }
         )
 
+        if "statistics" not in unordered_profile:
+            unordered_profile["statistics"] = {}
+
         unordered_profile["statistics"].update(
             {
                 "sample_size": profiler_utils.find_diff_of_numbers(

--- a/dataprofiler/profilers/text_column_profile.py
+++ b/dataprofiler/profilers/text_column_profile.py
@@ -108,9 +108,8 @@ class TextColumn(
         :rtype: dict
         """
         # Make sure other_profile's type matches this class
-        differences = NumericStatsMixin.diff(self, other_profile, options)
+        differences = BaseColumnProfiler.diff(self, other_profile, options)
 
-        del differences["psi"]
         vocab_diff = profiler_utils.find_diff_of_lists_and_sets(
             self.vocab, other_profile.vocab
         )


### PR DESCRIPTION
### Details

Profile differences weren't being computed for `data_type_stats` profiles. I discovered this because psi was only being computed for the categorical profiler. Simply am adding in a line to compute that.

Additionally, `dataprofiler/profilers/text_column_profile.py` was using the numeric stats mix in to compute diff simply to double check that the data type was the same. I've updated that to use the `BaseColumnProfiler` diff instead.