### PR TITLE
Docs update to include option for `sample_nrows` for parquet files

### DIFF
--- a/docs/source/data_readers.rst
+++ b/docs/source/data_readers.rst
@@ -113,6 +113,8 @@ Possible `options`:
 
 * data_format - must be a string, choices: "dataframe", "records", "json"
 * selected_keys - columns being selected from the entire dataset, must be a list `["column 1", "ssn"]`
+* sample_nrows - Random sampling to sample `"n"` rows out of a total of `"M"` rows.
+  Specified for how many rows to sample, default None.
 
 GraphData
 =========


### PR DESCRIPTION
Adding doc related to https://github.com/capitalone/DataProfiler/pull/1070/files#diff-6199c8b82b73b32f5fcaac940ca3bc280409012e690f09b354d4d86a1744b137R476