### PR TITLE
fix: replace broken hyperlink in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ json_data = Data('https://github.com/capitalone/DataProfiler/blob/main/dataprofi
 ```
 
 If the file type is not automatically identified (rare), you can specify them
-specifically, see section [Specifying a Filetype or Delimiter](#specifying-a-filetype-or-delimiter).
+specifically, see section [Specifying a Filetype or Delimiter](https://capitalone.github.io/DataProfiler/profiler.html#specifying-a-filetype-or-delimiter).
 
 ### Profile a File
 


### PR DESCRIPTION
## Summary

- Fixes the broken anchor link in the Load a File section of README.md
- The in-page anchor #specifying-a-filetype-or-delimiter pointed to a non-existent section
- Replaced with the absolute URL to the hosted documentation page where the section exists
- Verified the URL returns HTTP 200 and the anchor ID is present on the page

## Test plan

- [ ] Verify the link renders correctly in the GitHub README preview
- [ ] Click the link and confirm it navigates to the correct section in the docs

Closes #972