### PR TITLE
refactor: use mock_timeit utility in categorical timeit test

### DIFF
--- a/dataprofiler/tests/profilers/test_categorical_column_profile.py
+++ b/dataprofiler/tests/profilers/test_categorical_column_profile.py
@@ -3,7 +3,6 @@ import math
 import os
 import unittest
 from collections import defaultdict
-from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -94,8 +93,7 @@ class TestCategoricalColumn(unittest.TestCase):
         dataset = self.aws_dataset["host"].dropna()
         profile = CategoricalColumn(dataset.name)
 
-        time_array = [float(x) for x in range(17, 0, -1)]
-        with patch("time.time", side_effect=lambda: time_array.pop()):
+        with test_utils.mock_timeit():
             # Validate the time in the column class is empty.
             self.assertEqual(defaultdict(float), profile.profile["times"])
 


### PR DESCRIPTION
## Summary

- Replaces the manual `time.time` patch (hardcoded float array with `.pop()`) in `test_timeit_profile` with the shared `test_utils.mock_timeit()` context manager
- This makes the test consistent with other timeit tests in the same file (lines 940, 1004) and across the codebase
- Removes the now-unused `from unittest.mock import patch` import
- No behavioral change: the expected timing values (1.0 after first update, 2.0 after second) are identical

## Test plan

- [ ] `test_timeit_profile` passes with the new mock
- [ ] No other tests in the file are affected (only import and one test method changed)
- [ ] The -3 line diff confirms this is a minimal, targeted refactor

Closes #806