### PR TITLE
fix: datetime profile JSON encoding bug

### DIFF
--- a/dataprofiler/profilers/json_encoder.py
+++ b/dataprofiler/profilers/json_encoder.py
@@ -1,6 +1,7 @@
 """Contains ProfilerEncoder class."""
 
 import json
+from datetime import datetime
 
 import numpy as np
 import pandas as pd
@@ -52,7 +53,7 @@ class ProfileEncoder(json.JSONEncoder):
             return int(to_serialize)
         elif isinstance(to_serialize, np.ndarray):
             return to_serialize.tolist()
-        elif isinstance(to_serialize, pd.Timestamp):
+        elif isinstance(to_serialize, (pd.Timestamp, datetime)):
             return to_serialize.isoformat()
         elif isinstance(to_serialize, BaseDataLabeler):
             # TODO: This does not allow the user to serialize a model if it is loaded

--- a/dataprofiler/tests/profilers/test_datetime_column_profile.py
+++ b/dataprofiler/tests/profilers/test_datetime_column_profile.py
@@ -501,6 +501,47 @@ class TestDateTimeColumnProfiler(unittest.TestCase):
 
         self.assertEqual(serialized, expected)
 
+    def test_json_encode_datetime(self):
+        data = ["1209214"]
+        df = pd.Series(data)
+        profiler = DateTimeColumn("0")
+
+        expected_date_formats = [
+            "%Y-%m-%d %H:%M:%S",
+            "%b %d, %Y",
+            "%m/%d/%y %H:%M",
+        ]
+        with patch.object(
+            profiler, "_combine_unique_sets", return_value=expected_date_formats
+        ):
+            with patch("time.time", return_value=0.0):
+                profiler.update(df)
+
+        serialized = json.dumps(profiler, cls=ProfileEncoder)
+
+        expected = json.dumps(
+            {
+                "class": "DateTimeColumn",
+                "data": {
+                    "name": "0",
+                    "col_index": np.nan,
+                    "sample_size": 1,
+                    "metadata": {},
+                    "times": defaultdict(float, {"datetime": 0.0}),
+                    "thread_safe": True,
+                    "match_count": 1,
+                    "date_formats": expected_date_formats,
+                    "min": "1209214",
+                    "max": "1209214",
+                    "_dt_obj_min": "9214-01-20T00:00:00",
+                    "_dt_obj_max": "9214-01-20T00:00:00",
+                    "_DateTimeColumn__calculations": dict(),
+                },
+            }
+        )
+
+        self.assertEqual(serialized, expected)
+
     def test_json_decode(self):
         fake_profile_name = None
         expected_profile = DateTimeColumn(fake_profile_name)


### PR DESCRIPTION
This fix pertains to my recently created issue [here](https://github.com/capitalone/DataProfiler/issues/1100). The JSON encoder was only expecting/being tested for `pd.Timestamp` as values for `_dt_obj_min` and `_dt_obj_max`, but I ran into a case where those fields were `datetime.datetime` objects.

Running the newly created test on the lastest release reproduces the bug, running on this branch resolves it.



