### PR TITLE
docs: update test link to latest version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,7 +48,7 @@ To execute unit tests, run the following
 DATAPROFILER_SEED=0 python3 -m unittest discover -p "test*.py"
 ```
 
-For more nuanced testing runs, check out more detailed documentation [here](https://capitalone.github.io/DataProfiler/docs/0.8.1/html/install.html#testing).
+For more nuanced testing runs, check out more detailed documentation [here](https://capitalone.github.io/DataProfiler/docs/0.10.9/html/install.html#testing).
 
 ## Creating [Pull Requests](https://github.com/capitalone/DataProfiler/pulls)
 Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests:


### PR DESCRIPTION
More of a temp fix.  Better long term would be having something like `latest` for the docs URL.  See #972