### PR TITLE
Bug fix for float precision calculation using categorical data with trailing 0s

### DIFF
--- a/dataprofiler/profilers/float_column_profile.py
+++ b/dataprofiler/profilers/float_column_profile.py
@@ -305,7 +305,10 @@ class FloatColumn(
 
         # length of sampled cells after all punctuation removed
         len_per_float = (
-            df_series_clean.sample(sample_size).replace(to_replace=r, value="").map(len)
+            df_series_clean.sample(sample_size)
+            .astype(object)
+            .replace(to_replace=r, value="")
+            .map(len)
         ).astype(float)
 
         # Determine statistics precision

--- a/dataprofiler/tests/profilers/test_float_column_profile.py
+++ b/dataprofiler/tests/profilers/test_float_column_profile.py
@@ -211,6 +211,13 @@ class TestFloatColumn(unittest.TestCase):
                 msg=f"Errored for: {sample[0]}",
             )
 
+        # Validate categorical series with trailing zeros supported
+        categorical_series = pd.Series(
+            [202209, 202210, 202211], dtype="category"
+        ).apply(str)
+        float_profiler = FloatColumn("Name")
+        float_profiler.update(categorical_series)
+
     def test_profiled_min(self):
         # test with multiple values
         data = np.linspace(-5, 5, 11)


### PR DESCRIPTION
Bug fix for https://github.com/capitalone/DataProfiler/issues/1048#issuecomment-1973429619. 

The float precision calculation errors out for **categorical** data when one of the values has leading/ trailing zeros. This is due to the regex operation stripping these zeros and the resulting value being outside the list of possible values.

Passing tests:
![dataprofiler-bug](https://github.com/capitalone/DataProfiler/assets/12833400/ed4365ea-e2af-49d7-8e26-83c2c9f5f414)
