### PR TITLE
fix: use core config

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,3 +1,3 @@
 {
-    "settingsInheritedFrom": "capitalone/whitesource-config@python311"
+    "settingsInheritedFrom": "capitalone/whitesource-config"
 }


### PR DESCRIPTION
using the core whitesource config now that its been updated to use python 3.10. should resolve remaining vulns once the config gets to main and whitesource is run against it