### PR TITLE
Fix chardet import for compatibility with chardet >= 0.7.0

### DIFF
--- a/dataprofiler/data_readers/data_utils.py
+++ b/dataprofiler/data_readers/data_utils.py
@@ -30,7 +30,7 @@ import numpy as np
 import pandas as pd
 import pyarrow.parquet as pq
 import requests
-from chardet.universaldetector import UniversalDetector
+from chardet import UniversalDetector
 from typing_extensions import TypeGuard
 
 from .. import dp_logging, rng_utils


### PR DESCRIPTION
Changed from 'from chardet.universaldetector import UniversalDetector' to 'from chardet import UniversalDetector' to support chardet 0.7.0+ which changed their import structure.

Fixes #1204