### PR TITLE
fix: relax requests version from ==2.32.* to >=2.32.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,10 @@ python-snappy>=0.7.1
 charset-normalizer>=1.3.6
 psutil>=4.0.0
 scipy>=1.10.0
-requests==2.32.*
+requests>=2.32.0
 networkx>=2.5.1
 typing-extensions>=3.10.0.2
 HLL>=2.0.3
 datasketches>=4.1.0
 packaging>=23.0
 boto3>=1.28.61
-# adding comment to trigger mend check


### PR DESCRIPTION
## Summary

- Changes requests==2.32.* to requests>=2.32.0 in requirements.txt
- The ==2.32.* pin prevented using DataProfiler alongside projects that need requests 2.33+
- The security floor (CVE-2024-35195) is 2.32.0, so >=2.32.0 preserves the vulnerability fix while allowing future compatible versions
- Removes a stale comment that was only used to trigger a Mend check

## Test plan

- [ ] CI tests pass with the relaxed version constraint
- [ ] Verify pip install DataProfiler resolves requests correctly
- [ ] Confirm no regressions in URL loading via data_readers/data_utils.py

Closes #716