### PR TITLE
Multiprocessing and Performance Improvements

### DIFF
--- a/dataprofiler/profilers/profile_builder.py
+++ b/dataprofiler/profilers/profile_builder.py
@@ -3003,7 +3003,7 @@ class StructuredProfiler(BaseProfiler):
         notification_str = "Calculating the statistics... "
         pool = None
         if auto_multiprocess_toggle:
-            pool, pool_size = profiler_utils.generate_pool(4, est_data_size)
+            pool, pool_size = profiler_utils.generate_pool(profiler_utils.suggest_pool_size(), est_data_size)
             if pool:
                 notification_str += " (with " + str(pool_size) + " processes)"
 


### PR DESCRIPTION
This is related to some of the discussion in #1098

In my testing, I have a single dataset.  I am running this in a Docker container.  I'm running with the following settings:

```
import sys
import json
import time
import dataprofiler as dp

filename = "myfile.parquet"

def profile_test(filename):
    data = dp.Data(filename)
    profile_options = dp.ProfilerOptions()
    
    profile_options.set({
        "structured_options.data_labeler.is_enabled": False,
        "unstructured_options.data_labeler.is_enabled": False,
        "structured_options.correlation.is_enabled": False,
        "structured_options.multiprocess.is_enabled": True,
        "structured_options.chi2_homogeneity.is_enabled": False,
        "structured_options.category.max_sample_size_to_check_stop_condition": 1,
        "structured_options.category.stop_condition_unique_value_ratio": 0.001,
        "structured_options.sampling_ratio": 0.3,
        "structured_options.null_replication_metrics.is_enabled": False
    })

    print(profile_options)

    profile = dp.Profiler(data, options=profile_options)

    human_readable_report = profile.report(report_options={"output_format":"pretty"})

    with open("reportfile.json", "w") as outfile:
        outfile.write(json.dumps(human_readable_report, indent=4))

start_time = time.time()
profile_test(filename)
end_time = time.time()

print("Profile runtime for "+filename, end_time-start_time, 'seconds')
```

When Data Profiler gets to the first `tqdm` loop and displays `Finding the Null values in the columns...` it's pretty quick.  It also lists 19 processes corresponding to the pool_size available in the Python multiprocessing pool.  This works fine.

Then when it gets to the second `tqdm` loop and displays `Calculating the statistics...` I noticed that it was only using 4 processes.  When I looked at what was running, I am only seeing a single core being used.  When I looked at the code, `profile_builder.py` has 4 hard-coded.  This doesn't seem right.  There's a utility function `profiler_utils.suggest_pool_size` that's not even used that returns the pool size.  So I swapped that out.  Now when I run, instead of 4 processes it shows 19 so that seems better.  At least we're not leaving potential performance on the table with hard-coding.  

However, I'm still seeing only a single core being used.  I also checked the CPU affinity after reading some [comments on Stackoverflow](https://stackoverflow.com/questions/15639779/why-does-multiprocessing-use-only-a-single-core-after-i-import-numpy).  It looks reasonable to me.

```
print(f"Affinity: {os.sched_getaffinity(os.getpid())}")
```

I'm going to try profiling a bit more and see if I can figure out where it's hanging.  It seems like it should be faster, particularly on a multi-core machine.  Calculating all the statistics and stuff *is* taxing but it seems like it should be faster.